### PR TITLE
Add map type option to new game scenarios

### DIFF
--- a/assets/i18n/menu.json
+++ b/assets/i18n/menu.json
@@ -6,12 +6,13 @@
     "campaign_soon": "Campaign (coming soon)",
     "new_game": "New Game",
     "choose_scenario": "Choose a scenario",
-    "cancel": "Cancel",
+    "cancel": "Annuler",
     "blue": "Blue",
     "red": "Red",
     "random": "Random",
     "default_player_name": "Player",
     "map_size": "Map size",
+    "map_type": "Map type",
     "ai_difficulty": "AI Difficulty",
     "total_players": "Total players",
     "human_players": "Human players",
@@ -32,7 +33,9 @@
     "error": "Error",
     "pause": "Pause",
     "save": "Save",
-    "Red Knights": "Red Knights"
+    "Red Knights": "Red Knights",
+    "plaine": "Plains",
+    "marine": "Marine"
   },
   "fr": {
     "slot": "Emplacement {index}",
@@ -47,6 +50,7 @@
     "random": "Aléatoire",
     "default_player_name": "Joueur",
     "map_size": "Taille de la carte",
+    "map_type": "Type de carte",
     "ai_difficulty": "Difficulté de l'IA",
     "total_players": "Joueurs totaux",
     "human_players": "Joueurs humains",
@@ -67,6 +71,8 @@
     "error": "Erreur",
     "pause": "Pause",
     "save": "Sauvegarde",
-    "Red Knights": "Chevaliers rouges"
+    "Red Knights": "Chevaliers rouges",
+    "plaine": "Plaine",
+    "marine": "Marine"
   }
 }

--- a/core/game.py
+++ b/core/game.py
@@ -161,6 +161,7 @@ class Game:
         use_default_map: bool = True,
         slot: int = 0,
         map_size: str = constants.DEFAULT_MAP_SIZE,
+        map_type: str = "plaine",
         difficulty: str = constants.AI_DIFFICULTY,
         scenario: Optional[str] = None,
         player_name: str = "Joueur",
@@ -171,6 +172,7 @@ class Game:
         self.screen = screen
         self.current_slot = slot
         self.map_size = map_size
+        self.map_type = map_type
         self.scenario = scenario
         self.player_name = player_name
         self.player_colour = player_colour
@@ -240,10 +242,11 @@ class Game:
                 self.map_size, constants.MAP_SIZE_PRESETS[constants.DEFAULT_MAP_SIZE]
             )
             # Generate only the first region's biomes using the new indexing
+            land_chance = 0.55 if self.map_type == "plaine" else 0.35
             map_rows = generate_continent_map(
                 width,
                 height,
-                land_chance=0.55,
+                land_chance=land_chance,
                 smoothing_iterations=5,
                 biome_chars="GFD",
             )

--- a/tests/test_new_game_menu.py
+++ b/tests/test_new_game_menu.py
@@ -110,7 +110,7 @@ def test_scenario_config_confirm(monkeypatch):
     monkeypatch.setattr(pygame, "QUIT", 13, raising=False)
 
     events = []
-    for _ in range(7):
+    for _ in range(8):
         events.append([SimpleNamespace(type=pygame.KEYDOWN, key=pygame.K_DOWN)])
     events.append([SimpleNamespace(type=pygame.KEYDOWN, key=pygame.K_RETURN)])
 
@@ -121,3 +121,4 @@ def test_scenario_config_confirm(monkeypatch):
     config, _ = menu._scenario_config(screen, "foo.json")
     assert config["scenario"] == "foo.json"
     assert config["map_size"] == list(constants.MAP_SIZE_PRESETS.keys())[0]
+    assert config["map_type"] == "plaine"

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -175,6 +175,8 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
     size_labels = [f"{k} ({w}x{h})" for k, (w, h) in sizes]
     ai_keys = list(constants.AI_DIFFICULTIES)
     ai_labels = [constants.DIFFICULTY_LABELS[k] for k in ai_keys]
+    map_type_opts = ["plaine", "marine"]
+    map_type_labels = [MENU_TEXTS[opt] for opt in map_type_opts]
     colour_labels = [MENU_TEXTS["blue"], MENU_TEXTS["red"]]
     colour_values = [constants.BLUE, constants.RED]
     faction_opts = ["red_knights", None]
@@ -183,11 +185,12 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
     human_players_opts = [1, 2, 3, 4]
 
     # Current selection indices for each option group.
