### PR TITLE
feat: add spell selection to combat AI

### DIFF
--- a/tests/test_combat_ai.py
+++ b/tests/test_combat_ai.py
@@ -5,7 +5,7 @@ os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
 from core.entities import Unit, SWORDSMAN_STATS, DRAGON_STATS, MAGE_STATS
 from core.combat import Combat
-from core.combat_ai import ai_take_turn, allied_ai_turn
+from core.combat_ai import ai_take_turn, allied_ai_turn, select_spell
 import constants
 
 pygame.init()
@@ -54,7 +54,27 @@ def test_ai_mage_casts_fireball_when_out_of_range():
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     mage = Unit(MAGE_STATS, 1, 'enemy')
     combat = _create_combat([hero], [mage])
-    combat.move_unit(hero, 7, 0)
-    combat.move_unit(mage, 0, 0)
-    ai_take_turn(combat, mage, [hero])
-    assert hero.current_hp < hero.stats.max_hp
+    hero_unit = combat.hero_units[0]
+    mage_unit = combat.enemy_units[0]
+    combat.move_unit(hero_unit, 5, 0)
+    combat.move_unit(mage_unit, 0, 0)
+    ai_take_turn(combat, mage_unit, [hero_unit])
+    assert hero_unit.current_hp < hero_unit.stats.max_hp
+
+
+def test_select_spell_prefers_fireball_for_cluster():
+    mage = Unit(MAGE_STATS, 1, 'hero')
+    enemy1 = Unit(SWORDSMAN_STATS, 1, 'enemy')
+    enemy2 = Unit(SWORDSMAN_STATS, 1, 'enemy')
+    combat = _create_combat([mage], [enemy1, enemy2])
+    mage_unit = combat.hero_units[0]
+    e1 = combat.enemy_units[0]
+    e2 = combat.enemy_units[1]
+    combat.move_unit(mage_unit, 0, 0)
+    combat.move_unit(e1, 2, 0)
+    combat.move_unit(e2, 2, 1)
+    spell = select_spell(mage_unit, [e1, e2], combat)
+    assert spell and spell[0] == 'fireball'
+    ai_take_turn(combat, mage_unit, [e1, e2])
+    assert e1.current_hp < e1.stats.max_hp
+    assert e2.current_hp < e2.stats.max_hp

--- a/tests/test_units_abilities.py
+++ b/tests/test_units_abilities.py
@@ -5,6 +5,7 @@ os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
 import pygame
 
+from dataclasses import replace
 from core.entities import (
     Unit,
     SWORDSMAN_STATS,
@@ -35,7 +36,8 @@ def test_unit_stats_have_abilities():
 
 def test_multi_shot_double_damage():
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
-    dragon = Unit(DRAGON_STATS, 1, 'enemy')
+    dragon_stats = replace(DRAGON_STATS, abilities=[a for a in DRAGON_STATS.abilities if a != 'dragon_breath'])
+    dragon = Unit(dragon_stats, 1, 'enemy')
     combat = _create_combat([hero], [dragon])
     hero = combat.hero_units[0]
     dragon = combat.enemy_units[0]


### PR DESCRIPTION
## Summary
- allow units to declare castable spells
- teach combat AI to choose optimal spell based on mana, range, and clustering
- cover spell casting decisions with new combat tests

## Testing
- `pytest tests/test_combat_ai.py -q`
- `pytest tests/test_units_abilities.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9b5f87dac8321a944eab4b2b65003