### PR TITLE
Add battlefield definitions and integrate into combat

### DIFF
--- a/assets/battlefields/battlefields.json
+++ b/assets/battlefields/battlefields.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "default",
+    "image": "",
+    "hero_pos": [0, 0]
+  },
+  {
+    "id": "ocean",
+    "image": "assets/battlefields/ocean.png",
+    "hero_pos": [0, 0]
+  },
+  {
+    "id": "scarletia_echo_plain",
+    "image": "assets/battlefields/scarletia_echo_plain.png",
+    "hero_pos": [0, 0]
+  }
+]

--- a/core/combat.py
+++ b/core/combat.py
@@ -37,6 +37,8 @@ try:  # flora support optional in tests
 except Exception:  # pragma: no cover
     FloraLoader = PropInstance = None  # type: ignore
 from loaders.biomes import BiomeTileset
+# Battlefield definitions for background images and hero placement
+from loaders.battlefield_loader import BattlefieldDef
 # en haut de combat.py
 from core.combat_screen import CombatHUD
 from core.abilities import AbilityEngine, parse_abilities
@@ -114,7 +116,7 @@ class Combat:
         flora_props: Optional[List["PropInstance"]] = None,
         flora_loader: Optional["FloraLoader"] = None,
         biome_tilesets: Optional[Dict[str, BiomeTileset]] = None,
-        biome: str = "scarletia_echo_plain",
+        battlefield: Optional[BattlefieldDef] = None,
         num_obstacles: int = 0,
         unit_shadow_baked: Optional[Dict[str, bool]] = None,
         hero: Optional["Hero"] = None,
@@ -192,9 +194,10 @@ class Combat:
         self.teleport_unit: Optional[Unit] = None
         self.hero_mana: int = hero_mana
         self.hero_spells: Dict[str, int] = hero_spells or {}
-        self.biome = biome
+        # Battlefield definition provides background image and hero placement
+        self.battlefield = battlefield or BattlefieldDef("default", "", (0, 0))
         self.combat_map: List[List[str]] = combat_map or [
-            [biome for _ in range(constants.COMBAT_GRID_WIDTH)]
+            [self.battlefield.id for _ in range(constants.COMBAT_GRID_WIDTH)]
             for _ in range(constants.COMBAT_GRID_HEIGHT)
         ]
         # --- Siege mechanics ---

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -52,10 +52,13 @@ def draw(combat, frame: int = 0) -> None:
     # Draw battlefield background
     bg = getattr(combat, "_battlefield_bg", None)
     if bg is None:
-        path = os.path.join("assets", "battlefields", f"{combat.biome}.png")
-        try:
-            bg = pygame.image.load(path).convert_alpha()
-        except Exception:
+        path = getattr(combat.battlefield, "image", "")
+        if path:
+            try:
+                bg = pygame.image.load(path).convert_alpha()
+            except Exception:
+                bg = None
+        else:
             bg = None
         combat._battlefield_bg = bg
     if bg:
@@ -74,7 +77,10 @@ def draw(combat, frame: int = 0) -> None:
             if combat.zoom != 1:
                 img = pygame.transform.scale(img, (int(w * combat.zoom), int(h * combat.zoom)))
                 w, h = img.get_size()
-            combat.screen.blit(img, (combat.offset_x, combat.offset_y - h))
+            hx, hy = getattr(combat.battlefield, "hero_pos", (0, 0))
+            x = combat.offset_x + int(hx * combat.zoom)
+            y = combat.offset_y + int(hy * combat.zoom)
+            combat.screen.blit(img, (x, y))
 
     # Hex grid overlay
     for x in range(constants.COMBAT_GRID_WIDTH):

--- a/core/game.py
+++ b/core/game.py
@@ -64,6 +64,7 @@ from core.ai.creature_ai import CreatureAI
 from core.buildings import Building, Town, Shipyard, create_building
 from loaders.building_loader import BUILDINGS, get_surface
 from loaders.faction_loader import load_factions
