### PR TITLE
Add i18n support for difficulty labels

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1,0 +1,5 @@
+{
+  "Novice": "Novice",
+  "Intermédiaire": "Intermediate",
+  "Avancé": "Advanced"
+}

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1,0 +1,5 @@
+{
+  "Novice": "Novice",
+  "Intermédiaire": "Intermédiaire",
+  "Avancé": "Avancé"
+}

--- a/constants.py
+++ b/constants.py
@@ -16,6 +16,9 @@ import json
 import os
 from typing import Dict, List
 
+import settings
+from loaders.i18n import load_locale
+
 """
 Default screen settings.  When a custom map file is loaded, the actual
 window size will be determined dynamically based on the map dimensions.
@@ -31,11 +34,14 @@ UI_HEIGHT = 120
 FPS = 30
 
 # Difficulty levels for AI behaviour and default selection
-# The value can be changed via the options menu and influences how
-# aggressive enemy units are both on the world map and during combat.
-#
-# Renamed to more descriptive French labels matching the in‑game menu.
+# The list contains the canonical difficulty identifiers used internally.
+# ``DIFFICULTY_LABELS`` provides human readable, translated labels for
+# display purposes.  When a translation is missing the English text is used
+# as a fallback.
 AI_DIFFICULTIES = ["Novice", "Intermédiaire", "Avancé"]
+
+_LOCALE_STRINGS = load_locale(settings.LANGUAGE)
+DIFFICULTY_LABELS = {d: _LOCALE_STRINGS.get(d, d) for d in AI_DIFFICULTIES}
 AI_DIFFICULTY = "Intermédiaire"
 
 # Predefined world sizes exposed to the user when starting a new game.

--- a/loaders/i18n.py
+++ b/loaders/i18n.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Lightweight helpers for loading translation strings.
+
+The project keeps locale files in :mod:`assets/i18n` using a simple
+``key -> value`` mapping per language.  This module exposes a small helper
+that merges the default (English) strings with the requested language so
+missing keys gracefully fall back to the English text.
+"""
+
+from typing import Dict
+import os
+
+from .core import Context, read_json
+
+
+def load_locale(language: str, default: str = "en") -> Dict[str, str]:
+    """Return a dictionary of translation strings for ``language``.
+
+    ``default`` specifies the base language to fall back to when a key is not
+    present in the requested locale file.  The locale files are expected to
+    live in ``assets/i18n/<lang>.json`` relative to the repository root.
+    Missing files or parse errors result in an empty mapping so callers always
+    receive a dictionary.
+    """
+
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    ctx = Context(repo_root=repo_root, search_paths=["assets/i18n"])
+
+    try:
+        data = read_json(ctx, f"{default}.json")
+    except Exception:  # pragma: no cover - treated as empty fallback
+        data = {}
+
+    strings: Dict[str, str] = dict(data)
+    if language != default:
+        try:
+            extra = read_json(ctx, f"{language}.json")
+        except Exception:  # pragma: no cover - ignore missing locales
+            extra = {}
+        strings.update(extra)
+    return strings

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,6 +1,8 @@
 import os
 from types import SimpleNamespace
 
+import constants
+
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
 import pygame
@@ -71,3 +73,41 @@ def test_menu_escape(monkeypatch):
     monkeypatch.setattr(pygame.display, 'flip', lambda: None)
     choice, _ = menu._menu(screen, ['A', 'B'])
     assert choice is None
+
+
+def test_options_menu_shows_translated_difficulties(monkeypatch):
+    pygame.init()
+    screen = pygame.display.set_mode((200, 200))
+
+    from ui import options_menu
+
+    monkeypatch.setattr(pygame.display, 'flip', lambda: None, raising=False)
+
+    # Stub audio functions used by the options menu
+    monkeypatch.setattr(options_menu.audio, 'get_music_volume', lambda: 0.0)
+    monkeypatch.setattr(options_menu.audio, 'get_sfx_volume', lambda: 0.0)
+    monkeypatch.setattr(options_menu.audio, 'get_music_tracks', lambda: [])
+    monkeypatch.setattr(options_menu.audio, 'get_current_music', lambda: None)
+    monkeypatch.setattr(options_menu.audio, 'get_default_music', lambda: '')
+    monkeypatch.setattr(options_menu.audio, 'save_settings', lambda **_: None)
+    monkeypatch.setattr(options_menu.audio, 'set_music_volume', lambda *_: None)
+    monkeypatch.setattr(options_menu.audio, 'set_sfx_volume', lambda *_: None)
+    monkeypatch.setattr(options_menu.audio, 'play_music', lambda *_: None)
+    monkeypatch.setattr(options_menu.audio, 'stop_music', lambda: None)
+
+    calls = []
+
+    def fake_menu(_screen, options, title=''):
+        calls.append(options)
+        if len(calls) == 1:  # Open difficulty selection
+            return 3, _screen
+        if len(calls) == 2:  # Difficulty options displayed
+            return None, _screen
+        return 6, _screen  # Exit options menu
+
+    monkeypatch.setattr(options_menu, 'simple_menu', fake_menu)
+
+    options_menu.options_menu(screen)
+
+    expected = [constants.DIFFICULTY_LABELS[d] for d in constants.AI_DIFFICULTIES]
+    assert calls[1] == expected

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -174,7 +174,8 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
     # Precompute option lists for the various fields displayed on the screen.
     sizes = list(constants.MAP_SIZE_PRESETS.items())
     size_labels = [f"{k} ({w}x{h})" for k, (w, h) in sizes]
