### PR TITLE
Refactor creature AI behaviors and world generation

### DIFF
--- a/assets/units/creatures.json
+++ b/assets/units/creatures.json
@@ -1,7 +1,39 @@
 [
-  {"id": "fumet_lizard", "image": "units/scarletia/fumet_lizard_0.png", "anchor_px": [384, 580], "shadow_baked": false, "biomes": ["scarletia_volcanic"]},
-  {"id": "shadowleaf_wolf", "image": "units/scarletia/shadowleaf_wolf_0.png", "anchor_px": [384, 590], "shadow_baked": false, "biomes": ["scarletia_crimson_forest"]},
-  {"id": "boar_raven", "image": "units/scarletia/boar_raven_0.png", "anchor_px": [384, 610], "shadow_baked": false, "biomes": ["scarletia_echo_plain", "mountain"]},
-  {"id": "hurlombe", "image": "units/scarletia/hurlombe_0.png", "anchor_px": [384, 600], "shadow_baked": false, "biomes": ["scarletia_crimson_forest", "mountain"]}
+  {
+    "id": "fumet_lizard",
+    "image": "units/scarletia/fumet_lizard_0.png",
+    "anchor_px": [384, 580],
+    "shadow_baked": false,
+    "biomes": ["scarletia_volcanic"],
+    "behavior": "roamer",
+    "guard_range": 3
+  },
+  {
+    "id": "shadowleaf_wolf",
+    "image": "units/scarletia/shadowleaf_wolf_0.png",
+    "anchor_px": [384, 590],
+    "shadow_baked": false,
+    "biomes": ["scarletia_crimson_forest"],
+    "behavior": "roamer",
+    "guard_range": 3
+  },
+  {
+    "id": "boar_raven",
+    "image": "units/scarletia/boar_raven_0.png",
+    "anchor_px": [384, 610],
+    "shadow_baked": false,
+    "biomes": ["scarletia_echo_plain", "mountain"],
+    "behavior": "roamer",
+    "guard_range": 2
+  },
+  {
+    "id": "hurlombe",
+    "image": "units/scarletia/hurlombe_0.png",
+    "anchor_px": [384, 600],
+    "shadow_baked": false,
+    "biomes": ["scarletia_crimson_forest", "mountain"],
+    "behavior": "guardian",
+    "guard_range": 2
+  }
 ]
 

--- a/core/ai/creature_ai.py
+++ b/core/ai/creature_ai.py
@@ -1,38 +1,98 @@
-from __future__ import annotations
-
 """Behaviour for neutral creature stacks roaming the world map."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from enum import Enum
 import random
 from typing import List, Tuple
 
 from core.entities import Unit
 
 
+class CreatureBehavior(Enum):
+    """High level behaviour modes for neutral stacks."""
+
+    GUARDIAN = "guardian"
+    ROAMER = "roamer"
+    ERRATIC = "erratic"
+
+
 @dataclass
 class CreatureAI:
-    """Lightweight AI controller for a neutral group of creatures.
+    """Base AI controller for a neutral group of creatures.
 
-    Each instance tracks a stack of units spawned at a given position.  The
-    group patrols around its spawn point within ``patrol_radius`` tiles and
-    reacts to the player's hero: if the hero is weaker it will pursue, otherwise
-    it attempts to flee.
+    Sub-classes implement behaviour specific ``update`` methods.  ``spawn`` keeps
+    track of the original location so that guardians can respect their guard
+    range and roamers know their patrol origin.
     """
 
     x: int
     y: int
     units: List[Unit]
-    patrol_radius: int = 3
+    behavior: CreatureBehavior
     spawn: Tuple[int, int] = field(init=False)
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
         self.spawn = (self.x, self.y)
 
     def _strength(self) -> int:
         return sum(u.count for u in self.units)
 
     def update(self, world, hero_pos: Tuple[int, int], hero_strength: int) -> None:
