### PR TITLE
feat: scale hero sprite by hex factor

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -153,6 +153,8 @@ COMBAT_HEX_SIZE = 64
 COMBAT_GRID_WIDTH = 10
 COMBAT_GRID_HEIGHT = 10
 COMBAT_TILE_SIZE = 64
+# Hero sprite height relative to a combat hex
+HERO_HEX_FACTOR = 1.5
 
 # Colours (RGB)
 WHITE = (255, 255, 255)

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -105,10 +105,12 @@ def draw(combat, frame: int = 0) -> None:
         img = getattr(combat.hero, "battlefield_image", None)
         if isinstance(img, pygame.Surface):
             w, h = img.get_size()
-            if combat.zoom != 1:
-                img = pygame.transform.scale(
-                    img, (int(w * combat.zoom), int(h * combat.zoom))
-                )
+            target_h = int(
+                constants.COMBAT_HEX_SIZE * constants.HERO_HEX_FACTOR * combat.zoom
+            )
+            if h != target_h:
+                scale = target_h / h
+                img = pygame.transform.scale(img, (int(w * scale), target_h))
                 w, h = img.get_size()
             hx, hy = getattr(combat.battlefield, "hero_pos", (0, 0))
             if 0 <= hx <= 1 and 0 <= hy <= 1:
@@ -118,7 +120,8 @@ def draw(combat, frame: int = 0) -> None:
                 hx *= combat.zoom
                 hy *= combat.zoom
             x = combat.offset_x + int(hx)
-            y = combat.offset_y + int(hy)
+            base_h = int(constants.COMBAT_HEX_SIZE * combat.zoom)
+            y = combat.offset_y + int(hy) - (h - base_h)
             combat.screen.blit(img, (x, y))
 
     # Hex grid overlay


### PR DESCRIPTION
## Summary
- add `HERO_HEX_FACTOR` constant to define hero height relative to combat hex
- scale hero image by hex factor and adjust vertical alignment during combat rendering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab7d13548483219a5868124db5dbfc