### PR TITLE
Add ocean sanctuary and lighthouse buildings

### DIFF
--- a/assets/buildings/buildings.json
+++ b/assets/buildings/buildings.json
@@ -69,6 +69,24 @@
     "path": "buildings/town/town_0.png",
     "variants": 1,
     "provides": {"resource": "gold", "per_day": 0}
+  },
+  {
+    "id": "sea_sanctuary",
+    "footprint": [1, 1],
+    "anchor_px": [512, 1020],
+    "passable": true,
+    "occludes": true,
+    "path": "buildings/sea_sanctuary/sea_sanctuary_0.png",
+    "variants": 1
+  },
+  {
+    "id": "lighthouse",
+    "footprint": [1, 1],
+    "anchor_px": [512, 1020],
+    "passable": true,
+    "occludes": true,
+    "path": "buildings/lighthouse/lighthouse_0.png",
+    "variants": 1
   }
 ]
 

--- a/core/buildings.py
+++ b/core/buildings.py
@@ -110,11 +110,35 @@ class Shipyard(Building):
             hero.naval_unit = self.boats[index]
 
 
+class SeaSanctuary(Building):
+    """Building that revives a fallen unit stack when visited."""
+
+    def interact(self, hero: "Hero") -> None:
+        super().interact(hero)
+        for unit in hero.army:
+            if unit.count <= 0:
+                unit.count = 1
+                unit.current_hp = unit.stats.max_hp
+                break
+
+
+class Lighthouse(Building):
+    """Grants a vision range bonus to the visiting hero."""
+
+    def interact(self, hero: "Hero") -> None:
+        super().interact(hero)
+        current = getattr(hero, "vision_bonus", 0)
+        hero.vision_bonus = max(current, 2)
+
 def create_building(bid: str, defs: Optional[Dict[str, BuildingAsset]] = None) -> Building:
     asset = (defs or building_loader.BUILDINGS)[bid]
     b: Building
     if bid == "shipyard":
         b = Shipyard()
+    elif bid == "sea_sanctuary":
+        b = SeaSanctuary()
+    elif bid == "lighthouse":
+        b = Lighthouse()
     else:
         b = Building()
     b.id = asset.id

--- a/core/vision.py
+++ b/core/vision.py
@@ -28,6 +28,7 @@ def compute_vision(
     biome = BiomeCatalog.get(tile.biome)
     if biome is not None:
         bonus += getattr(biome, "vision_bonus", 0)
+    bonus += getattr(actor, "vision_bonus", 0)
     radius += bonus
     has_boat = getattr(actor, "naval_unit", None) is not None
 

--- a/core/world.py
+++ b/core/world.py
@@ -1204,8 +1204,6 @@ class WorldMap:
             "mountain": "mine",
             "scarletia_volcanic": "pyramid",
         }
-        if count <= 0:
-            return
         candidates = [
             (x, y)
             for y, row in enumerate(self.grid)
@@ -1218,16 +1216,38 @@ class WorldMap:
         ]
         random.shuffle(candidates)
         placed = 0
-        for x, y in candidates:
-            tile = self.grid[y][x]
-            btype = building_map.get(tile.biome)
-            if not btype:
-                continue
-            building = create_building(btype)
-            if self._can_place_building(x, y, building):
-                self._stamp_building(x, y, building)
-                placed += 1
-                if placed >= count:
+        if count > 0:
+            for x, y in candidates:
+                tile = self.grid[y][x]
+                btype = building_map.get(tile.biome)
+                if not btype:
+                    continue
+                building = create_building(btype)
+                if self._can_place_building(x, y, building):
+                    self._stamp_building(x, y, building)
+                    placed += 1
+                    if placed >= count:
+                        break
+
+        # Scatter special ocean buildings regardless of ``count``
+        ocean_candidates = [
+            (x, y)
+            for y, row in enumerate(self.grid)
+            for x, tile in enumerate(row)
+            if tile.biome in constants.WATER_BIOMES
+            and not tile.obstacle
+            and tile.treasure is None
+            and tile.enemy_units is None
+            and tile.resource is None
+            and tile.building is None
+        ]
+        random.shuffle(ocean_candidates)
+        for bid in ("sea_sanctuary", "lighthouse"):
+            while ocean_candidates:
+                x, y = ocean_candidates.pop()
+                building = create_building(bid)
+                if self._can_place_building(x, y, building):
+                    self._stamp_building(x, y, building)
                     break
 
 

--- a/tests/test_ocean_buildings.py
+++ b/tests/test_ocean_buildings.py
@@ -1,0 +1,45 @@
+from core.buildings import create_building
+from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.vision import compute_vision
+from core.world import WorldMap
+import constants
+
+
+def test_sea_sanctuary_revives_first_dead_unit():
+    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 0, "hero")])
+    building = create_building("sea_sanctuary")
+    building.interact(hero)
+    assert hero.alive()
+
+
+def test_lighthouse_grants_vision_bonus():
+    wm = WorldMap(
+        width=10,
+        height=1,
+        biome_weights={"scarletia_echo_plain": 1.0},
+        num_obstacles=0,
+        num_treasures=0,
+        num_enemies=0,
+    )
+    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])
+    before = compute_vision(wm, hero)
+    building = create_building("lighthouse")
+    building.interact(hero)
+    after = compute_vision(wm, hero)
+    assert (6, 0) in after and (6, 0) not in before
+
+
+def test_ocean_buildings_spawn_on_water():
+    rows = ["W.W.", "W.W."]
+    world = WorldMap(map_data=rows)
+    world._place_buildings(0)
+    found = {"sea_sanctuary": False, "lighthouse": False}
+    for row in world.grid:
+        for tile in row:
+            if tile.building:
+                bid = tile.building.id
+                if bid in found:
+                    assert tile.biome in constants.WATER_BIOMES
+                    found[bid] = True
+    assert all(found.values())
+


### PR DESCRIPTION
## Summary
- add Sea Sanctuary and Lighthouse entries to building manifest
- allow heroes to resurrect units or gain vision bonus when visiting these buildings
- scatter new ocean buildings during world generation and test their effects

## Testing
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab02bbb77c8321bb4dd9902539e1dc