### PR TITLE
Enrich marine maps with ocean points of interest

### DIFF
--- a/tests/test_marine_ocean_features.py
+++ b/tests/test_marine_ocean_features.py
@@ -1,0 +1,29 @@
+import random
+
+from mapgen.continents import generate_continent_map
+from core.world import WorldMap
+import constants
+
+
+def test_marine_world_scattered_ocean_features():
+    random.seed(0)
+    rows = generate_continent_map(30, 30, seed=0, map_type="marine")
+    world = WorldMap(map_data=rows)
+
+    buildings = {"sea_sanctuary": 0, "lighthouse": 0}
+    water_resources = 0
+    water_creatures = 0
+    for row in world.grid:
+        for tile in row:
+            if tile.biome in constants.WATER_BIOMES:
+                if tile.building and tile.building.id in buildings:
+                    buildings[tile.building.id] += 1
+                if tile.resource is not None:
+                    water_resources += 1
+                if tile.enemy_units is not None:
+                    water_creatures += 1
+
+    assert buildings["sea_sanctuary"] >= 1
+    assert buildings["lighthouse"] >= 1
+    assert water_resources >= 1
+    assert water_creatures >= 1


### PR DESCRIPTION
## Summary
- scatter sea sanctuaries, lighthouses, bonus resources and marine creature spawns across water tiles on marine maps
- ensure ocean enrichment triggers automatically for marine-dominated maps
- add regression test for marine ocean feature placement

## Testing
- `pytest tests/test_random_map_generation.py tests/test_ocean_buildings.py tests/test_marine_ocean_features.py -q`
- `pytest -q` *(fails: process killed by environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ab35b9f3688321a90e27d31fcbcb2c