-        """Update the creature group's position for one world turn."""
+        raise NotImplementedError
+
+
+@dataclass
+class GuardianAI(CreatureAI):
+    """Stationary guards that only react within ``guard_range``."""
+
+    guard_range: int = 0
+
+    def __init__(self, x: int, y: int, units: List[Unit], guard_range: int = 0):
+        super().__init__(x, y, units, CreatureBehavior.GUARDIAN)
+        self.guard_range = guard_range
+
+    def update(self, world, hero_pos: Tuple[int, int], hero_strength: int) -> None:
+        if not self.units:
+            return
+        hx, hy = hero_pos
+        dist = abs(hx - self.x) + abs(hy - self.y)
+        if dist > self.guard_range:
+            return  # stay put
+        pursuing = self._strength() >= hero_strength
+        dx = 1 if hx > self.x else -1 if hx < self.x else 0
+        dy = 1 if hy > self.y else -1 if hy < self.y else 0
+        if not pursuing:
+            dx, dy = -dx, -dy
+        nx, ny = self.x + dx, self.y + dy
+        if (
+            world.in_bounds(nx, ny)
+            and abs(nx - self.spawn[0]) + abs(ny - self.spawn[1]) <= self.guard_range
+        ):
+            dest = world.grid[ny][nx]
+            if (
+                dest.is_passable()
+                and dest.enemy_units is None
+                and dest.treasure is None
+                and not (hx == nx and hy == ny)
+            ):
+                world.grid[self.y][self.x].enemy_units = None
+                dest.enemy_units = self.units
+                self.x, self.y = nx, ny
+
+
+@dataclass
+class RoamingAI(CreatureAI):
+    """Wandering stacks that patrol around ``patrol_radius`` tiles."""
+
+    patrol_radius: int = 3
+
+    def __init__(self, x: int, y: int, units: List[Unit], patrol_radius: int = 3):
+        super().__init__(x, y, units, CreatureBehavior.ROAMER)
+        self.patrol_radius = patrol_radius
+
+    def update(self, world, hero_pos: Tuple[int, int], hero_strength: int) -> None:
         if not self.units:
             return
         hx, hy = hero_pos

--- a/core/game.py
+++ b/core/game.py
@@ -242,7 +242,7 @@ class Game:
             treasure_count = max(1, land_tiles // 18)
             enemy_count = max(1, land_tiles // 18)
             self.world._place_treasures(treasure_count)
-            self.world._place_enemies(enemy_count)
+            self.world._generate_clusters(random, enemy_count)
 
         # Apply scenario specific data such as pre-placed units or objectives
         if self.scenario:

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -4,6 +4,7 @@ from core.buildings import Town, Building
 from core.game import Game
 import core.exploration_ai as exploration_ai
 import constants
+from core.ai.creature_ai import GuardianAI, RoamingAI
 
 
 def _make_world(width, height):
@@ -108,3 +109,28 @@ def test_free_tiles_updates_when_tile_occupied():
     assert (1, 0) in game.free_tiles
     Game.move_enemy_heroes(game)
     assert (1, 0) not in game.free_tiles
+
+
+def test_guardian_stays_put():
+    world = _make_world(5, 5)
+    units = [Unit(SWORDSMAN_STATS, 5, "enemy")]
+    world.grid[2][2].enemy_units = units
+    ai = GuardianAI(2, 2, units, guard_range=1)
+    hero_pos = (0, 0)
+    ai.update(world, hero_pos, hero_strength=10)
+    assert (ai.x, ai.y) == (2, 2)
+
+
+def test_roamer_patrols():
+    world = _make_world(5, 5)
+    units = [Unit(SWORDSMAN_STATS, 5, "enemy")]
+    world.grid[2][2].enemy_units = units
+    ai = RoamingAI(2, 2, units, patrol_radius=2)
+    hero_pos = (0, 0)
+    moved = False
+    for _ in range(5):
+        ai.update(world, hero_pos, hero_strength=100)
+        if (ai.x, ai.y) != (2, 2):
+            moved = True
+            break
+    assert moved


### PR DESCRIPTION
## Summary
- Add `CreatureBehavior` enum and specialized `GuardianAI` and `RoamingAI` controllers
- Tag creatures with behavior metadata and guard ranges
- Replace enemy/resource placement with Poisson-disc cluster generator and roaming stacks
- Add tests ensuring guardians stay at post and roamers patrol

## Testing
- `pytest tests/test_world_ai.py tests/test_resource_distribution.py tests/test_creatures_manifest_warning.py tests/test_random_map_generation.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa339b37708321be2bce703e5f9fe0