### PR TITLE
Add map type option for continent map generation

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -242,11 +242,10 @@ class Game:
                 self.map_size, constants.MAP_SIZE_PRESETS[constants.DEFAULT_MAP_SIZE]
             )
             # Generate only the first region's biomes using the new indexing
-            land_chance = 0.55 if self.map_type == "plaine" else 0.35
             map_rows = generate_continent_map(
                 width,
                 height,
-                land_chance=land_chance,
+                map_type=self.map_type,
                 smoothing_iterations=5,
                 biome_chars="GFD",
             )

--- a/tests/test_collect_flora.py
+++ b/tests/test_collect_flora.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import random
 
 pygame_stub = types.SimpleNamespace()
 sys.modules.setdefault("pygame", pygame_stub)
@@ -14,6 +15,8 @@ def test_collect_flora_adds_item_and_removes_prop(monkeypatch):
     import audio
 
     monkeypatch.setattr(audio, "play_sound", lambda *a, **k: None)
+
+    random.seed(0)
 
     game = Game.__new__(Game)
     game.world = WorldMap(width=2, height=1, num_obstacles=0, num_treasures=0, num_enemies=0)

--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -118,3 +118,11 @@ def test_building_images_loaded():
             del sys.modules["pygame"]
         sys.modules.pop("pygame.draw", None)
 
+
+def test_marine_map_has_two_starting_areas():
+    random.seed(0)
+    rows = generate_continent_map(30, 30, seed=0, map_type="marine")
+    world = WorldMap(map_data=rows)
+    assert world.starting_area is not None
+    assert world.enemy_starting_area is not None
+


### PR DESCRIPTION
## Summary
- allow `generate_continent_map` to accept `map_type` and choose land density (plaine vs marine)
- preserve large islands on marine maps and let `Game` pass map type
- add marine map starting area test and stabilize flora collection test with a fixed seed

## Testing
- `pytest tests/test_starting_area.py::test_marine_map_has_two_starting_areas -q`
- `pytest tests/test_collect_flora.py::test_collect_flora_adds_item_and_removes_prop -q`
- `pytest tests/test_continent_generation.py::test_generate_continent_map_contains_land_and_ocean -q`
- `pytest tests/test_enemy_ai.py::test_enemy_starting_area_has_town -q`
- `pytest tests/test_shipyard_placement.py::test_each_continent_has_shipyard -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab31c0177c832180656efa4497ff51