### PR TITLE
Add boat entity with embark system and UI

### DIFF
--- a/core/entities.py
+++ b/core/entities.py
@@ -323,6 +323,36 @@ class Army(UnitCarrier):
         self.ap = self.max_ap
 
 
+@dataclass
+class Boat(UnitCarrier):
+    """Boat available on the world map that can carry units."""
+
+    id: str
+    x: int
+    y: int
+    movement: int
+    capacity: int
+    owner: int | None
+    garrison: List[Unit] = field(default_factory=list)
+    ap: int = 0
+    name: str = "Boat"
+    portrait: Any | None = None
+
+    def __post_init__(self) -> None:
+        self.ap = self.movement
+
+    @property
+    def units(self) -> List[Unit]:  # Alias required by UnitCarrier
+        return self.garrison
+
+    @units.setter
+    def units(self, value: List[Unit]) -> None:
+        self.garrison = value
+
+    def apply_bonuses_to_army(self) -> None:  # pragma: no cover - no bonuses yet
+        return None
+
+
 
 class Hero:
     """Represents the player on the world map along with their army."""

--- a/core/world.py
+++ b/core/world.py
@@ -314,6 +314,8 @@ class Tile:
     resource: Optional[str] = None
     # Optional building such as a mine or sawmill
     building: Optional['Building'] = None
+    # Optional boat anchored on this water tile
+    boat: Optional["Boat"] = None
     owner: Optional[int] = None
 
     @property

--- a/render/world_renderer.py
+++ b/render/world_renderer.py
@@ -249,6 +249,14 @@ class WorldRenderer:
                     tile = self.world.grid[wy][wx]
                     if (
                         self.game
+                        and getattr(tile, "boat", None)
+                        and hasattr(self.game, "embark")
+                    ):
+                        hero = getattr(self.game, "hero", None)
+                        if hero and abs(hero.x - wx) + abs(hero.y - wy) == 1:
+                            self.game.embark(hero, tile.boat)
+                    elif (
+                        self.game
                         and isinstance(getattr(tile, "building", None), Town)
                         and tile.building.owner == 0
                         and hasattr(self.game, "open_town")
@@ -535,6 +543,25 @@ class WorldRenderer:
         for y in range(start_y, end_y):
             for x in range(start_x, end_x):
                 tile = world.grid[y][x]
+                if getattr(tile, "boat", None):
+                    boat_obj = tile.boat
+                    boat_id = boat_obj.id
+                    path = boat_id
+                    if getattr(self.game, "boat_defs", None):
+                        boat_def = self.game.boat_defs.get(boat_id)
+                        if boat_def:
+                            path = boat_def.path
+                    img = self.assets.get(path)
+                    if img:
+                        if img.get_size() != (tile_size, tile_size):
+                            try:
+                                img = pygame.transform.smoothscale(img, (tile_size, tile_size))
+                            except Exception:
+                                pass
+                        layers[constants.LAYER_UNITS].blit(
+                            img,
+                            ((x - start_x) * tile_size + offset_x, (y - start_y) * tile_size + offset_y),
+                        )
                 if tile.enemy_units:
                     strongest = max(tile.enemy_units, key=lambda u: u.stats.max_hp)
                     img_name = ENEMY_UNIT_IMAGES.get(strongest.stats.name)

--- a/tests/test_boat_exchange.py
+++ b/tests/test_boat_exchange.py
@@ -1,0 +1,29 @@
+import types
+import sys
+
+from tests.test_open_town import make_pygame_stub
+
+
+def test_boat_garrison_exchange(monkeypatch):
+    pygame_stub = make_pygame_stub()
+    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+    from core.entities import Hero, Unit, SWORDSMAN_STATS, Boat
+    from ui.boat_screen import BoatScreen
+
+    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])
+    boat = Boat("barge", 1, 0, 4, 7, owner=0, garrison=[Unit(SWORDSMAN_STATS, 2, "hero")])
+    game = types.SimpleNamespace(hero=hero)
+    screen = pygame_stub.display.set_mode((200, 200))
+    bs = BoatScreen(screen, game, boat)
+    bs.drag_src = ("hero", 0)
+    bs.drag_unit = hero.army[0]
+    bs._drop_to("boat", 0)
+    assert len(hero.army) == 0
+    assert boat.garrison[0].count == 3
+    bs.drag_src = ("boat", 0)
+    bs.drag_unit = boat.garrison[0]
+    bs._drop_to("hero", 0)
+    assert len(boat.garrison) == 0
+    assert hero.army[0].count == 3
+

