### PR TITLE
Remove combat flora usage in combat map and rendering

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -127,25 +127,6 @@ def draw(combat, frame: int = 0) -> None:
             rect = combat.cell_rect(x, y)
             draw_hex(overlay, rect, constants.WHITE, 40, width=1)
 
-    # Draw decorative flora if any
-    if combat.flora_loader and combat.flora_props:
-
-        def grid_to_screen(tx: int, ty: int) -> Tuple[int, int]:
-            r = combat.cell_rect(tx, ty)
-            return r.centerx, r.bottom
-
-        decals = []
-        others = []
-        for p in combat.flora_props:
-            a = combat.flora_loader.assets.get(p.asset_id)
-            if a and a.type == "decal":
-                decals.append(p)
-            else:
-                others.append(p)
-        if decals:
-            combat.flora_loader.draw_props(combat.screen, decals, grid_to_screen)
-        if others:
-            combat.flora_loader.draw_props(combat.screen, others, grid_to_screen)
     # Highlight reachable squares when preparing a movement action
     if (
         combat.selected_unit

--- a/core/world.py
+++ b/core/world.py
@@ -241,8 +241,9 @@ def generate_combat_map(
     The returned grid has ``width``×``height`` cells and initially copies the
     biome of the source tile ``(x, y)``.  If the source tile borders a
     different biome, the second biome is mixed in using a simple checkerboard
-    pattern.  Decorative flora props are generated using the world's existing
-    ``flora_loader`` when available.
+    pattern.  Decorative flora props are not generated; an empty list is
+    returned.  Obstacles continue to be managed separately via
+    :attr:`combat.obstacles` and :meth:`Combat.generate_obstacles`.
     """
 
     origin_biome = world.grid[y][x].biome
@@ -266,16 +267,8 @@ def generate_combat_map(
                 if (xx + yy) % 2:
                     grid[yy][xx] = secondary
 
+    # Combat maps no longer place decorative flora automatically.
     flora_props: List["PropInstance"] = []
-    loader = getattr(world, "flora_loader", None)
-    if loader:
-        tags = [["" for _ in range(width)] for _ in range(height)]
-        allowed: Dict[str, List[str]] = {}
-        for biome_id in {cell for row in grid for cell in row}:
-            biome = BiomeCatalog.get(biome_id)
-            if biome and biome.flora:
-                allowed[biome_id] = biome.flora
-        flora_props = loader.autoplace(grid, tags, 0, allowed if allowed else None)
 
     return grid, flora_props
 


### PR DESCRIPTION
## Summary
- combat maps no longer auto-place flora and always return an empty flora prop list
- remove decorative flora drawing from combat renderer

## Testing
- `pytest -q` *(fails: process killed, likely OOM)*
- `pytest tests/test_combat_map_shoreline.py tests/test_collectible_rendering.py tests/test_collect_flora.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab8845a718832186cea71a7187b3f2