### PR TITLE
Scale combat grid from background image

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -150,8 +150,8 @@ MARKET_RATES = {
 # Battlefield dimensions for tactical combat
 # ``COMBAT_HEX_SIZE`` represents the width of a single hex cell in pixels.
 COMBAT_HEX_SIZE = 64
-COMBAT_GRID_WIDTH = 10
-COMBAT_GRID_HEIGHT = 10
+COMBAT_GRID_WIDTH = 11
+COMBAT_GRID_HEIGHT = 7
 COMBAT_TILE_SIZE = 64
 # Hero sprite height relative to a combat hex
 HERO_HEX_FACTOR = 1.5

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Tuple
 
-import math
 import pygame
 import constants
 import theme
@@ -61,8 +60,8 @@ def draw(combat, frame: int = 0) -> None:
         available_w / combat.grid_pixel_width,
         available_h / combat.grid_pixel_height,
     )
-    tile_w = int(constants.COMBAT_HEX_SIZE * combat.zoom)
-    tile_h = int(constants.COMBAT_HEX_SIZE * combat.zoom * math.sqrt(3) / 2)
+    tile_w = int(combat.hex_width * combat.zoom)
+    tile_h = int(combat.hex_height * combat.zoom)
     grid_w = int(combat.grid_pixel_width * combat.zoom)
     grid_h = int(combat.grid_pixel_height * combat.zoom)
     extra_w = available_w - grid_w
@@ -100,7 +99,7 @@ def draw(combat, frame: int = 0) -> None:
         if isinstance(img, pygame.Surface):
             w, h = img.get_size()
             target_h = int(
-                constants.COMBAT_HEX_SIZE * constants.HERO_HEX_FACTOR * combat.zoom
+                combat.hex_width * constants.HERO_HEX_FACTOR * combat.zoom
             )
             if h != target_h:
                 scale = target_h / h
@@ -114,7 +113,7 @@ def draw(combat, frame: int = 0) -> None:
                 hx *= combat.zoom
                 hy *= combat.zoom
             x = combat.offset_x + int(hx)
-            base_h = int(constants.COMBAT_HEX_SIZE * combat.zoom)
+            base_h = int(combat.hex_width * combat.zoom)
             y = combat.offset_y + int(hy) - (h - base_h)
             combat.screen.blit(img, (x, y))
 


### PR DESCRIPTION
## Summary
- Set combat grid to 11x7 cells
- Derive combat hex size from battlefield image and recompute grid dimensions
- Render combat grid using computed hex size to keep even side margins

## Testing
- `pytest tests/test_combat_ai.py`
- `python -m py_compile constants.py core/combat.py core/combat_render.py`
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab97124dc0832186613d112b95778a