### PR TITLE
Add automatic shipyard placement

### DIFF
--- a/tests/test_shipyard_placement.py
+++ b/tests/test_shipyard_placement.py
@@ -1,0 +1,31 @@
+import random
+
+from mapgen.continents import generate_continent_map
+from core.world import WorldMap
+
+
+def _shipyard_positions(world: WorldMap):
+    return [
+        (x, y)
+        for y in range(world.height)
+        for x in range(world.width)
+        if world.grid[y][x].building and world.grid[y][x].building.name == "Shipyard"
+    ]
+
+
+def test_starting_area_has_shipyard_when_near_water():
+    random.seed(0)
+    rows = generate_continent_map(30, 30, seed=0)
+    world = WorldMap(map_data=rows)
+    htx, hty = world.hero_town
+    shipyards = _shipyard_positions(world)
+    assert any(abs(x - htx) + abs(y - hty) <= 5 for x, y in shipyards)
+
+
+def test_each_continent_has_shipyard():
+    random.seed(0)
+    rows = generate_continent_map(30, 30, seed=0)
+    world = WorldMap(map_data=rows)
+    shipyards = set(_shipyard_positions(world))
+    for continent in world._find_continents():
+        assert any((x, y) in shipyards for x, y in continent)


### PR DESCRIPTION
## Summary
- place shipyards near starting towns when water is nearby
- ensure every continent has at least one shipyard on its coastline
- test shipyard placement around starting area and per-continent fallback

## Testing
- `pytest tests/test_shipyard_placement.py -q`
- `pytest tests/test_starting_area.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf5970bd48321ba0da99a5aa09286