-    idx_size = idx_diff = idx_total = idx_human = idx_colour = idx_faction = 0
+    idx_size = idx_map = idx_diff = idx_total = idx_human = idx_colour = idx_faction = 0
     player_name = MENU_TEXTS["default_player_name"]
 
     rows = [
         MENU_TEXTS["map_size"],
+        MENU_TEXTS["map_type"],
         MENU_TEXTS["ai_difficulty"],
         MENU_TEXTS["total_players"],
         MENU_TEXTS["human_players"],
@@ -223,40 +226,44 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
                     if row_idx == 0:
                         idx_size = (idx_size - 1) % len(size_labels)
                     elif row_idx == 1:
-                        idx_diff = (idx_diff - 1) % len(ai_keys)
+                        idx_map = (idx_map - 1) % len(map_type_labels)
                     elif row_idx == 2:
+                        idx_diff = (idx_diff - 1) % len(ai_keys)
+                    elif row_idx == 3:
                         idx_total = max(0, idx_total - 1)
                         _clamp_humans()
-                    elif row_idx == 3:
+                    elif row_idx == 4:
                         idx_human = max(0, idx_human - 1)
                         _clamp_humans()
-                    elif row_idx == 4:
-                        idx_colour = (idx_colour - 1) % len(colour_labels)
                     elif row_idx == 5:
+                        idx_colour = (idx_colour - 1) % len(colour_labels)
+                    elif row_idx == 6:
                         idx_faction = (idx_faction - 1) % len(faction_labels)
                 elif event.key in (pygame.K_RIGHT, pygame.K_d):
                     if row_idx == 0:
                         idx_size = (idx_size + 1) % len(size_labels)
                     elif row_idx == 1:
-                        idx_diff = (idx_diff + 1) % len(ai_keys)
+                        idx_map = (idx_map + 1) % len(map_type_labels)
                     elif row_idx == 2:
+                        idx_diff = (idx_diff + 1) % len(ai_keys)
+                    elif row_idx == 3:
                         idx_total = min(len(total_players_opts) - 1, idx_total + 1)
                         _clamp_humans()
-                    elif row_idx == 3:
+                    elif row_idx == 4:
                         idx_human = min(len(human_players_opts) - 1, idx_human + 1)
                         _clamp_humans()
-                    elif row_idx == 4:
-                        idx_colour = (idx_colour + 1) % len(colour_labels)
                     elif row_idx == 5:
+                        idx_colour = (idx_colour + 1) % len(colour_labels)
+                    elif row_idx == 6:
                         idx_faction = (idx_faction + 1) % len(faction_labels)
                 elif event.key == pygame.K_RETURN:
-                    if row_idx == 6:  # Name field
+                    if row_idx == 7:  # Name field
                         player_name, screen = _text_input(
                             screen, MENU_TEXTS["player_name_prompt"], default=player_name
                         )
                         if player_name is None:
                             player_name = MENU_TEXTS["default_player_name"]
-                    elif row_idx == 7:  # Confirm
+                    elif row_idx == 8:  # Confirm
                         _clamp_humans()
                         total_players = total_players_opts[idx_total]
                         human_players = min(
@@ -268,6 +275,7 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
                         return (
                             {
                                 "map_size": sizes[idx_size][0],
+                                "map_type": map_type_opts[idx_map],
                                 "difficulty": ai_keys[idx_diff],
                                 "scenario": scenario,
                                 "total_players": total_players,
@@ -279,7 +287,7 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
                             },
                             screen,
                         )
-                    elif row_idx == 8:  # Cancel
+                    elif row_idx == 9:  # Cancel
                         return None, screen
                 elif event.key == pygame.K_ESCAPE:
                     return None, screen
@@ -299,6 +307,7 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
 
         values = [
             size_labels[idx_size],
+            map_type_labels[idx_map],
             ai_labels[idx_diff],
             str(total_players_opts[idx_total]),
             str(human_players_opts[idx_human]),
@@ -378,6 +387,7 @@ def main_menu(screen: pygame.Surface, can_resume: bool = False) -> pygame.Surfac
                 use_default_map=False,
                 slot=slot,
                 map_size=config["map_size"],
+                map_type=config["map_type"],
                 difficulty=config["difficulty"],
                 scenario=config["scenario"],
                 player_name=config["player_name"],


### PR DESCRIPTION
## Summary
- Let players pick a map type (plaine or marine) when configuring a scenario
- Pass the map type into Game and tweak land generation accordingly
- Extend translations and tests for the new option

## Testing
- `pytest tests/test_new_game_menu.py -q`
- `pytest -q` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e66e8788321846cda91d36c7cb8