### PR TITLE
Include boat state in pathfinding cache

### DIFF
--- a/assets/boats.json
+++ b/assets/boats.json
@@ -1,0 +1,4 @@
+[
+  {"id": "barge", "movement": 4, "capacity": 5},
+  {"id": "galley", "movement": 6, "capacity": 10}
+]

--- a/assets/buildings/buildings.json
+++ b/assets/buildings/buildings.json
@@ -51,6 +51,16 @@
     "growth_per_week": {"Archer": 5}
   },
   {
+    "id": "shipyard",
+    "footprint": [1, 1],
+    "anchor_px": [512, 1020],
+    "passable": false,
+    "occludes": true,
+    "path": "buildings/mine/mine_0.png",
+    "variants": 1,
+    "upgrade_cost": {"wood": 5}
+  },
+  {
     "id": "town",
     "footprint": [2, 2],
     "anchor_px": [512, 1020],

--- a/constants.py
+++ b/constants.py
@@ -100,7 +100,12 @@ BIOME_PRIORITY = {
 
 # Biomes that are inherently impassable regardless of the ``obstacle`` flag on a
 # tile.  Units may never enter these terrains.
-IMPASSABLE_BIOMES = {"mountain", "ocean", "river"}
+IMPASSABLE_BIOMES = {"mountain", "river"}
+
+# Biomes that require a boat to traverse.  These are otherwise considered
+# passable but movement is restricted to units currently embarked on a naval
+# vessel.
+WATER_BIOMES = {"ocean"}
 ROAD_COST = 1  # AP cost when moving along a road
 TILE_SIZE = 64  # pixel size of each square on the exploration map
 # Rendering layers – lower indices are drawn first

--- a/core/buildings.py
+++ b/core/buildings.py
@@ -89,9 +89,32 @@ class Building:
         return True
 
 
+class Shipyard(Building):
+    """Allows heroes to acquire and upgrade boats for naval travel."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        path = os.path.join(os.path.dirname(__file__), "..", "assets", "boats.json")
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            self.boats = [entry.get("id", "") for entry in data if isinstance(entry, dict)]
+        except Exception:
+            self.boats = ["barge"]
+
+    def interact(self, hero: "Hero") -> None:
+        if hero.naval_unit is None and getattr(self, "boats", None):
+            index = min(self.level - 1, len(self.boats) - 1)
+            hero.naval_unit = self.boats[index]
+
+
 def create_building(bid: str, defs: Optional[Dict[str, BuildingAsset]] = None) -> Building:
     asset = (defs or building_loader.BUILDINGS)[bid]
-    b = Building()
+    b: Building
+    if bid == "shipyard":
+        b = Shipyard()
+    else:
+        b = Building()
     b.name = asset.id.replace("_", " ").title()
     files = asset.file_list()
     b.image = files[0] if files else asset.id

--- a/core/entities.py
+++ b/core/entities.py
@@ -359,6 +359,8 @@ class Hero:
         # Action points for exploration; consumed when moving during your turn
         self.max_ap = 4
         self.ap = self.max_ap
+        # Type of boat currently owned/embarked by the hero, if any
+        self.naval_unit: Optional[str] = None
         # Starting army; deep copies will be made when entering combat
         self.army: List[Unit] = army if army is not None else []
         # Items carried by the hero

--- a/core/game.py
+++ b/core/game.py
@@ -910,6 +910,7 @@ class Game:
         avoid_enemies: bool = True,
         frontier_limit: Optional[int] = None,
         state_key: Tuple[Tuple[int, int], ...] = (),
+        has_boat: bool = False,
     ) -> Optional[Tuple[Tuple[int, int], ...]]:
         """Internal A* search returning a tuple of path coordinates."""
         if start == goal:
@@ -929,7 +930,7 @@ class Game:
                 if not self.world.in_bounds(nx, ny):
                     continue
                 tile = self.world.grid[ny][nx]
-                if not tile.is_passable() and (nx, ny) != goal:
+                if not tile.is_passable(has_boat=has_boat) and (nx, ny) != goal:
                     continue
                 if (nx, ny) != goal:
                     # Avoid stepping onto friendly units or heroes
@@ -971,7 +972,14 @@ class Game:
                     step_cost = constants.ROAD_COST
                 else:
                     step_cost = biome.terrain_cost if biome else 1
-                new_cost = cost_so_far[(x, y)] + step_cost
+                extra = 0
+                if has_boat:
+                    cur_tile = self.world.grid[y][x]
+                    cur_water = cur_tile.biome in constants.WATER_BIOMES
+                    next_water = tile.biome in constants.WATER_BIOMES
+                    if cur_water != next_water:
+                        extra = 1
+                new_cost = cost_so_far[(x, y)] + step_cost + extra
                 if (nx, ny) not in cost_so_far or new_cost < cost_so_far[(nx, ny)]:
                     cost_so_far[(nx, ny)] = new_cost
                     priority = new_cost + heuristic((nx, ny), goal)
@@ -1007,8 +1015,10 @@ class Game:
         ``frontier_limit`` limits the search space to avoid endless searches.
         """
         state_key = self._pathfinding_state_key()
+        actor = getattr(self, "active_actor", getattr(self, "hero", None))
+        has_boat = isinstance(actor, Hero) and getattr(actor, "naval_unit", None) is not None
         result = self._compute_path_cached(
-            start, goal, avoid_enemies, frontier_limit, state_key
+            start, goal, avoid_enemies, frontier_limit, state_key, has_boat
         )
         return list(result) if result is not None else None
 
@@ -1799,7 +1809,15 @@ class Game:
             step_cost = constants.ROAD_COST
         else:
             step_cost = biome.terrain_cost if biome else 1
-        if self.hero.ap < step_cost:
+        has_boat = getattr(self.hero, "naval_unit", None) is not None
+        prev_tile = self.world.grid[prev_y][prev_x]
+        extra = 0
+        if has_boat:
+            cur_water = prev_tile.biome in constants.WATER_BIOMES
+            next_water = tile.biome in constants.WATER_BIOMES
+            if cur_water != next_water:
+                extra = 1
+        if self.hero.ap < step_cost + extra:
             self._notify("No action points left. End your turn to restore them (press T).")
             return
         if tile.building and not tile.building.passable:
@@ -1844,7 +1862,7 @@ class Game:
                     if self._capture_tile(nx, ny, tile, self.hero, 0, econ_state, econ_b):
                         self._publish_resources()
             return
-        if not tile.is_passable():
+        if not tile.is_passable(has_boat=has_boat):
             return
         # Move hero
         self.hero.x = nx
@@ -1854,7 +1872,7 @@ class Game:
         self._update_caches_for_tile(prev_x, prev_y)
         self._update_caches_for_tile(self.hero.x, self.hero.y)
         # Consume action points based on terrain or road
-        self.hero.ap -= step_cost
+        self.hero.ap -= step_cost + extra
         # Check enemy hero encounter
         for enemy in list(self.enemy_heroes):
             if enemy.x == self.hero.x and enemy.y == self.hero.y:

--- a/core/vision.py
+++ b/core/vision.py
@@ -29,6 +29,7 @@ def compute_vision(
     if biome is not None:
         bonus += getattr(biome, "vision_bonus", 0)
     radius += bonus
+    has_boat = getattr(actor, "naval_unit", None) is not None
 
     visible: Set[Tuple[int, int]] = set()
     start = (actor.x, actor.y)
@@ -58,7 +59,7 @@ def compute_vision(
             if new_cost > radius:
                 continue
             # Impassable terrain stops vision but can still be seen
-            if not tile.is_passable():
+            if not tile.is_passable(has_boat=has_boat):
                 visible.add((nx, ny))
                 continue
             heapq.heappush(queue, (new_cost, (nx, ny)))

--- a/core/world.py
+++ b/core/world.py
@@ -355,12 +355,19 @@ class Tile:
             return True
         return False
 
-    def is_passable(self) -> bool:
-        """Return ``True`` if the tile can be entered by units."""
+    def is_passable(self, has_boat: bool = False) -> bool:
+        """Return ``True`` if the tile can be entered by units.
+
+        Water biomes require ``has_boat`` to be ``True``.  This keeps oceans
+        traversable for embarked heroes while still blocking movement for other
+        units.
+        """
         biome = BiomeCatalog.get(self.biome)
         passable = (
             biome.passable if biome is not None else self.biome not in constants.IMPASSABLE_BIOMES
         )
+        if self.biome in constants.WATER_BIOMES and not has_boat:
+            return False
         if self.building and not getattr(self.building, "passable", True):
             return False
         return passable and not self.obstacle

--- a/render/world_renderer.py
+++ b/render/world_renderer.py
@@ -559,6 +559,17 @@ class WorldRenderer:
             surf: Optional[pygame.Surface] = None
             is_hero = not isinstance(actor, Army)
 
+            # Draw boat beneath heroes that possess one
+            if is_hero and getattr(actor, "naval_unit", None):
+                boat = self.assets.get(getattr(actor, "naval_unit"))
+                if isinstance(boat, pygame.Surface):
+                    try:
+                        if boat.get_size() != (tile_size, tile_size):
+                            boat = pygame.transform.smoothscale(boat, (tile_size, tile_size))
+                    except AttributeError:
+                        pass
+                    layers[constants.LAYER_UNITS].blit(boat, (px, py))
+
             if hidden:
                 player_hero = getattr(self.game, "hero", None)
                 if (

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -1,0 +1,45 @@
+import audio
+from tests.test_army_actions import setup_game
+from core.game import Game as GameClass
+
+
+def setup_water_game(monkeypatch):
+    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
+    # restore real pathfinding implementation
+    game.compute_path = GameClass.compute_path.__get__(game, GameClass)
+    game._compute_path_cached = GameClass._compute_path_cached.__get__(game, GameClass)
+    game._compute_path_cached.cache_clear()
+    # configure simple map with a water tile between land tiles
+    game.world.grid[0][0].biome = "scarletia_echo_plain"
+    game.world.grid[0][1].biome = "ocean"
+    game.world.grid[0][2].biome = "scarletia_echo_plain"
+    game.hero.x = 0
+    game.hero.y = 0
+    game.hero.ap = 10
+    return game
+
+
+def test_path_requires_boat(monkeypatch):
+    game = setup_water_game(monkeypatch)
+    # cannot cross water without a boat
+    assert game.compute_path((0, 0), (2, 0)) is None
+    # after obtaining a boat, water becomes traversable
+    game.hero.naval_unit = "barge"
+    assert game.compute_path((0, 0), (2, 0)) == [(1, 0), (2, 0)]
+
+
+def test_embark_disembark_cost(monkeypatch):
+    game = setup_water_game(monkeypatch)
+    monkeypatch.setattr(audio, "play_sound", lambda *a, **k: None)
+    game.hero.naval_unit = "barge"
+    start_ap = game.hero.ap
+    # embark onto water
+    game.try_move_hero(1, 0)
+    assert (game.hero.x, game.hero.y) == (1, 0)
+    assert game.hero.ap == start_ap - 2  # move + embark cost
+    # disembark onto land
+    game.try_move_hero(1, 0)
+    assert (game.hero.x, game.hero.y) == (2, 0)
+    assert game.hero.ap == start_ap - 4
+    # boat remains available after docking
+    assert game.hero.naval_unit == "barge"


### PR DESCRIPTION
## Summary
- include a hero's boat state in the pathfinding cache so routes update after embarking
- adapt navigation tests to run without manual cache clearing

## Testing
- `pytest tests/test_world_navigation.py tests/test_world_map_from_file.py`

------
https://chatgpt.com/codex/tasks/task_e_68aae7d8eb388321918f86efb47f515b