### PR TITLE
feat: enlarge combat grid

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -149,7 +149,7 @@ MARKET_RATES = {
 # Combat settings
 # Battlefield dimensions for tactical combat
 # ``COMBAT_HEX_SIZE`` represents the width of a single hex cell in pixels.
-COMBAT_HEX_SIZE = 64
+COMBAT_HEX_SIZE = 128
 COMBAT_GRID_WIDTH = 11
 COMBAT_GRID_HEIGHT = 7
 COMBAT_TILE_SIZE = 64

--- a/core/combat.py
+++ b/core/combat.py
@@ -239,18 +239,7 @@ class Combat:
 
         cols = constants.COMBAT_GRID_WIDTH
         rows = constants.COMBAT_GRID_HEIGHT
-        if self._battlefield_bg:
-            img_w, img_h = self._battlefield_bg.get_size()
-            ratio_w = 0.9
-            ratio_h = 1.0
-            hex_w = min(
-                img_w * ratio_w / (1 + (cols - 1) * 0.75),
-                img_h * ratio_h / (rows + 0.5) * 2 / math.sqrt(3),
-            )
-            self.hex_width = int(hex_w)
-        else:
-            self.hex_width = constants.COMBAT_HEX_SIZE
-
+        self.hex_width = constants.COMBAT_HEX_SIZE
         self.hex_height = int(self.hex_width * math.sqrt(3) / 2)
         self.grid_pixel_width = int(
             self.hex_width + (cols - 1) * self.hex_width * 3 / 4
@@ -258,7 +247,6 @@ class Combat:
         self.grid_pixel_height = int(
             self.hex_height * rows + self.hex_height / 2
         )
-        constants.COMBAT_HEX_SIZE = self.hex_width
         # Offset and zoom/pan state
         self.offset_x = 10
         self.offset_y = 10

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -51,23 +51,16 @@ def draw(combat, frame: int = 0) -> None:
     combat.screen.fill(theme.PALETTE["panel"])
 
     screen_w, screen_h = combat.screen.get_size()
-    margin = HUD_MARGIN
-    right_min = PANEL_W
     bottom_min = BUTTON_H + 8
-    available_w = screen_w - right_min - margin * 3
-    available_h = screen_h - bottom_min - margin * 2
-    combat.zoom = min(
-        available_w / combat.grid_pixel_width,
-        available_h / combat.grid_pixel_height,
-    )
+    combat.zoom = 1.0
     tile_w = int(combat.hex_width * combat.zoom)
     tile_h = int(combat.hex_height * combat.zoom)
     grid_w = int(combat.grid_pixel_width * combat.zoom)
     grid_h = int(combat.grid_pixel_height * combat.zoom)
-    extra_w = available_w - grid_w
-    side_margin = int(margin + extra_w / 2)
-    combat.offset_x = side_margin
-    combat.offset_y = margin
+    side_margin = 64
+    top_margin = 128
+    combat.offset_x = HUD_MARGIN + side_margin
+    combat.offset_y = screen_h - bottom_min - HUD_MARGIN - grid_h
     shadow_surf = pygame.Surface((tile_w, tile_h), pygame.SRCALPHA)
     pygame.draw.ellipse(shadow_surf, (0, 0, 0, 100), shadow_surf.get_rect())
     overlay = pygame.Surface(combat.screen.get_size(), pygame.SRCALPHA)
@@ -85,13 +78,22 @@ def draw(combat, frame: int = 0) -> None:
             bg = None
         combat._battlefield_bg = bg
     if bg:
-        if bg.get_size() != (grid_w, grid_h):
-            bg = pygame.transform.scale(bg, (grid_w, grid_h))
-        combat.screen.blit(bg, (combat.offset_x, combat.offset_y))
+        if bg.get_size() != (grid_w + 2 * side_margin, grid_h + top_margin):
+            bg = pygame.transform.scale(
+                bg, (grid_w + 2 * side_margin, grid_h + top_margin)
+            )
+        combat.screen.blit(
+            bg, (combat.offset_x - side_margin, combat.offset_y - top_margin)
+        )
     else:
         combat.screen.fill(
             constants.GREEN,
-            pygame.Rect(combat.offset_x, combat.offset_y, grid_w, grid_h),
+            pygame.Rect(
+                combat.offset_x - side_margin,
+                combat.offset_y - top_margin,
+                grid_w + 2 * side_margin,
+                grid_h + top_margin,
+            ),
         )
 
     if getattr(combat, "hero", None):


### PR DESCRIPTION
## Summary
- expand combat hex size to 128
- simplify grid sizing calculations
- render combat grid with fixed margins and zoom

## Testing
- `python -m pytest -q` *(fails: KeyboardInterrupt in tests/test_combat_show_stats_screen.py:59)*

------
https://chatgpt.com/codex/tasks/task_e_68aba36c58548321ac447b60a16a4143