### PR TITLE
Use spritesheet for red knights skills

### DIFF
--- a/assets/skills/red_knights.json
+++ b/assets/skills/red_knights.json
@@ -1,26 +1,28 @@
 {
+  "sheet": "red_knights_skills.png",
   "logistics": {
-    "N": {"id": "logistics_N", "name": "Crimson Surge", "desc": "", "cost": 1, "effects": [], "icon": "crimson_surge", "coords": [2, 2]},
-    "A": {"id": "logistics_A", "name": "Valiant Charge", "desc": "", "cost": 1, "effects": [], "icon": "valiant_charge", "coords": [3, 0]},
-    "E": {"id": "logistics_E", "name": "Rally on the Road", "desc": "", "cost": 1, "effects": [], "icon": "rally", "coords": [0, 0]},
-    "M": {"id": "logistics_M", "name": "Sapper’s Path", "desc": "", "cost": 1, "effects": [], "icon": "sapper_charge", "coords": [0, 3]}
+    "N": {"id": "logistics_N", "name": "Crimson Surge", "desc": "", "cost": 1, "effects": [], "coords": [2, 2]},
+    "A": {"id": "logistics_A", "name": "Valiant Charge", "desc": "", "cost": 1, "effects": [], "coords": [3, 0]},
+    "E": {"id": "logistics_E", "name": "Rally on the Road", "desc": "", "cost": 1, "effects": [], "coords": [0, 0]},
+    "M": {"id": "logistics_M", "name": "Sapper’s Path", "desc": "", "cost": 1, "effects": [], "coords": [0, 3]}
   },
   "tactics": {
-    "N": {"id": "tactics_N", "name": "Guard Order", "desc": "", "cost": 1, "effects": [], "icon": "guard_order", "coords": [1, 0]},
-    "A": {"id": "tactics_A", "name": "Deploy Stakes", "desc": "", "cost": 1, "effects": [], "icon": "deploy_stakes", "coords": [3, 2]},
-    "E": {"id": "tactics_E", "name": "Aegis Wedge", "desc": "", "cost": 1, "effects": [], "icon": "aegis", "coords": [1, 1]},
-    "M": {"id": "tactics_M", "name": "Mass Bless", "desc": "", "cost": 1, "effects": [], "icon": "mass_bless", "coords": [0, 1]}
+    "N": {"id": "tactics_N", "name": "Guard Order", "desc": "", "cost": 1, "effects": [], "coords": [1, 0]},
+    "A": {"id": "tactics_A", "name": "Deploy Stakes", "desc": "", "cost": 1, "effects": [], "coords": [3, 2]},
+    "E": {"id": "tactics_E", "name": "Aegis Wedge", "desc": "", "cost": 1, "effects": [], "coords": [1, 1]},
+    "M": {"id": "tactics_M", "name": "Mass Bless", "desc": "", "cost": 1, "effects": [], "coords": [0, 1]}
   },
   "marksmanship": {
-    "N": {"id": "marksmanship_N", "name": "Firebolt Drills", "desc": "", "cost": 1, "effects": [], "icon": "firebolt", "coords": [1, 3]},
-    "A": {"id": "marksmanship_A", "name": "Volley", "desc": "", "cost": 1, "effects": [], "icon": "volley", "coords": [2, 0]},
-    "E": {"id": "marksmanship_E", "name": "Armor Traverse", "desc": "", "cost": 1, "effects": [], "icon": "fireball", "coords": [2, 3]},
-    "M": {"id": "marksmanship_M", "name": "Deadeye", "desc": "", "cost": 1, "effects": [], "icon": "deadeye", "coords": [2, 1]}
+    "N": {"id": "marksmanship_N", "name": "Firebolt Drills", "desc": "", "cost": 1, "effects": [], "coords": [1, 3]},
+    "A": {"id": "marksmanship_A", "name": "Volley", "desc": "", "cost": 1, "effects": [], "coords": [2, 0]},
+    "E": {"id": "marksmanship_E", "name": "Armor Traverse", "desc": "", "cost": 1, "effects": [], "coords": [2, 3]},
+    "M": {"id": "marksmanship_M", "name": "Deadeye", "desc": "", "cost": 1, "effects": [], "coords": [2, 1]}
   },
   "weaponsmithing": {
-    "N": {"id": "weaponsmithing_N", "name": "Intimidate", "desc": "", "cost": 1, "effects": [], "icon": "intimidate", "coords": [1, 2]},
-    "A": {"id": "weaponsmithing_A", "name": "Sharpen", "desc": "", "cost": 1, "effects": [], "icon": "sharpen", "coords": [3, 1]},
-    "E": {"id": "weaponsmithing_E", "name": "Steel Discipline", "desc": "", "cost": 1, "effects": [], "icon": "flame_alt", "coords": [3, 3]},
-    "M": {"id": "weaponsmithing_M", "name": "Overrun", "desc": "", "cost": 1, "effects": [], "icon": "overrun", "coords": [0, 2]}
+    "N": {"id": "weaponsmithing_N", "name": "Intimidate", "desc": "", "cost": 1, "effects": [], "coords": [1, 2]},
+    "A": {"id": "weaponsmithing_A", "name": "Sharpen", "desc": "", "cost": 1, "effects": [], "coords": [3, 1]},
+    "E": {"id": "weaponsmithing_E", "name": "Steel Discipline", "desc": "", "cost": 1, "effects": [], "coords": [3, 3]},
+    "M": {"id": "weaponsmithing_M", "name": "Overrun", "desc": "", "cost": 1, "effects": [], "coords": [0, 2]}
   }
 }
+

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2,7 +2,6 @@ import os
 
 from core.entities import Hero, HeroStats, SkillNode, Modifier, SKILL_CATALOG
 from tools.skill_manifest import load_skill_manifest
-from tools.icon import get_icon
 
 
 def test_learn_skill_modifies_stats_and_points():
@@ -42,10 +41,10 @@ def test_learn_skill_adds_tag():
 
 def test_red_knights_manifest_and_icons():
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    manifest = load_skill_manifest(repo_root)
+    assets = {}
+    manifest = load_skill_manifest(repo_root, assets)
     branches = ["logistics", "tactics", "marksmanship", "weaponsmithing"]
     ranks = ["N", "A", "E", "M"]
-    sheet = os.path.join(repo_root, "assets", "red_knights_skills.png")
     for branch in branches:
         entries = [e for e in manifest if e.get("branch") == branch]
         prev_id = None
@@ -53,7 +52,7 @@ def test_red_knights_manifest_and_icons():
             entry = next(e for e in entries if e["rank"] == rank)
             if prev_id:
                 assert prev_id in entry["requires"]
-            icon = get_icon(sheet, tuple(entry["coords"]))
+            icon = assets.get(entry["id"])
             assert hasattr(icon, "get_width") and icon.get_width() > 0
             prev_id = entry["id"]
 


### PR DESCRIPTION
## Summary
- switch Red Knights skill definitions to share a single spritesheet
- load skill icons from spritesheet into assets when parsing skill manifests
- adjust skill tests for spritesheet based icons

## Testing
- `pytest -q` *(killed: out-of-memory?)*
- `pytest tests/test_skills.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aade168b8c8321816399454c100025