### PR TITLE
Ensure marine maps allocate islands per player

### DIFF
--- a/mapgen/continents.py
+++ b/mapgen/continents.py
@@ -182,6 +182,7 @@ def generate_continent_map(
     coast_char: str = "C",
     min_continent_size: Optional[int] = None,
     biome_compatibility: Optional[Dict[str, set[str]]] = None,
+    num_players: int = 2,
 ) -> List[str]:
     """Generate map data with continents and biome regions.
 
@@ -194,7 +195,9 @@ def generate_continent_map(
     higher level code will place obstacles and items afterwards.
     ``map_type`` controls the overall ratio of land to water and defaults to
     ``"plaine"`` for land‑heavy maps.  Passing ``"marine"`` yields mostly
-    water with a few larger islands preserved for starting areas.
+    water with a few larger islands preserved for starting areas.  When
+    generating marine maps ``num_players`` landmasses are retained to host the
+    starting areas for each player; all other continents are flooded.
     """
     if seed is not None:
         random.seed(seed)
@@ -217,11 +220,15 @@ def generate_continent_map(
 
     if map_type == "marine":
         continents = _label_continents(grid)
-        largest = sorted(continents.values(), key=len, reverse=True)
-        for cells in largest[2:]:
+        for cells in continents.values():
             if len(cells) < min_continent_size:
                 for x, y in cells:
                     grid[y][x] = False
+        continents = _label_continents(grid)
+        largest = sorted(continents.values(), key=len, reverse=True)
+        for cells in largest[num_players:]:
+            for x, y in cells:
+                grid[y][x] = False
         continents = _label_continents(grid)
     else:
         _remove_small_continents(grid, min_continent_size)

--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -119,10 +119,24 @@ def test_building_images_loaded():
         sys.modules.pop("pygame.draw", None)
 
 
-def test_marine_map_has_two_starting_areas():
+def test_marine_islands_have_required_buildings():
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0, map_type="marine")
     world = WorldMap(map_data=rows)
     assert world.starting_area is not None
     assert world.enemy_starting_area is not None
+    continents = world._find_continents()
+    assert len(continents) == 2
+    for continent in continents:
+        buildings = [
+            world.grid[y][x].building
+            for x, y in continent
+            if world.grid[y][x].building is not None
+        ]
+        names = {b.name for b in buildings}
+        assert any(name.startswith("Town") for name in names)
+        assert any(
+            n in {"Mine", "Crystal Mine", "Sawmill"} for n in names
+        )
+        assert "Shipyard" in names
 


### PR DESCRIPTION
## Summary
- Keep only the largest islands equal to the player count when generating marine maps
- Determine marine maps heuristically and create player starts on separate islands
- Guarantee each starting island includes a town, resource buildings, and a shipyard

## Testing
- `pytest tests/test_starting_area.py::test_marine_islands_have_required_buildings -q`
- `pytest tests/test_shipyard_placement.py -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab331a0048832183bf604aa70fb33f