### PR TITLE
feat: support battlefield scaling for units

### DIFF
--- a/assets/units/creatures.json
+++ b/assets/units/creatures.json
@@ -42,7 +42,8 @@
     "shadow_baked": false,
     "biomes": ["ocean"],
     "behavior": "roamer",
-    "guard_range": 3
+    "guard_range": 3,
+    "battlefield_scale": 1.75
   }
 ]
 

--- a/assets/units/units.json
+++ b/assets/units/units.json
@@ -2,7 +2,7 @@
   {"id": "swordsman", "image": "units/swordsman.png", "anchor_px": [32, 64], "shadow_baked": false},
   {"id": "archer", "image": "units/archer.png", "anchor_px": [32, 64], "shadow_baked": false},
   {"id": "mage", "image": "units/mage.png", "anchor_px": [32, 64], "shadow_baked": false},
-  {"id": "dragon", "image": "units/dragon.png", "anchor_px": [32, 64], "shadow_baked": false},
+  {"id": "dragon", "image": "units/dragon.png", "anchor_px": [32, 64], "shadow_baked": false, "battlefield_scale": 1.75},
   {"id": "priest", "image": "units/priest.png", "anchor_px": [32, 64], "shadow_baked": false},
   {"id": "cavalry", "image": "units/cavalry.png", "anchor_px": [32, 64], "shadow_baked": false}
 ]

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -268,11 +268,17 @@ def draw(combat, frame: int = 0) -> None:
                 if 0 <= index < len(frames):
                     img = frames[index]
         if img:
-            if rect.size != img.get_size():
-                img = pygame.transform.scale(img, rect.size)
+            target_h = int(rect.height * unit.stats.battlefield_scale)
+            w, h = img.get_size()
+            if h != target_h:
+                scale = target_h / h
+                img = pygame.transform.scale(img, (int(w * scale), target_h))
+                w, h = img.get_size()
+            x = rect.center[0] - w // 2
+            y = rect.bottom - h
             if not combat.unit_shadow_baked.get(key or "", False):
                 combat.screen.blit(shadow_surf, rect.topleft)
-            combat.screen.blit(img, rect.topleft)
+            combat.screen.blit(img, (x, y))
         else:
             colour = (
                 combat.hero_colour if unit.side == "hero" else constants.RED

--- a/core/entities.py
+++ b/core/entities.py
@@ -99,6 +99,7 @@ class UnitStats:
     mana: int = 0
     min_range: int = 1
     retaliations_per_round: int = 1
+    battlefield_scale: float = 1.0
 
 
 @dataclass

--- a/loaders/units_loader.py
+++ b/loaders/units_loader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+from core.entities import UnitStats
 from .core import Context, read_json, require_keys
 
 
@@ -29,5 +30,10 @@ def load_units(ctx: Context, manifest: str = "units/units.json") -> Dict[str, di
         require_keys(entry, ["id", "stats"])
         unit = dict(entry)
         unit["abilities"] = _parse_abilities(entry.get("abilities", []))
+        stats = dict(entry["stats"])
+        stats["battlefield_scale"] = entry.get(
+            "battlefield_scale", stats.get("battlefield_scale", 1.0)
+        )
+        unit["stats"] = UnitStats(**stats)
         units[unit["id"]] = unit
     return units

--- a/tests/test_combat_unit_sort.py
+++ b/tests/test_combat_unit_sort.py
@@ -31,6 +31,7 @@ def test_units_drawn_in_coordinate_order(monkeypatch):
     u1 = _make_unit("u1")
     u2 = _make_unit("u2")
     u3 = _make_unit("u3")
+    u3.stats.battlefield_scale = 1.75
 
     assets = {"u1": pygame.Surface((10, 10)), "u2": pygame.Surface((10, 10)), "u3": pygame.Surface((10, 10))}
 


### PR DESCRIPTION
## Summary
- add optional `battlefield_scale` to unit and creature manifests
- load `battlefield_scale` into `UnitStats`
- scale combat sprites on battlefield while keeping them centered
- ensure drawing order remains stable for scaled units

## Testing
- `pytest tests/test_combat_unit_sort.py -q`
- Full `pytest` run was killed (environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_68ab98f901108321a85320ea6ee752bd