### PR TITLE
Add hex battlefield rendering

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -148,8 +148,10 @@ MARKET_RATES = {
 
 # Combat settings
 # Battlefield dimensions for tactical combat
-COMBAT_GRID_WIDTH = 8
-COMBAT_GRID_HEIGHT = 6
+# ``COMBAT_HEX_SIZE`` represents the width of a single hex cell in pixels.
+COMBAT_HEX_SIZE = 64
+COMBAT_GRID_WIDTH = 10
+COMBAT_GRID_HEIGHT = 10
 COMBAT_TILE_SIZE = 64
 
 # Colours (RGB)


### PR DESCRIPTION
## Summary
- introduce COMBAT_HEX_SIZE and enlarge combat grid to 10x10
- render biome-specific battlefield background and hex grid overlay
- use hexagonal coordinates for combat cell placement and distance

## Testing
- `pytest` *(killed: out-of-memory?)*
- `pytest tests/test_combat_ai.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab53a1ada88321a6191153a129c4c2