### PR TITLE
Notify players when moving onto water without a boat

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -1910,6 +1910,8 @@ class Game:
                         self._publish_resources()
             return
         if not tile.is_passable(has_boat=has_boat):
+            if tile.biome in constants.WATER_BIOMES and not has_boat:
+                self._notify("A boat is required to embark.")
             return
         # Move hero
         self.hero.x = nx

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -51,6 +51,16 @@ def test_embark_disembark_cost(monkeypatch):
     assert game.world.grid[0][1].boat is not None
 
 
+def test_move_requires_boat_notifies(monkeypatch):
+    game = setup_water_game(monkeypatch)
+    monkeypatch.setattr(audio, "play_sound", lambda *a, **k: None)
+    notices = []
+    game._notify = lambda msg: notices.append(msg)
+    game.try_move_hero(1, 0)
+    assert notices == ["A boat is required to embark."]
+    assert (game.hero.x, game.hero.y) == (0, 0)
+
+
 def _generate_world(map_type: str) -> WorldMap:
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0, map_type=map_type)


### PR DESCRIPTION
## Summary
- warn players if they attempt to enter water tiles without a boat
- test that moving into water without a naval unit emits a notification

## Testing
- `pytest tests/test_world_navigation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3dce72148321b89f6ba291f5425a