### PR TITLE
Add marine creature and ocean spawning logic

### DIFF
--- a/assets/units/creatures.json
+++ b/assets/units/creatures.json
@@ -34,6 +34,15 @@
     "biomes": ["scarletia_crimson_forest", "mountain"],
     "behavior": "guardian",
     "guard_range": 2
+  },
+  {
+    "id": "reef_serpent",
+    "image": "units/scarletia/reef_serpent_0.png",
+    "anchor_px": [384, 600],
+    "shadow_baked": false,
+    "biomes": ["ocean"],
+    "behavior": "roamer",
+    "guard_range": 3
   }
 ]
 

--- a/core/entities.py
+++ b/core/entities.py
@@ -945,6 +945,34 @@ HURLOMBE_STATS = UnitStats(
     mana=2,
 )
 
+# Serpent des récifs — créature marine ne vivant que dans l'océan
+REEF_SERPENT_STATS = UnitStats(
+    name="reef_serpent",
+    max_hp=48,
+    attack_min=6,
+    attack_max=9,
+    defence_melee=3,
+    defence_ranged=3,
+    defence_magic=2,
+    speed=4,
+    attack_range=1,
+    initiative=7,
+    sheet="creatures",
+    hero_frames=(0, 0),
+    enemy_frames=(0, 0),
+    min_range=1,
+    retaliations_per_round=1,
+    morale=0,
+    luck=0,
+    abilities=[
+        "water_resistance(25%)",
+        "constrict(immobilize=1)",
+    ],
+    role="Prédateur marin à l'étreinte constrictive",
+    unit_type="beast",
+    mana=0,
+)
+
 
 def create_random_enemy_army() -> List[Unit]:
     """Generate a random selection of enemy units for the world map."""

--- a/core/world.py
+++ b/core/world.py
@@ -31,6 +31,7 @@ from core.entities import (
     SHADOWLEAF_WOLF_STATS,
     BOAR_RAVEN_STATS,
     HURLOMBE_STATS,
+    REEF_SERPENT_STATS,
     Army,
     UnitCarrier,
 )
@@ -66,6 +67,7 @@ ENEMY_UNIT_IMAGES: Dict[str, str] = {
     SHADOWLEAF_WOLF_STATS.name: SHADOWLEAF_WOLF_STATS.name,
     BOAR_RAVEN_STATS.name: BOAR_RAVEN_STATS.name,
     HURLOMBE_STATS.name: HURLOMBE_STATS.name,
+    REEF_SERPENT_STATS.name: REEF_SERPENT_STATS.name,
 }
 
 # Number of tiles grouped into a single flora chunk used for spatial indexing
@@ -77,6 +79,7 @@ CREATURE_STATS: Dict[str, "UnitStats"] = {
     SHADOWLEAF_WOLF_STATS.name: SHADOWLEAF_WOLF_STATS,
     BOAR_RAVEN_STATS.name: BOAR_RAVEN_STATS,
     HURLOMBE_STATS.name: HURLOMBE_STATS,
+    REEF_SERPENT_STATS.name: REEF_SERPENT_STATS,
 }
 
 
@@ -887,9 +890,19 @@ class WorldMap:
                     break
 
     def _create_enemy_army_for_biome(self, biome: str) -> List[Unit]:
-        """Generate an enemy army themed to the given biome."""
+        """Generate an enemy army themed to the given biome.
 
-        creature_names = CREATURES_BY_BIOME.get(biome, DEFAULT_ENEMY_UNITS)
+        Water biomes have dedicated marine units defined in the creature
+        manifest.  If a biome has no specific entries fall back to the default
+        land creatures.
+        """
+
+        creature_names = CREATURES_BY_BIOME.get(biome)
+        if not creature_names:
+            if biome in constants.WATER_BIOMES:
+                creature_names = [REEF_SERPENT_STATS.name]
+            else:
+                creature_names = DEFAULT_ENEMY_UNITS
         num_stacks = random.randint(1, 3)
         units: List[Unit] = []
         for _ in range(num_stacks):

--- a/tests/test_ocean_enemy_spawn.py
+++ b/tests/test_ocean_enemy_spawn.py
@@ -1,0 +1,20 @@
+import os
+import tempfile
+
+from core.world import WorldMap
+from core.entities import REEF_SERPENT_STATS
+
+
+def test_ocean_tiles_spawn_marine_enemies():
+    # create a map with a single ocean tile containing an enemy
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        tmp.write("WE")
+        path = tmp.name
+    try:
+        world = WorldMap.from_file(path)
+        tile = world.grid[0][0]
+        assert tile.biome == "ocean"
+        assert tile.enemy_units is not None
+        assert all(u.stats.name == REEF_SERPENT_STATS.name for u in tile.enemy_units)
+    finally:
+        os.remove(path)


### PR DESCRIPTION
## Summary
- Define reef serpent stats and register as a water-only creature
- Map reef serpents to the `ocean` biome and load with world enemy army logic
- Test that ocean tiles spawn reef serpent enemies

## Testing
- `pytest -q` *(killed: process exited prematurely)*
- `pytest tests/test_ocean_enemy_spawn.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2449b9a08321a169f11104ae4ffd