+from loaders.battlefield_loader import load_battlefields, BattlefieldDef
 from ui.main_screen import MainScreen
 from ui import dialogs
 from state.event_bus import (
@@ -195,6 +196,13 @@ class Game:
         BiomeCatalog.load(self.ctx, "biomes/biomes.json")
         init_biome_images()
         self.load_assets()
+
+        battlefield_manifest = os.path.join(
+            repo_root, "assets", "battlefields", "battlefields.json"
+        )
+        self.battlefields: Dict[str, BattlefieldDef] = load_battlefields(
+            battlefield_manifest, self.assets
+        )
 
         self.biome_tilesets: Dict[str, BiomeTileset] = {
             b.id: load_tileset(self.ctx, b, tile_size=constants.COMBAT_TILE_SIZE)
@@ -1708,6 +1716,12 @@ class Game:
                         constants.COMBAT_GRID_WIDTH,
                         constants.COMBAT_GRID_HEIGHT,
                     )
+                    bf_id = getattr(tile, "biome", "default")
+                    bf_dict = getattr(self, "battlefields", {})
+                    battlefield = bf_dict.get(
+                        bf_id,
+                        bf_dict.get("default", BattlefieldDef("default", "", (0, 0))),
+                    )
                     combat = Combat(
                         self.screen,
                         self.assets,
@@ -1719,7 +1733,7 @@ class Game:
                         flora_props=flora,
                         flora_loader=self.world.flora_loader,
                         biome_tilesets=self.biome_tilesets,
-                        biome=tile.biome,
+                        battlefield=battlefield,
                         num_obstacles=random.randint(1, 3),
                         unit_shadow_baked=self.unit_shadow_baked,
                         hero=None,
@@ -2016,6 +2030,12 @@ class Game:
                     constants.COMBAT_GRID_WIDTH,
                     constants.COMBAT_GRID_HEIGHT,
                 )
+                bf_id = getattr(tile, "biome", "default")
+                bf_dict = getattr(self, "battlefields", {})
+                battlefield = bf_dict.get(
+                    bf_id,
+                    bf_dict.get("default", BattlefieldDef("default", "", (0, 0))),
+                )
                 combat = Combat(
                     self.screen,
                     self.assets,
@@ -2027,7 +2047,7 @@ class Game:
                     flora_props=flora,
                     flora_loader=self.world.flora_loader,
                     biome_tilesets=self.biome_tilesets,
-                    biome=tile.biome,
+                    battlefield=battlefield,
                     num_obstacles=random.randint(1, 3),
                     unit_shadow_baked=self.unit_shadow_baked,
                     hero=self.hero,
@@ -2812,6 +2832,11 @@ class Game:
                 constants.COMBAT_GRID_HEIGHT,
             )
             obstacles = random.randint(1, 3)
+        bf_id = getattr(tile, "biome", "default")
+        bf_dict = getattr(self, "battlefields", {})
+        battlefield = bf_dict.get(
+            bf_id, bf_dict.get("default", BattlefieldDef("default", "", (0, 0)))
+        )
         combat = Combat(
             self.screen,
             self.assets,
@@ -2823,7 +2848,7 @@ class Game:
             flora_props=flora,
             flora_loader=self.world.flora_loader,
             biome_tilesets=self.biome_tilesets,
-            biome=tile.biome,
+            battlefield=battlefield,
             num_obstacles=obstacles,
             unit_shadow_baked=self.unit_shadow_baked,
             hero=self.hero,

--- a/loaders/battlefield_loader.py
+++ b/loaders/battlefield_loader.py
@@ -1,0 +1,62 @@
+"""Loader for battlefield definitions.
+
+This module provides a small helper to read battlefield metadata from a JSON
+manifest. Each entry specifies an identifier, image path and optional hero
+position used when rendering the combat background.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple
+import json
+import os
+
+
+@dataclass
+class BattlefieldDef:
+    """Definition of a combat battlefield."""
+
+    id: str
+    image: str
+    hero_pos: Tuple[int, int] = (0, 0)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+def load_battlefields(path: str, assets: Dict[str, Any] | None = None) -> Dict[str, BattlefieldDef]:
+    """Load battlefield definitions from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the JSON manifest containing battlefield entries.
+    assets:
+        Optional asset manager used to preload images referenced by entries.
+
+    Returns
+    -------
+    dict
+        Mapping of battlefield id to :class:`BattlefieldDef`.
+    """
+
+    defs: Dict[str, BattlefieldDef] = {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception:
+        return defs
+
+    for entry in data:
+        bid = entry.get("id")
+        if not bid:
+            continue
+        image = entry.get("image", "")
+        pos = entry.get("hero_pos", [0, 0])
+        hero_pos = (int(pos[0]), int(pos[1])) if isinstance(pos, (list, tuple)) and len(pos) >= 2 else (0, 0)
+        meta = {k: v for k, v in entry.items() if k not in {"id", "image", "hero_pos"}}
+        defs[bid] = BattlefieldDef(id=bid, image=image, hero_pos=hero_pos, meta=meta)
+        if assets is not None and image:
+            try:
+                assets.get(image)
+            except Exception:
+                pass
+    return defs


### PR DESCRIPTION
## Summary
- Introduce battlefields manifest with id, image and hero position metadata
- Load battlefield definitions and provide `BattlefieldDef` dataclass
- Pass battlefield info to combat and render background/hero using it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab6966f6a88321a0976bace465b6cd