--- a/tests/test_boat_spawn.py
+++ b/tests/test_boat_spawn.py
@@ -1,0 +1,35 @@
+import types
+import sys
+
+from tests.test_open_town import make_pygame_stub
+
+
+def test_shipyard_purchases_spawn_boat(monkeypatch):
+    pygame_stub = make_pygame_stub()
+    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+    from core.world import WorldMap
+    from core.entities import Hero
+    from core.buildings import Shipyard
+    from loaders.boat_loader import BoatDef
+    from ui.shipyard_screen import ShipyardScreen
+
+    wm = WorldMap(
+        width=2,
+        height=1,
+        biome_weights={"scarletia_echo_plain": 1.0},
+        num_obstacles=0,
+        num_treasures=0,
+        num_enemies=0,
+    )
+    wm.grid[0][1].biome = "ocean"
+    shipyard = Shipyard()
+    shipyard.origin = (0, 0)
+    wm.grid[0][0].building = shipyard
+
+    hero = Hero(0, 0, [])
+    game = types.SimpleNamespace(world=wm, hero=hero, boat_defs={"barge": BoatDef("barge", 4, 7, {}, "barge.png")})
+    ss = types.SimpleNamespace(game=game, shipyard=shipyard)
+    ShipyardScreen._buy_boat(ss, game.boat_defs["barge"])
+    assert wm.grid[0][1].boat is not None
+

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -1,45 +1,46 @@
 import audio
 from tests.test_army_actions import setup_game
 from core.game import Game as GameClass
+from core.entities import Boat
+from loaders.boat_loader import BoatDef
+import audio
 
 
 def setup_water_game(monkeypatch):
     game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
-    # restore real pathfinding implementation
     game.compute_path = GameClass.compute_path.__get__(game, GameClass)
     game._compute_path_cached = GameClass._compute_path_cached.__get__(game, GameClass)
-    # configure simple map with a water tile between land tiles
     game.world.grid[0][0].biome = "scarletia_echo_plain"
     game.world.grid[0][1].biome = "ocean"
     game.world.grid[0][2].biome = "scarletia_echo_plain"
     game.hero.x = 0
     game.hero.y = 0
     game.hero.ap = 10
+    game.boat_defs = {"barge": BoatDef("barge", 4, 7, {}, "barge.png")}
+    boat = Boat("barge", 1, 0, 4, 7, owner=0)
+    game.world.grid[0][1].boat = boat
     return game
 
 
 def test_path_requires_boat(monkeypatch):
     game = setup_water_game(monkeypatch)
-    # cannot cross water without a boat
     assert game.compute_path((0, 0), (2, 0)) is None
-    # after obtaining a boat, water becomes traversable
-    game.hero.naval_unit = "barge"
+    boat = game.world.grid[0][1].boat
+    game.embark(game.hero, boat)
     game._compute_path_cached.cache_clear()
-    assert game.compute_path((0, 0), (2, 0)) == [(1, 0), (2, 0)]
+    assert game.compute_path((1, 0), (2, 0)) == [(2, 0)]
 
 
 def test_embark_disembark_cost(monkeypatch):
     game = setup_water_game(monkeypatch)
     monkeypatch.setattr(audio, "play_sound", lambda *a, **k: None)
-    game.hero.naval_unit = "barge"
+    boat = game.world.grid[0][1].boat
     start_ap = game.hero.ap
-    # embark onto water
-    game.try_move_hero(1, 0)
+    game.embark(game.hero, boat)
     assert (game.hero.x, game.hero.y) == (1, 0)
-    assert game.hero.ap == start_ap - 2  # move + embark cost
-    # disembark onto land
+    assert game.hero.ap == start_ap - 1
     game.try_move_hero(1, 0)
     assert (game.hero.x, game.hero.y) == (2, 0)
-    assert game.hero.ap == start_ap - 4
-    # boat remains available after docking
-    assert game.hero.naval_unit == "barge"
+    assert game.hero.ap == start_ap - 3
+    assert game.hero.naval_unit is None
+    assert game.world.grid[0][1].boat is not None

