### PR TITLE
Maintain free tile cache for AI movement

### DIFF
--- a/core/exploration_ai.py
+++ b/core/exploration_ai.py
@@ -74,14 +74,9 @@ def compute_enemy_step(game, enemy, difficulty: str = "Intermédiaire") -> Optio
     if best_path:
         return best_path[0]
 
-    # Fallback: wander towards a random passable tile using pathfinding rather
-    # than a single random step.  This keeps enemy movement deterministic and
-    # still utilises weighted path search.
-    candidates: List[Tuple[int, int]] = []
-    for y, row in enumerate(game.world.grid):
-        for x, tile in enumerate(row):
-            if tile.is_passable() and tile.enemy_units is None and not (x == enemy.x and y == enemy.y):
-                candidates.append((x, y))
+    # Fallback: wander towards a random free tile using the precomputed cache
+    # on the game instance.  This avoids scanning the whole grid each turn.
+    candidates: List[Tuple[int, int]] = list(getattr(game, "free_tiles", []))
     random.shuffle(candidates)
     for target in candidates:
         path = game.compute_path(start, target, avoid_enemies=params["avoid_enemies"])

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -101,3 +101,10 @@ def test_enemy_targets_hero_after_building_capture():
     assert world.grid[0][1].building.owner == 1
     step = exploration_ai.compute_enemy_step(game, enemy)
     assert step == (2, 0)
+
+
+def test_free_tiles_updates_when_tile_occupied():
+    game, enemy = _create_game_with_enemy()
+    assert (1, 0) in game.free_tiles
+    Game.move_enemy_heroes(game)
+    assert (1, 0) not in game.free_tiles


### PR DESCRIPTION
## Summary
- Track free tiles in `Game` and refresh cache on tile changes, hero movements and enemy movements
- Use the precomputed free tile list when enemies wander
- Test that free tile cache updates when tiles become occupied

## Testing
- `pytest tests/test_world_ai.py -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1ea35c848321ba62c7038d5da085