### PR TITLE
Ensure shipyards are only placed next to water

### DIFF
--- a/core/buildings.py
+++ b/core/buildings.py
@@ -27,6 +27,7 @@ class Caravan:
 class Building:
     """Base class for world map buildings (resource nodes, towns…)."""
 
+    id: str = ""
     name: str = "Building"
     image: str = ""
     income: Dict[str, int] = {}
@@ -35,6 +36,7 @@ class Building:
     production_per_level: Dict[str, int] = {}
 
     def __init__(self) -> None:
+        self.id = ""
         self.owner: Optional[int] = None
         self.footprint: List[Tuple[int, int]] = [(0, 0)]
         self.anchor: Tuple[int, int] = (constants.TILE_SIZE // 2, constants.TILE_SIZE)
@@ -115,6 +117,7 @@ def create_building(bid: str, defs: Optional[Dict[str, BuildingAsset]] = None) -
         b = Shipyard()
     else:
         b = Building()
+    b.id = asset.id
     b.name = asset.id.replace("_", " ").title()
     files = asset.file_list()
     b.image = files[0] if files else asset.id

--- a/core/world.py
+++ b/core/world.py
@@ -684,6 +684,19 @@ class WorldMap:
                 or tile.building is not None
             ):
                 return False
+
+        if getattr(building, "id", "") == "shipyard":
+            touches_water = False
+            for dx, dy in building.footprint:
+                xx, yy = x + dx, y + dy
+                for nx, ny in ((xx - 1, yy), (xx + 1, yy), (xx, yy - 1), (xx, yy + 1)):
+                    if self.in_bounds(nx, ny) and self.grid[ny][nx].biome in constants.WATER_BIOMES:
+                        touches_water = True
+                        break
+                if touches_water:
+                    break
+            if not touches_water:
+                return False
         return True
 
     def _stamp_building(self, x: int, y: int, building: "Building") -> None:

--- a/tests/test_shipyard_inland.py
+++ b/tests/test_shipyard_inland.py
@@ -1,0 +1,24 @@
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import constants
+from core.buildings import create_building
+from core.world import WorldMap
+
+
+def test_shipyard_rejected_inland():
+    world = WorldMap(
+        width=5,
+        height=5,
+        num_obstacles=0,
+        num_treasures=0,
+        num_enemies=0,
+        num_resources=0,
+        num_buildings=0,
+        biome_weights={"scarletia_echo_plain": 1.0},
+    )
+    shipyard = create_building("shipyard")
+    assert not world._can_place_building(2, 2, shipyard)
+    world.grid[2][1].biome = next(iter(constants.WATER_BIOMES))
+    assert world._can_place_building(2, 2, shipyard)


### PR DESCRIPTION
## Summary
- Track building IDs and flag shipyards
- Require shipyards touch water when placed
- Test that inland shipyards are rejected

## Testing
- `pytest tests/test_shipyard_inland.py tests/test_shipyard_placement.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf714f30c8321b51cca4eaa2439b0