--- a/ui/boat_screen.py
+++ b/ui/boat_screen.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from typing import List, Tuple, Optional
+import pygame
+
+from core.entities import Boat, Hero, Unit
+
+SLOT_COUNT = 7
+SLOT_PAD = 6
+ROW_H = 96
+GAP = 10
+
+COLOR_BG = (16, 18, 22)
+COLOR_PANEL = (28, 30, 36)
+COLOR_TEXT = (240, 240, 240)
+COLOR_ACCENT = (210, 180, 80)
+COLOR_SLOT_BG = (36, 38, 44)
+COLOR_SLOT_BD = (80, 80, 90)
+
+
+class BoatScreen:
+    """Interface to exchange units between hero army and boat garrison."""
+
+    def __init__(
+        self,
+        screen: pygame.Surface,
+        game: "Game",
+        boat: Boat,
+        clock: Optional[pygame.time.Clock] = None,
+    ) -> None:
+        self.screen = screen
+        self.game = game
+        self.hero: Hero = game.hero
+        self.boat = boat
+        self.clock = clock or pygame.time.Clock()
+        self.running = True
+        self.font = pygame.font.SysFont(None, 18)
+        self.font_big = pygame.font.SysFont(None, 20, bold=True)
+        self.hero_slots: List[pygame.Rect] = []
+        self.boat_slots: List[pygame.Rect] = []
+        self.drag_active = False
+        self.drag_src = ("", -1)
+        self.drag_unit: Optional[Unit] = None
+        self.drag_offset = (0, 0)
+        self.mouse_pos = (0, 0)
+
+    def _compute_layout(self) -> Tuple[pygame.Rect, pygame.Rect]:
+        W, H = self.screen.get_size()
+        rect_hero = pygame.Rect(20, H - ROW_H - GAP - ROW_H, W - 40, ROW_H)
+        rect_boat = pygame.Rect(20, H - ROW_H, W - 40, ROW_H)
+        return rect_hero, rect_boat
+
+    def _draw_label(self, text: str, rect: pygame.Rect) -> None:
+        self.screen.blit(self.font_big.render(text, True, COLOR_TEXT), (rect.x, rect.y))
+
+    def _draw_army_row(self, units, rect: pygame.Rect) -> List[pygame.Rect]:
+        slots: List[pygame.Rect] = []
+        w = (rect.width - (SLOT_COUNT + 1) * SLOT_PAD) // SLOT_COUNT
+        h = rect.height - 2 * SLOT_PAD
+        y = rect.y + SLOT_PAD
+        x = rect.x + SLOT_PAD
+        for i in range(SLOT_COUNT):
+            r = pygame.Rect(x, y, w, h)
+            slots.append(r)
+            pygame.draw.rect(self.screen, COLOR_SLOT_BG, r, border_radius=6)
+            pygame.draw.rect(self.screen, COLOR_SLOT_BD, r, 2, border_radius=6)
+            if i < len(units):
+                u = units[i]
+                name = getattr(u.stats, "name", "Unit")
+                cnt = getattr(u, "count", 1)
+                self.screen.blit(self.font.render(name, True, COLOR_TEXT), (r.x + 6, r.y + 6))
+                self.screen.blit(self.font.render(f"x{cnt}", True, COLOR_ACCENT), (r.right - 28, r.bottom - 20))
+            x += w + SLOT_PAD
+        return slots
+
+    def draw(self) -> None:
+        self.screen.fill(COLOR_BG)
+        rect_hero, rect_boat = self._compute_layout()
+        pygame.draw.rect(self.screen, COLOR_PANEL, rect_hero)
+        pygame.draw.rect(self.screen, COLOR_PANEL, rect_boat)
+        self._draw_label(getattr(self.hero, "name", "Hero"), rect_hero.inflate(-8, -ROW_H + 24).move(8, 4))
+        self._draw_label("Boat", rect_boat.inflate(-8, -ROW_H + 24).move(8, 4))
+        self.hero_slots = self._draw_army_row(self.hero.army, rect_hero)
+        self.boat_slots = self._draw_army_row(self.boat.garrison, rect_boat)
+        if self.drag_active and self.drag_unit:
+            mx, my = self.mouse_pos
+            gx, gy = mx - self.drag_offset[0], my - self.drag_offset[1]
+            ghost = pygame.Rect(gx, gy, 140, 64)
+            pygame.draw.rect(self.screen, (60, 64, 80, 230), ghost, border_radius=6)
+            pygame.draw.rect(self.screen, (120, 120, 140), ghost, 2, border_radius=6)
+            name = getattr(self.drag_unit.stats, "name", "Unit")
+            cnt = getattr(self.drag_unit, "count", 1)
+            self.screen.blit(self.font.render(name, True, COLOR_TEXT), (ghost.x + 8, ghost.y + 8))
+            self.screen.blit(self.font.render(f"x{cnt}", True, COLOR_ACCENT), (ghost.x + 8, ghost.y + 34))
+
+    def run(self) -> None:
+        while self.running:
+            for evt in pygame.event.get():
+                t = getattr(evt, "type", None)
+                if t == pygame.QUIT:
+                    self.running = False
+                elif t == pygame.KEYDOWN and evt.key in (pygame.K_ESCAPE, pygame.K_b):
+                    self.running = False
+                elif t == pygame.MOUSEMOTION:
+                    self.mouse_pos = evt.pos
+                elif t == pygame.MOUSEBUTTONDOWN:
+                    self._on_mousedown(evt.pos)
+                elif t == pygame.MOUSEBUTTONUP:
+                    self._on_mouseup(evt.pos)
+            self.draw()
+            pygame.display.flip()
+            self.clock.tick(60)
+
+    def _on_mousedown(self, pos: Tuple[int, int]) -> None:
+        for i, r in enumerate(self.hero_slots):
+            if r.collidepoint(pos) and i < len(self.hero.army):
+                self.drag_active = True
+                self.drag_src = ("hero", i)
+                self.drag_unit = self.hero.army[i]
+                self.drag_offset = (pos[0] - r.x, pos[1] - r.y)
+                return
+        for i, r in enumerate(self.boat_slots):
+            if r.collidepoint(pos) and i < len(self.boat.garrison):
+                self.drag_active = True
+                self.drag_src = ("boat", i)
+                self.drag_unit = self.boat.garrison[i]
+                self.drag_offset = (pos[0] - r.x, pos[1] - r.y)
+                return
+
+    def _on_mouseup(self, pos: Tuple[int, int]) -> None:
+        if not self.drag_active or not self.drag_unit:
+            return
+        dropped = False
+        for i, r in enumerate(self.hero_slots):
+            if r.collidepoint(pos):
+                dropped = True
+                self._drop_to("hero", i)
+                break
+        if not dropped:
+            for i, r in enumerate(self.boat_slots):
+                if r.collidepoint(pos):
+                    dropped = True
+                    self._drop_to("boat", i)
+                    break
+        self.drag_active = False
+        self.drag_unit = None
+        self.drag_src = ("", -1)
+
+    def _drop_to(self, target: str, index: int) -> None:
+        src_row, src_idx = self.drag_src
+        if src_row not in ("hero", "boat") or src_idx < 0:
+            return
+        if target == src_row and index == src_idx:
+            return
+        src_list = self.hero.army if src_row == "hero" else self.boat.garrison
+        dst_list = self.hero.army if target == "hero" else self.boat.garrison
+        if index > SLOT_COUNT - 1:
+            index = SLOT_COUNT - 1
+        unit = src_list[src_idx]
+        for u in dst_list:
+            if u.stats is unit.stats:
+                u.count += unit.count
+                src_list.pop(src_idx)
+                self.hero.apply_bonuses_to_army()
+                self.boat.apply_bonuses_to_army()
+                return
+        if index < len(dst_list):
+            dst_list[index], src_list[src_idx] = src_list[src_idx], dst_list[index]
+        else:
+            dst_list.append(src_list.pop(src_idx))
+        self.hero.apply_bonuses_to_army()
+        self.boat.apply_bonuses_to_army()
+
+
+def open(
+    screen: pygame.Surface,
+    game: "Game",
+    boat: Boat,
+    clock: Optional[pygame.time.Clock] = None,
+) -> None:
+    if not pygame.display.get_init() or pygame.display.get_surface() is None:
+        return
+    BoatScreen(screen, game, boat, clock).run()
+