-    ai_labels = list(constants.AI_DIFFICULTIES)
+    ai_keys = list(constants.AI_DIFFICULTIES)
+    ai_labels = [constants.DIFFICULTY_LABELS[k] for k in ai_keys]
     colour_labels = [MENU_TEXTS["blue"], MENU_TEXTS["red"]]
     colour_values = [constants.BLUE, constants.RED]
     faction_opts = [Faction.RED_KNIGHTS, None]
@@ -226,7 +227,7 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
                     if row_idx == 0:
                         idx_size = (idx_size - 1) % len(size_labels)
                     elif row_idx == 1:
-                        idx_diff = (idx_diff - 1) % len(ai_labels)
+                        idx_diff = (idx_diff - 1) % len(ai_keys)
                     elif row_idx == 2:
                         idx_total = max(0, idx_total - 1)
                         _clamp_humans()
@@ -241,7 +242,7 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
                     if row_idx == 0:
                         idx_size = (idx_size + 1) % len(size_labels)
                     elif row_idx == 1:
-                        idx_diff = (idx_diff + 1) % len(ai_labels)
+                        idx_diff = (idx_diff + 1) % len(ai_keys)
                     elif row_idx == 2:
                         idx_total = min(len(total_players_opts) - 1, idx_total + 1)
                         _clamp_humans()
@@ -271,7 +272,7 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
                         return (
                             {
                                 "map_size": sizes[idx_size][0],
-                                "difficulty": ai_labels[idx_diff],
+                                "difficulty": ai_keys[idx_diff],
                                 "scenario": scenario,
                                 "total_players": total_players,
                                 "human_players": human_players,

--- a/ui/options_menu.py
+++ b/ui/options_menu.py
@@ -34,15 +34,17 @@ def _load_fullscreen() -> bool:
 
 
 def _load_difficulty() -> str:
-    """Return the saved AI difficulty or default to 'Intermédiaire'."""
+    """Return the saved AI difficulty or a sensible default."""
+    default = constants.AI_DIFFICULTY
     if os.path.isfile(SETTINGS_FILE):
         try:
             with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            return str(data.get("ai_difficulty", "Intermédiaire"))
+            diff = str(data.get("ai_difficulty", default))
+            return diff if diff in constants.AI_DIFFICULTIES else default
         except Exception:  # pragma: no cover - invalid json
-            return "Intermédiaire"
-    return "Intermédiaire"
+            return default
+    return default
 
 
 def _key_name(code: int) -> str:
@@ -96,7 +98,8 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
     music = audio.get_music_volume()
     sfx = audio.get_sfx_volume()
     fullscreen = _load_fullscreen()
-    difficulties = ["Novice", "Intermédiaire", "Avancé"]
+    difficulties = list(constants.AI_DIFFICULTIES)
+    labels = [constants.DIFFICULTY_LABELS[d] for d in difficulties]
     difficulty_idx = difficulties.index(_load_difficulty())
     tracks = audio.get_music_tracks()
     current_track = audio.get_current_music() or audio.get_default_music()
@@ -108,7 +111,7 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
             f"Musique : {int(music * 100)}%",
             f"Sons : {int(sfx * 100)}%",
             f"Plein écran : {'Oui' if fullscreen else 'Non'}",
-            f"Difficulté IA : {difficulties[difficulty_idx]}",
+            f"Difficulté IA : {labels[difficulty_idx]}",
             f"Musique de fond : {track_name}",
             "Touches",
         )
@@ -158,7 +161,7 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
         elif choice == 3:
             sel, screen = simple_menu(
                 screen,
-                [d.capitalize() for d in difficulties],
+                [l.capitalize() for l in labels],
                 title="Difficulté IA",
             )
             if sel is not None:


### PR DESCRIPTION
## Summary
- load localized difficulty labels via new i18n helper
- use translated difficulty names in menus
- test that options menu shows translated difficulties

## Testing
- `pytest tests/test_menu.py::test_options_menu_shows_translated_difficulties -q`
- `pytest -q` *(killed: out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c3f9ec7c832199c2b91116cbbc1a