### PR TITLE
Load audio manifests for sounds and music

### DIFF
--- a/assets/audio/music.json
+++ b/assets/audio/music.json
@@ -1,0 +1,4 @@
+[
+  {"id": "title", "file": "audio/title_theme.ogg", "default": true},
+  {"id": "battle", "file": "audio/battle_theme.ogg"}
+]

--- a/assets/audio/sounds.json
+++ b/assets/audio/sounds.json
@@ -1,0 +1,8 @@
+[
+  {"id": "move", "file": "audio/move.wav"},
+  {"id": "attack", "file": "audio/attack.wav"},
+  {"id": "victory", "file": "audio/victory.wav"},
+  {"id": "hover", "file": "audio/hover.wav"},
+  {"id": "click", "file": "audio/click.wav"},
+  {"id": "end_turn", "file": "audio/end_turn.wav"}
+]

--- a/constants.py
+++ b/constants.py
@@ -233,15 +233,3 @@ BIOME_BASE_IMAGES: Dict[str, List[str]] = {
     "scarletia_crimson_forest": ["terrain/forest.png"],
     "scarletia_volcanic": ["terrain/desert.png"],
 }
-
-
-
-# Audio file names (may be missing in minimal test environments)
-SOUND_MOVE = "move.wav"
-SOUND_ATTACK = "attack.wav"
-SOUND_VICTORY = "victory.wav"
-# UI interaction sounds
-SOUND_HOVER = "hover.wav"
-SOUND_CLICK = "click.wav"
-SOUND_END_TURN = "end_turn.wav"
-MUSIC_TITLE = "title_theme.ogg"

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -347,7 +347,9 @@ def main_menu(screen: pygame.Surface, can_resume: bool = False) -> pygame.Surfac
     "Retour au jeu" option is added which exits the menu immediately.
     """
 
-    audio.play_music(constants.MUSIC_TITLE)
+    initial_track = audio.get_current_music() or audio.get_default_music()
+    if initial_track:
+        audio.play_music(initial_track)
 
     while True:
         options = [
@@ -389,7 +391,9 @@ def main_menu(screen: pygame.Surface, can_resume: bool = False) -> pygame.Surfac
             )
             game.run()
             screen = pygame.display.get_surface()
-            audio.play_music(constants.MUSIC_TITLE)
+            track = audio.get_current_music() or audio.get_default_music()
+            if track:
+                audio.play_music(track)
 
         elif choice == 1 + offset:  # Load game
             slot, screen = _slot_menu(screen, title=MENU_TEXTS["choose_save"])
@@ -409,7 +413,9 @@ def main_menu(screen: pygame.Surface, can_resume: bool = False) -> pygame.Surfac
             try:
                 game.load_game(save_path)
             except FileNotFoundError:
-                audio.play_music(constants.MUSIC_TITLE)
+                track = audio.get_current_music() or audio.get_default_music()
+                if track:
+                    audio.play_music(track)
                 _, screen = simple_menu(
                     screen,
                     [MENU_TEXTS["file_not_found"], MENU_TEXTS["back"]],
@@ -418,7 +424,9 @@ def main_menu(screen: pygame.Surface, can_resume: bool = False) -> pygame.Surfac
                 continue
             game.run()
             screen = pygame.display.get_surface()
-            audio.play_music(constants.MUSIC_TITLE)
+            track = audio.get_current_music() or audio.get_default_music()
+            if track:
+                audio.play_music(track)
 
         elif choice == 2 + offset:  # Options
             screen = options_menu(screen)


### PR DESCRIPTION
## Summary
- define `assets/audio/sounds.json` and `music.json` to list sound effects and music tracks
- load audio manifests in `audio` module and expose track selection helpers
- drop hard-coded sound and music constants
- allow background music selection in options menu and use selected track in menu

## Testing
- `pytest` *(fails: process killed)*
- `pytest tests/test_collect_flora.py::test_collect_flora_adds_item_and_removes_prop -q`
- `pytest tests/test_menu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9b15c1524832198e0e2ac554b72aa