### PR TITLE
Display hero info and spellbook in combat HUD

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -303,8 +303,8 @@ def handle_button_click(combat, current_unit, pos: Tuple[int, int]) -> bool:
 
     for action, rect in combat.action_buttons.items():
         if rect.collidepoint(mx, my):
-            if combat.selected_action == "spell":
-                if action == "back":
+            if combat.selected_action in ("spell", "spellbook"):
+                if action in ("back", "spellbook"):
                     combat.selected_action = None
                     break
                 combat.start_spell(current_unit, action)

--- a/core/combat_rules.py
+++ b/core/combat_rules.py
@@ -90,9 +90,10 @@ def compute_damage(attacker: UnitView, defender: UnitView, *,
 
     # Pénalités/bonus
     min_range = getattr(attacker.stats, "min_range", 1)
-    if attack_type == "ranged" and distance < max(2, min_range):
-        dmg = int(round(dmg * 0.75))  # pénalité tir trop proche
+    if attack_type == "ranged":
         defence = defender.stats.defence_ranged
+        if distance < max(2, min_range):
+            dmg = int(round(dmg * 0.75))  # pénalité tir trop proche
     elif attack_type == "magic":
         defence = defender.stats.defence_magic
     else:


### PR DESCRIPTION
## Summary
- add optional top HUD panel showing hero portrait, stats and spellbook access
- allow casting hero spells via new spellbook button and start_spell
- ensure focus spell always doubles next shot and drop flanking bonus on ranged attacks

## Testing
- `pytest tests/test_spells.py`
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5dceebc88321b30a099d39c5b333