--- a/ui/shipyard_screen.py
+++ b/ui/shipyard_screen.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Tuple
 import theme
 import constants
 from loaders.boat_loader import BoatDef
-from core.entities import Hero
+from core.entities import Hero, Boat
 from core.buildings import Shipyard
 
 # Layout constants similar to town_screen
@@ -77,7 +77,26 @@ class ShipyardScreen:
         hero: Hero = self.game.hero
         for res, amt in bdef.cost.items():
             hero.resources[res] = hero.resources.get(res, 0) - int(amt)
-        hero.naval_unit = bdef.id
+        sx, sy = self.shipyard.origin
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                if dx == 0 and dy == 0:
+                    continue
+                tx, ty = sx + dx, sy + dy
+                if not self.game.world.in_bounds(tx, ty):
+                    continue
+                tile = self.game.world.grid[ty][tx]
+                if tile.biome in constants.WATER_BIOMES and tile.boat is None:
+                    boat = Boat(
+                        id=bdef.id,
+                        x=tx,
+                        y=ty,
+                        movement=bdef.movement,
+                        capacity=bdef.capacity,
+                        owner=0,
+                    )
+                    tile.boat = boat
+                    return
 
     # ---------------------------------------------------------------- drawing
     def draw(self) -> None:


### PR DESCRIPTION
## Summary
- Introduce Boat unit carrier and track boats per tile
- Enable buying and embarking boats, plus disembarking leave-behind
- Add boat management UI and tests for spawning, movement costs, and garrison exchange

## Testing
- `pytest tests/test_boat_spawn.py tests/test_boat_exchange.py tests/test_world_navigation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aafc9ccae8832188aac7fadafe59d1