### PR TITLE
Add map type navigation tests

### DIFF
--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -4,6 +4,11 @@ from core.game import Game as GameClass
 from core.entities import Boat
 from loaders.boat_loader import BoatDef
 import audio
+import random
+
+from mapgen.continents import generate_continent_map
+from core.world import WorldMap
+import constants
 
 
 def setup_water_game(monkeypatch):
@@ -44,3 +49,63 @@ def test_embark_disembark_cost(monkeypatch):
     assert game.hero.ap == start_ap - 3
     assert game.hero.naval_unit is None
     assert game.world.grid[0][1].boat is not None
+
+
+def _generate_world(map_type: str) -> WorldMap:
+    random.seed(0)
+    rows = generate_continent_map(30, 30, seed=0, map_type=map_type)
+    return WorldMap(map_data=rows)
+
+
+def test_plaine_map_is_land_heavy():
+    world = _generate_world("plaine")
+    total = world.width * world.height
+    land = sum(
+        1
+        for row in world.grid
+        for tile in row
+        if tile.biome not in constants.WATER_BIOMES
+    )
+    assert land / total > 0.6
+
+
+def test_marine_map_features_and_starting_islands():
+    world = _generate_world("marine")
+    total = world.width * world.height
+    water = sum(
+        1
+        for row in world.grid
+        for tile in row
+        if tile.biome in constants.WATER_BIOMES
+    )
+    assert water / total > 0.7
+
+    assert world.starting_area and world.enemy_starting_area
+    continents = world._find_continents()
+
+    def continent_for_area(area):
+        x0, y0, size = area
+        area_cells = {
+            (x, y) for x in range(x0, x0 + size) for y in range(y0, y0 + size)
+        }
+        for cont in continents:
+            if area_cells & set(cont):
+                return cont
+        return None
+
+    cont1 = continent_for_area(world.starting_area)
+    cont2 = continent_for_area(world.enemy_starting_area)
+    assert cont1 is not None and cont2 is not None and cont1 is not cont2
+
+    for continent in (cont1, cont2):
+        assert any(
+            world.grid[y][x].building and world.grid[y][x].building.name == "Shipyard"
+            for x, y in continent
+        )
+
+    assert any(
+        tile.building
+        and tile.building.id in {"sea_sanctuary", "lighthouse"}
+        for row in world.grid
+        for tile in row
+    )


### PR DESCRIPTION
## Summary
- ensure plaine maps have majority land and marine maps are water-heavy
- verify marine starts on separate shipyard-equipped islands with ocean features

## Testing
- `pytest tests/test_world_navigation.py tests/test_marine_ocean_features.py tests/test_starting_area.py tests/test_shipyard_placement.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab386ff0508321ab78220d327b0f56