### PR TITLE
Add naval combat map and detect boat engagements

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -70,6 +70,20 @@ UNIT_SPELLS: Dict[str, Dict[str, int]] = {
     'Dragon': {'Dragon Breath': 2},
 }
 
+
+def water_battlefield_template() -> List[List[str]]:
+    """Return a combat grid filled entirely with water tiles.
+
+    Naval battles take place on open water with no obstacles.  The returned
+    template mirrors the standard combat grid dimensions and contains only the
+    ``"ocean"`` biome.
+    """
+
+    return [
+        ["ocean" for _ in range(constants.COMBAT_GRID_WIDTH)]
+        for _ in range(constants.COMBAT_GRID_HEIGHT)
+    ]
+
 @dataclass
 class CombatSpell:
     """Represents a spell that can be cast during combat."""

--- a/core/game.py
+++ b/core/game.py
@@ -2709,15 +2709,21 @@ class Game:
                     self._notify("You have been defeated!")
                     self.hero.army = []
                 return True
-        from core.combat import Combat
+        from core.combat import Combat, water_battlefield_template
         tile = self.world.grid[self.hero.y][self.hero.x]
-        combat_map, flora = generate_combat_map(
-            self.world,
-            self.hero.x,
-            self.hero.y,
-            constants.COMBAT_GRID_WIDTH,
-            constants.COMBAT_GRID_HEIGHT,
-        )
+        if getattr(self.hero, "naval_unit", None) is not None:
+            combat_map = water_battlefield_template()
+            flora: List["PropInstance"] = []
+            obstacles = 0
+        else:
+            combat_map, flora = generate_combat_map(
+                self.world,
+                self.hero.x,
+                self.hero.y,
+                constants.COMBAT_GRID_WIDTH,
+                constants.COMBAT_GRID_HEIGHT,
+            )
+            obstacles = random.randint(1, 3)
         combat = Combat(
             self.screen,
             self.assets,
@@ -2730,7 +2736,7 @@ class Game:
             flora_loader=self.world.flora_loader,
             biome_tilesets=self.biome_tilesets,
             biome=tile.biome,
-            num_obstacles=random.randint(1, 3),
+            num_obstacles=obstacles,
             unit_shadow_baked=self.unit_shadow_baked,
             hero=self.hero,
             hero_faction=self.hero.faction,

--- a/tests/test_naval_combat_map.py
+++ b/tests/test_naval_combat_map.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+from core.game import Game
+
+
+def test_naval_combat_map_is_all_water(monkeypatch):
+    """Heroes fighting at sea should use a water-only combat map."""
+
+    # --- Stub out external dependencies ---
+    monkeypatch.setattr("core.game.audio.play_sound", lambda *args, **kwargs: None)
+
+    class DummyUnit:
+        def __init__(self):
+            self.count = 1
+            self.current_hp = 1
+
+    class DummyHero:
+        def __init__(self):
+            self.x = 0
+            self.y = 0
+            self.army = [DummyUnit()]
+            self.mana = 0
+            self.max_mana = 0
+            self.spells = {}
+            self.faction = None
+            self.naval_unit = "boat"
+
+        def gain_exp(self, amount: int) -> None:  # pragma: no cover - trivial
+            pass
+
+    class DummyEnemy:
+        def __init__(self):
+            self.x = 0
+            self.y = 0
+            self.army = [DummyUnit()]
+
+    class DummyTile:
+        biome = "ocean"
+
+    class DummyWorld:
+        grid = [[DummyTile()]]
+        flora_loader = None
+
+    hero = DummyHero()
+    enemy = DummyEnemy()
+
+    game = Game.__new__(Game)
+    game.screen = SimpleNamespace()
+    game.assets = {}
+    game.hero = hero
+    game.enemy_heroes = [enemy]
+    game.world = DummyWorld()
+    game.biome_tilesets = {}
+    game.unit_shadow_baked = {}
+    game._update_caches_for_tile = lambda x, y: None
+    game._notify = lambda msg: None
+    game.quit_to_menu = False
+
+    captured = {}
+
+    class DummyCombat:
+        def __init__(self, *args, **kwargs):
+            captured["combat_map"] = kwargs["combat_map"]
+            captured["num_obstacles"] = kwargs["num_obstacles"]
+            self.hero_units = hero.army
+            self.enemy_units = enemy.army
+            self.exit_to_menu = False
+
+        def run(self):
+            return True, 0
+
+    monkeypatch.setattr("core.combat.Combat", DummyCombat)
+
+    game.combat_with_enemy_hero(enemy, initiated_by="enemy")
+
+    grid = captured["combat_map"]
+    assert all(cell == "ocean" for row in grid for cell in row)
+    assert captured["num_obstacles"] == 0
+


### PR DESCRIPTION
## Summary
- Add reusable water-only combat map template
- Detect naval battles and use water template without obstacles
- Test that naval combat maps consist solely of water tiles

## Testing
- `pytest tests/test_naval_combat_map.py tests/test_combat_map_shoreline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab225ab65483218d29e76d8379f644