### PR TITLE
Add hero battlefield image rendering

### DIFF
--- a/assets/units/heroes.json
+++ b/assets/units/heroes.json
@@ -2,6 +2,7 @@
   {
     "id": "default_hero",
     "portrait": "hero/portrait_hero.png",
+    "battlefield": "hero/bf_default.png",
     "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
   }
 ]

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -67,6 +67,15 @@ def draw(combat, frame: int = 0) -> None:
             constants.GREEN, pygame.Rect(combat.offset_x, combat.offset_y, grid_w, grid_h)
         )
 
+    if getattr(combat, "hero", None):
+        img = getattr(combat.hero, "battlefield_image", None)
+        if isinstance(img, pygame.Surface):
+            w, h = img.get_size()
+            if combat.zoom != 1:
+                img = pygame.transform.scale(img, (int(w * combat.zoom), int(h * combat.zoom)))
+                w, h = img.get_size()
+            combat.screen.blit(img, (combat.offset_x, combat.offset_y - h))
+
     # Hex grid overlay
     for x in range(constants.COMBAT_GRID_WIDTH):
         for y in range(constants.COMBAT_GRID_HEIGHT):

--- a/core/entities.py
+++ b/core/entities.py
@@ -364,6 +364,7 @@ class Hero:
         army: Optional[List[Unit]] = None,
         base_stats: Optional[HeroStats] = None,
         portrait: Any | None = None,
+        battlefield_image: Any | None = None,
         name: str = "Hero",
         colour: Tuple[int, int, int] = constants.BLUE,
         faction: FactionDef | None = None,
@@ -371,6 +372,7 @@ class Hero:
         self.x = x
         self.y = y
         self.portrait = portrait
+        self.battlefield_image = battlefield_image
         self.name = name
         self.colour = colour
         self.faction = faction

--- a/core/game.py
+++ b/core/game.py
@@ -353,17 +353,22 @@ class Game:
             Unit(DRAGON_STATS, 5, 'hero'),
             Unit(PRIEST_STATS, 15, 'hero'),
         ]
+        hero_asset = self.assets.get("default_hero")
+        portrait = None
+        battlefield = None
+        if isinstance(hero_asset, dict):
+            portrait = hero_asset.get("portrait")
+            battlefield = hero_asset.get("battlefield")
         self.hero = Hero(
             hx,
             hy,
             starting_army,
+            portrait=portrait,
+            battlefield_image=battlefield,
             name=self.player_name,
             colour=self.player_colour,
             faction=self.faction,
         )
-        hero_asset = self.assets.get("default_hero")
-        if isinstance(hero_asset, dict):
-            self.hero.portrait = hero_asset.get("portrait")
         self.hero.inventory.extend(STARTING_ARTIFACTS)
         # Quest system
         self.quest_manager = QuestManager(self)
@@ -687,22 +692,24 @@ class Game:
             try:
                 with open(heroes_path, "r", encoding="utf-8") as f:
                     entries = json.load(f)
-                for entry in entries:
-                    try:
-                        portrait = self.assets.get(entry.get("portrait", ""))
-                        icon_info = entry.get("icon", {})
-                        icon_surf = self.assets.get(icon_info.get("image", ""))
-                        size = icon_info.get("scale", constants.TILE_SIZE)
-                        icon_surf = scale_surface(icon_surf, (size, size), smooth=True)
-                        self.assets[entry["id"]] = {
-                            "portrait": portrait,
-                            "icon": {
-                                "surface": icon_surf,
-                                "anchor": tuple(icon_info.get("anchor", (0, 0))),
-                            },
-                        }
-                    except Exception:
-                        continue
+                    for entry in entries:
+                        try:
+                            portrait = self.assets.get(entry.get("portrait", ""))
+                            battlefield = self.assets.get(entry.get("battlefield", ""))
+                            icon_info = entry.get("icon", {})
+                            icon_surf = self.assets.get(icon_info.get("image", ""))
+                            size = icon_info.get("scale", constants.TILE_SIZE)
+                            icon_surf = scale_surface(icon_surf, (size, size), smooth=True)
+                            self.assets[entry["id"]] = {
+                                "portrait": portrait,
+                                "battlefield": battlefield,
+                                "icon": {
+                                    "surface": icon_surf,
+                                    "anchor": tuple(icon_info.get("anchor", (0, 0))),
+                                },
+                            }
+                        except Exception:
+                            continue
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- load battlefield image for heroes and store in assets
- extend Hero with battlefield image and draw it during combat

## Testing
- `pytest -q` *(killed: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68ab67b71308832194adb92e7417179b