### PR TITLE
Chunked flora prop rendering

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -2014,6 +2014,7 @@ class Game:
                 self.world.collectibles.pop(pos, None)
             if prop in self.world.flora_props:
                 self.world.flora_props.remove(prop)
+                self.world.invalidate_prop_chunk(prop)
         # Check treasure
         if tile.treasure is not None:
             treasure = tile.treasure
@@ -3055,6 +3056,7 @@ class Game:
                     for yy in range(y, y + fh):
                         for xx in range(x, x + fw):
                             world.collectibles[(xx, yy)] = prop
+            world._build_flora_prop_index()
         self.hero = hero
         self.world = world
         self.map_size = data.get("map_size", constants.DEFAULT_MAP_SIZE)

--- a/tests/test_collect_flora.py
+++ b/tests/test_collect_flora.py
@@ -49,6 +49,7 @@ def test_collect_flora_adds_item_and_removes_prop(monkeypatch):
     )
     game.world.flora_props = [prop]
     game.world.collectibles = {(1, 0): prop}
+    game.world.invalidate_prop_chunk(prop)
 
     game._try_move_hero(1, 0)
 

--- a/tests/test_collectible_rendering.py
+++ b/tests/test_collectible_rendering.py
@@ -5,6 +5,11 @@ from core.world import WorldMap
 from loaders.flora_loader import PropInstance
 
 class DummyRect:
+    left = 0
+    top = 0
+    right = constants.TILE_SIZE
+    bottom = constants.TILE_SIZE
+
     def colliderect(self, other):
         return True
 
@@ -20,6 +25,7 @@ def test_collectible_rendering_does_not_error():
     prop = PropInstance("scarlet_herb_a", "scarletia", (0,0), 0, (1,1), (0,0), True, False, DummyRect())
     world.flora_props = [prop]
     world.collectibles = {(0,0): prop}
+    world.invalidate_prop_chunk(prop)
     renderer = WorldRenderer({})
     renderer.world = world
     dest = types.SimpleNamespace(get_width=lambda: constants.TILE_SIZE, get_height=lambda: constants.TILE_SIZE, blit=lambda *a,**k: None)


### PR DESCRIPTION
## Summary
- Index flora props into 32x32 tile chunks during world generation
- Render flora by checking only props from chunks intersecting the camera view
- Provide `WorldMap.invalidate_prop_chunk` to keep chunk index in sync

## Testing
- `pytest tests/test_collectible_rendering.py::test_collectible_rendering_does_not_error tests/test_collect_flora.py::test_collect_flora_adds_item_and_removes_prop -q`
- `pytest --maxfail=1 -q` *(failed: process killed after running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aa219b278c8321897f57aba6cc6e79