### PR TITLE
Ensure boats require shoreline to embark/disembark

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -2140,11 +2140,24 @@ class Game:
         # otherwise just move
 
     def embark(self, hero: Hero, boat: Boat) -> bool:
-        """Embark ``hero`` onto ``boat`` if adjacent."""
+        """Embark ``hero`` onto ``boat`` if adjacent and at shore."""
         if abs(hero.x - boat.x) + abs(hero.y - boat.y) != 1:
+            return False
+        # Hero must be on land and not already embarked
+        if getattr(hero, "naval_unit", None) is not None:
+            return False
+        hero_tile = self.world.grid[hero.y][hero.x]
+        if hero_tile.biome in constants.WATER_BIOMES:
             return False
         tile = self.world.grid[boat.y][boat.x]
         if tile.boat is not boat or hero.ap <= 0:
+            return False
+        # Boat must be adjacent to at least one land tile
+        if all(
+            not self.world.in_bounds(boat.x + dx, boat.y + dy)
+            or self.world.grid[boat.y + dy][boat.x + dx].biome in constants.WATER_BIOMES
+            for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))
+        ):
             return False
         prev_x, prev_y = hero.x, hero.y
         hero.ap -= 1
@@ -2162,6 +2175,13 @@ class Game:
         """Leave the boat on water tile ``(x, y)`` and remove naval status."""
         boat_id = getattr(hero, "naval_unit", None)
         if not boat_id:
+            return
+        # Ensure the disembark location is adjacent to land
+        if all(
+            not self.world.in_bounds(x + dx, y + dy)
+            or self.world.grid[y + dy][x + dx].biome in constants.WATER_BIOMES
+            for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))
+        ):
             return
         bdef = self.boat_defs.get(boat_id) if hasattr(self, "boat_defs") else None
         movement = bdef.movement if bdef else 0

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -27,6 +27,23 @@ def setup_water_game(monkeypatch):
     return game
 
 
+def setup_open_sea_game(monkeypatch):
+    """Create a game where the hero and a boat are at sea away from land."""
+    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
+    game.compute_path = GameClass.compute_path.__get__(game, GameClass)
+    game._compute_path_cached = GameClass._compute_path_cached.__get__(game, GameClass)
+    for x in range(3):
+        game.world.grid[0][x].biome = "ocean"
+    game.hero.x = 0
+    game.hero.y = 0
+    game.hero.ap = 10
+    game.boat_defs = {"barge": BoatDef("barge", 4, 7, {}, "barge.png")}
+    game.hero.naval_unit = "barge"
+    boat = Boat("barge", 1, 0, 4, 7, owner=0)
+    game.world.grid[0][1].boat = boat
+    return game, boat
+
+
 def test_path_requires_boat(monkeypatch):
     game = setup_water_game(monkeypatch)
     assert game.compute_path((0, 0), (2, 0)) is None
@@ -59,6 +76,21 @@ def test_move_requires_boat_notifies(monkeypatch):
     game.try_move_hero(1, 0)
     assert notices == ["A boat is required to embark."]
     assert (game.hero.x, game.hero.y) == (0, 0)
+
+
+def test_embark_requires_adjacent_land(monkeypatch):
+    game, boat = setup_open_sea_game(monkeypatch)
+    monkeypatch.setattr(audio, "play_sound", lambda *a, **k: None)
+    assert not game.embark(game.hero, boat)
+    assert game.hero.naval_unit == "barge"
+    assert game.world.grid[0][1].boat is boat
+
+
+def test_disembark_requires_adjacent_land(monkeypatch):
+    game, _ = setup_open_sea_game(monkeypatch)
+    game.disembark(game.hero, 0, 0)
+    assert game.hero.naval_unit == "barge"
+    assert game.world.grid[0][0].boat is None
 
 
 def _generate_world(map_type: str) -> WorldMap:


### PR DESCRIPTION
## Summary
- Require heroes to be on land and adjacent to shore before embarking onto a boat
- Prevent disembarking unless the boat is next to land
- Add navigation tests for embarking/disembarking rules

## Testing
- `pytest tests/test_world_navigation.py -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab44c5db50832190d916fb636fc3ca