### PR TITLE
Add boat manifest and loader

### DIFF
--- a/assets/boats.json
+++ b/assets/boats.json
@@ -1,4 +1,8 @@
 [
-  {"id": "barge", "movement": 4, "capacity": 5},
-  {"id": "galley", "movement": 6, "capacity": 10}
+  {"id": "barge", "movement": 4, "capacity": 5,
+  "cost": {"wood": 5, "stone": 2},
+  "path": "Units/ships/barge.png"},
+  {"id": "galley", "movement": 6, "capacity": 10,
+  "cost": {"wood": 10, "stone": 5},
+  "path": "Units/ships/galley.png"}
 ]

--- a/core/game.py
+++ b/core/game.py
@@ -29,6 +29,7 @@ from loaders.flora_loader import FloraLoader, PropInstance
 from loaders.resources_loader import load_resources, ResourceDef
 from loaders.biomes import BiomeCatalog, BiomeTileset, load_tileset
 from loaders import units_loader
+from loaders.boat_loader import load_boats, BoatDef
 from loaders.scenario_loader import load_scenario
 from tools.artifact_manifest import load_artifact_manifest
 from tools.load_manifest import load_manifest
@@ -207,6 +208,10 @@ class Game:
             self.unit_defs = units_loader.load_units(self.ctx, "units/units.json")
         except Exception:
             self.unit_defs = {}
+        try:
+            self.boat_defs: Dict[str, BoatDef] = load_boats(self.ctx, "boats.json")
+        except Exception:
+            self.boat_defs = {}
         # Initialise audio system and load sound effects
         audio.init()
         try:
@@ -2973,7 +2978,10 @@ class Game:
             hero_info.get("colour", getattr(self, "player_colour", constants.BLUE))
         )
         faction_val = hero_info.get("faction", "red_knights")
-        faction = self.factions.get(faction_val, FactionDef(faction_val, faction_val.title()))
+        factions = getattr(self, "factions", {})
+        faction = factions.get(
+            faction_val, FactionDef(faction_val, faction_val.title())
+        )
         hero = Hero(
             hero_info["x"],
             hero_info["y"],

--- a/loaders/boat_loader.py
+++ b/loaders/boat_loader.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from .core import Context, read_json, require_keys
+
+
+@dataclass
+class BoatDef:
+    """Definition for a boat type loaded from ``boats.json``."""
+
+    id: str
+    movement: int
+    capacity: int
+    cost: Dict[str, int]
+    path: str
+
+
+def load_boats(ctx: Context, manifest: str = "boats.json") -> Dict[str, BoatDef]:
+    """Load boat definitions from ``manifest`` using ``ctx``.
+
+    Surfaces are loaded via the provided :class:`AssetManager` (if any) and
+    registered under their boat ``id`` so other systems can reference them by
+    identifier.
+    """
+
+    defs: Dict[str, BoatDef] = {}
+    try:
+        entries = read_json(ctx, manifest)
+    except Exception:
+        return defs
+
+    for entry in entries:
+        require_keys(entry, ["id", "movement", "capacity", "cost", "path"])
+        bdef = BoatDef(
+            id=entry["id"],
+            movement=int(entry["movement"]),
+            capacity=int(entry["capacity"]),
+            cost={k: int(v) for k, v in entry.get("cost", {}).items()},
+            path=entry["path"],
+        )
+        defs[bdef.id] = bdef
+
+        # Preload and register surface under the boat id for convenience.
+        try:
+            if ctx.asset_loader is not None:
+                surf = ctx.asset_loader.get(bdef.path)
+                ctx.asset_loader[bdef.id] = surf  # type: ignore[index]
+        except Exception:
+            pass
+
+    return defs

--- a/render/world_renderer.py
+++ b/render/world_renderer.py
@@ -561,7 +561,13 @@ class WorldRenderer:
 
             # Draw boat beneath heroes that possess one
             if is_hero and getattr(actor, "naval_unit", None):
-                boat = self.assets.get(getattr(actor, "naval_unit"))
+                boat_id = getattr(actor, "naval_unit")
+                path = boat_id
+                if getattr(self.game, "boat_defs", None):
+                    boat_def = self.game.boat_defs.get(boat_id)
+                    if boat_def:
+                        path = boat_def.path
+                boat = self.assets.get(path)
                 if isinstance(boat, pygame.Surface):
                     try:
                         if boat.get_size() != (tile_size, tile_size):


### PR DESCRIPTION
## Summary
- extend boat manifest with costs and asset paths
- add boat loader to register images and expose BoatDef
- hook boat definitions into Game and world rendering

## Testing
- `pytest tests/test_world_navigation.py -q`
- `pytest tests/test_asset_manager_paths.py -q`
- `pytest -q --maxfail=1` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf821985c8321a8ffc014074cd1a0