### PR TITLE
feat: add combat overlays

### DIFF
--- a/assets/overlays/overlays.json
+++ b/assets/overlays/overlays.json
@@ -1,8 +1,8 @@
 [
-  {"id": "mask_n",  "image": "overlays/mask_n.png"},
-  {"id": "mask_e",  "image": "overlays/mask_e.png"},
-  {"id": "mask_s",  "image": "overlays/mask_s.png"},
-  {"id": "mask_w",  "image": "overlays/mask_w.png"},
+  {"id": "mask_n", "image": "overlays/mask_n.png"},
+  {"id": "mask_e", "image": "overlays/mask_e.png"},
+  {"id": "mask_s", "image": "overlays/mask_s.png"},
+  {"id": "mask_w", "image": "overlays/mask_w.png"},
   {"id": "mask_ne", "image": "overlays/mask_ne.png"},
   {"id": "mask_nw", "image": "overlays/mask_nw.png"},
   {"id": "mask_se", "image": "overlays/mask_se.png"},
@@ -11,6 +11,19 @@
   {"id": "active_unit", "image": "overlays/active_unit_overlay.png"},
   {"id": "melee_range", "image": "overlays/melee_range_overlay.png"},
   {"id": "ranged_range", "image": "overlays/ranged_range_overlay.png"},
-  {"id": "move_arrow", "image": "overlays/move_arrow.png"}
-  {"id": "hero_flag", "image": "overlays/hero_flag.png"}
+  {"id": "move_arrow", "image": "overlays/move_arrow.png"},
+  {"id": "hero_flag", "image": "overlays/hero_flag.png"},
+  {"id": "move_overlay", "image": "overlays/move_overlay.png"},
+  {"id": "enemy_overlay", "image": "overlays/enemy_overlay.png"},
+  {"id": "melee_overlay", "image": "overlays/melee_overlay.png"},
+  {"id": "ranged_overlay", "image": "overlays/ranged_overlay.png"},
+  {"id": "spell_overlay", "image": "overlays/spell_overlay.png"},
+  {"id": "select_overlay", "image": "overlays/select_overlay.png"},
+  {"id": "blocked_overlay", "image": "overlays/blocked_overlay.png"},
+  {"id": "ally_buff_overlay", "image": "overlays/ally_buff_overlay.png"},
+  {"id": "enemy_debuff_overlay", "image": "overlays/enemy_debuff_overlay.png"},
+  {"id": "danger_overlay", "image": "overlays/danger_overlay.png"},
+  {"id": "path_overlay", "image": "overlays/path_overlay.png"},
+  {"id": "obstacle_overlay", "image": "overlays/obstacle_overlay.png"},
+  {"id": "summon_overlay", "image": "overlays/summon_overlay.png"}
 ]

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -19,15 +19,19 @@ def draw_hex(surface: pygame.Surface, rect: pygame.Rect, colour: Tuple[int, int,
     ``alpha`` controls the transparency of the drawn shape.
     """
 
+    w = rect.width
+    h = rect.height
     points = [
-        (rect.x + rect.w * 0.25, rect.y),
-        (rect.x + rect.w * 0.75, rect.y),
-        (rect.x + rect.w, rect.y + rect.h / 2),
-        (rect.x + rect.w * 0.75, rect.y + rect.h),
-        (rect.x + rect.w * 0.25, rect.y + rect.h),
-        (rect.x, rect.y + rect.h / 2),
+        (rect.x + w * 0.25, rect.y),
+        (rect.x + w * 0.75, rect.y),
+        (rect.x + w, rect.y + h / 2),
+        (rect.x + w * 0.75, rect.y + h),
+        (rect.x + w * 0.25, rect.y + h),
+        (rect.x, rect.y + h / 2),
     ]
-    pygame.draw.polygon(surface, (*colour, alpha), points, width)
+    draw = getattr(pygame, "draw", None)
+    if draw and hasattr(draw, "polygon"):
+        draw.polygon(surface, (*colour, alpha), points, width)
 
 
 def draw(combat, frame: int = 0) -> None:
@@ -149,7 +153,7 @@ def draw(combat, frame: int = 0) -> None:
         and combat.selected_action == "move"
     ):
         reachable = combat.reachable_squares(combat.selected_unit)
-        highlight_img = combat.assets.get("move_overlay") or combat.assets.get("highlight")
+        highlight_img = combat.assets.get("move_overlay")
         for (cx, cy) in reachable:
             rect = combat.cell_rect(cx, cy)
             if highlight_img:
@@ -188,7 +192,7 @@ def draw(combat, frame: int = 0) -> None:
                     for x in range(constants.COMBAT_GRID_WIDTH)
                     if combat.grid[y][x] is None and (x, y) not in combat.obstacles
                 ]
-        highlight_img = combat.assets.get("spell_overlay") or combat.assets.get("highlight")
+        highlight_img = combat.assets.get("spell_overlay")
         for (cx, cy) in targets:
             rect = combat.cell_rect(cx, cy)
             if highlight_img:

--- a/core/game.py
+++ b/core/game.py
@@ -787,6 +787,25 @@ class Game:
                 overlay_files = [e.get("image") for e in entries if e.get("image")]
                 if overlay_files:
                     self.load_additional_assets(overlay_files)
+                scale_ids = {
+                    "highlight",
+                    "active_unit",
+                    "melee_range",
+                    "ranged_range",
+                    "move_overlay",
+                    "enemy_overlay",
+                    "melee_overlay",
+                    "ranged_overlay",
+                    "spell_overlay",
+                    "select_overlay",
+                    "blocked_overlay",
+                    "ally_buff_overlay",
+                    "enemy_debuff_overlay",
+                    "danger_overlay",
+                    "path_overlay",
+                    "obstacle_overlay",
+                    "summon_overlay",
+                }
                 for entry in entries:
                     oid = entry.get("id")
                     img = entry.get("image")
@@ -794,12 +813,7 @@ class Game:
                         continue
                     surf = self.assets.get(img)
                     if surf:
-                        if oid in {
-                            "highlight",
-                            "active_unit",
-                            "melee_range",
-                            "ranged_range",
-                        }:
+                        if oid in scale_ids:
                             surf = scale_surface(
                                 surf,
                                 (


### PR DESCRIPTION
## Summary
- add new overlay identifiers for combat highlight states
- load and scale overlay assets for combat use
- stop using generic highlight and improve hex drawing fallback

## Testing
- `pytest tests/test_overlay_rendering.py -q`
- `pytest -q` *(killed: process out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ad248308321a43b55870bf78826