### PR TITLE
Refactor Tile to use dataclass slots and add memory test

### DIFF
--- a/tests/test_tile_memory.py
+++ b/tests/test_tile_memory.py
@@ -1,0 +1,28 @@
+import sys
+
+from core.world import WorldMap
+
+
+class DictTile:
+    """Reference tile using a ``__dict__`` for attributes."""
+
+    def __init__(self) -> None:
+        self.biome = "scarletia_echo_plain"
+        self.obstacle = False
+        self.treasure = None
+        self.enemy_units = None
+        self.resource = None
+        self.building = None
+        self.owner = None
+
+
+def test_tile_memory_reduction() -> None:
+    """Ensure dataclass tiles consume less memory than dict-based tiles."""
+
+    old_tile = DictTile()
+    old_size = sys.getsizeof(old_tile) + sys.getsizeof(old_tile.__dict__)
+
+    world = WorldMap(width=1, height=1, num_obstacles=0, num_treasures=0, num_enemies=0)
+    new_size = sys.getsizeof(world.grid[0][0])
+
+    assert new_size < old_size


### PR DESCRIPTION
## Summary
- convert Tile to a `@dataclass(slots=True)` and store biome/obstacle arrays on `WorldMap`
- adjust world map rendering helpers for new arrays
- add regression test verifying Tile uses less memory than dict-based tile

## Testing
- `pytest tests/test_tile_memory.py -q`
- `pytest -q` *(fails: KeyboardInterrupt in tests/test_combat_show_stats_screen.py:59)*

------
https://chatgpt.com/codex/tasks/task_e_68aa272accec83218d6eb187dd93ac5e