### PR TITLE
Add spellbook overlay and controls

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -375,6 +375,25 @@ class Combat:
         self.damage_stats[attacker]["dealt"] += dmg
         self.damage_stats[defender]["taken"] += dmg
 
+    def show_spellbook(self) -> None:
+        """Display the hero's spellbook overlay."""
+        try:  # pragma: no cover - allow running without package context
+            from ui.spellbook_overlay import SpellbookOverlay
+        except ImportError:  # pragma: no cover
+            from .ui.spellbook_overlay import SpellbookOverlay  # type: ignore
+
+        overlay = SpellbookOverlay(self.screen, self)
+        clock = pygame.time.Clock()
+        running = True
+        while running:
+            for event in pygame.event.get():
+                if overlay.handle_event(event):
+                    running = False
+                    break
+            overlay.draw()
+            pygame.display.flip()
+            clock.tick(constants.FPS)
+
     def show_stats(self) -> None:
         """Display a summary of combat damage for all units."""
         heading_font = theme.get_font(36) or pygame.font.SysFont(None, 36)
@@ -1064,6 +1083,8 @@ class Combat:
                             return False, self.experience_gained()
                         elif event.key == pygame.K_h:
                             self.auto_mode = False
+                        elif event.key == pygame.K_s:
+                            self.show_spellbook()
                     elif event.type == pygame.MOUSEBUTTONDOWN:
                         if (
                             event.button == 1
@@ -1115,6 +1136,8 @@ class Combat:
                             self.screen.get_width() // 2,
                             self.screen.get_height() // 2,
                         ))
+                    elif event.key == pygame.K_s:
+                        self.show_spellbook()
                     elif current_unit.side == 'hero':
                         if event.key == pygame.K_SPACE:
                             current_unit.acted = True

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -330,7 +330,9 @@ def handle_button_click(combat, current_unit, pos: Tuple[int, int]) -> bool:
 
     for action, rect in combat.action_buttons.items():
         if rect.collidepoint(mx, my):
-            if combat.selected_action == "spell":
+            if action == "spellbook":
+                combat.show_spellbook()
+            elif combat.selected_action == "spell":
                 if action == "back":
                     combat.selected_action = None
                     break

--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -134,15 +134,6 @@ class CombatHUD:
 
             # Buttons below the turn order
             y += 10
-            if combat.hero_spells:
-                r = pygame.Rect(right.x + 10, y, right.width - 20, BUTTON_H)
-                pygame.draw.rect(screen, (52, 55, 63), r)
-                pygame.draw.rect(screen, LINE, r, 1)
-                txt = self.small.render("Spellbook", True, theme.PALETTE["text"])
-                screen.blit(txt, txt.get_rect(center=r.center))
-                action_buttons["spellbook"] = r
-                y = r.bottom + 6
-
             auto_button = pygame.Rect(right.x + 10, y, right.width - 20, BUTTON_H)
             pygame.draw.rect(screen, (52, 55, 63), auto_button)
             pygame.draw.rect(screen, LINE, auto_button, 1)
@@ -152,6 +143,15 @@ class CombatHUD:
                 theme.PALETTE["text"],
             )
             screen.blit(lab, lab.get_rect(center=auto_button.center))
+            y = auto_button.bottom + 6
+
+            if combat.hero_spells:
+                r = pygame.Rect(right.x + 10, y, right.width - 20, BUTTON_H)
+                pygame.draw.rect(screen, (52, 55, 63), r)
+                pygame.draw.rect(screen, LINE, r, 1)
+                txt = self.small.render("Spellbook", True, theme.PALETTE["text"])
+                screen.blit(txt, txt.get_rect(center=r.center))
+                action_buttons["spellbook"] = r
         # ---- Action bar (bottom) ----
         x = bottom.x + 8
 

--- a/ui/spellbook_overlay.py
+++ b/ui/spellbook_overlay.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pygame
+import theme
+
+
+class SpellbookOverlay:
+    """Full-screen overlay displaying the hero's spell list."""
+
+    BG = theme.PALETTE["background"]
+    TEXT = theme.PALETTE["text"]
+
+    def __init__(self, screen: pygame.Surface, combat) -> None:
+        self.screen = screen
+        self.combat = combat
+        self.font = theme.get_font(20) or pygame.font.SysFont(None, 20)
+
+    def handle_event(self, event: pygame.event.Event) -> bool:
+        """Return ``True`` to close the overlay."""
+        if event.type == pygame.KEYDOWN and event.key in (pygame.K_s, pygame.K_ESCAPE):
+            return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            return True
+        return False
+
+    def draw(self) -> None:
+        """Draw the overlay to the attached screen."""
+        w, h = self.screen.get_size()
+        overlay = pygame.Surface((w, h), pygame.SRCALPHA)
+        overlay.fill((*self.BG, 230))
+        theme.draw_frame(overlay, overlay.get_rect())
+
+        y = 40
+        title = self.font.render("Spellbook", True, self.TEXT)
+        overlay.blit(title, ((w - title.get_width()) // 2, 10))
+        y += 20
+        for name in sorted(self.combat.hero_spells.keys()):
+            label = self.font.render(name, True, self.TEXT)
+            overlay.blit(label, (40, y))
+            y += label.get_height() + 8
+
+        self.screen.blit(overlay, (0, 0))


### PR DESCRIPTION
## Summary
- add full-screen Spellbook overlay and `Combat.show_spellbook`
- draw Auto then Spellbook button on combat HUD
- wire button and 'S' key to toggle spellbook during combat

## Testing
- `pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9c03f4b483219f8bc70c8b58496b