### PR TITLE
feat: support unit battlefield scale

### DIFF
--- a/assets/units/creatures.json
+++ b/assets/units/creatures.json
@@ -6,7 +6,8 @@
     "shadow_baked": false,
     "biomes": ["scarletia_volcanic"],
     "behavior": "roamer",
-    "guard_range": 3
+    "guard_range": 3,
+    "battlefield_scale": 1.0
   },
   {
     "id": "shadowleaf_wolf",
@@ -15,7 +16,8 @@
     "shadow_baked": false,
     "biomes": ["scarletia_crimson_forest"],
     "behavior": "roamer",
-    "guard_range": 3
+    "guard_range": 3,
+    "battlefield_scale": 1.0
   },
   {
     "id": "boar_raven",
@@ -24,7 +26,8 @@
     "shadow_baked": false,
     "biomes": ["scarletia_echo_plain", "mountain"],
     "behavior": "roamer",
-    "guard_range": 2
+    "guard_range": 2,
+    "battlefield_scale": 1.0
   },
   {
     "id": "hurlombe",
@@ -33,7 +36,8 @@
     "shadow_baked": false,
     "biomes": ["scarletia_crimson_forest", "mountain"],
     "behavior": "guardian",
-    "guard_range": 2
+    "guard_range": 2,
+    "battlefield_scale": 1.0
   },
   {
     "id": "reef_serpent",

--- a/assets/units/heroes.json
+++ b/assets/units/heroes.json
@@ -3,6 +3,7 @@
     "id": "default_hero",
     "portrait": "hero/portrait_hero.png",
     "battlefield": "hero/bf_default.png",
-    "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
+    "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64},
+    "battlefield_scale": 1.0
   }
 ]

--- a/assets/units/units.json
+++ b/assets/units/units.json
@@ -1,9 +1,9 @@
 [
-  {"id": "swordsman", "image": "units/swordsman.png", "anchor_px": [32, 64], "shadow_baked": false},
-  {"id": "archer", "image": "units/archer.png", "anchor_px": [32, 64], "shadow_baked": false},
-  {"id": "mage", "image": "units/mage.png", "anchor_px": [32, 64], "shadow_baked": false},
+  {"id": "swordsman", "image": "units/swordsman.png", "anchor_px": [32, 64], "shadow_baked": false, "battlefield_scale": 1.0},
+  {"id": "archer", "image": "units/archer.png", "anchor_px": [32, 64], "shadow_baked": false, "battlefield_scale": 1.0},
+  {"id": "mage", "image": "units/mage.png", "anchor_px": [32, 64], "shadow_baked": false, "battlefield_scale": 1.0},
   {"id": "dragon", "image": "units/dragon.png", "anchor_px": [32, 64], "shadow_baked": false, "battlefield_scale": 1.75},
-  {"id": "priest", "image": "units/priest.png", "anchor_px": [32, 64], "shadow_baked": false},
-  {"id": "cavalry", "image": "units/cavalry.png", "anchor_px": [32, 64], "shadow_baked": false}
+  {"id": "priest", "image": "units/priest.png", "anchor_px": [32, 64], "shadow_baked": false, "battlefield_scale": 1.0},
+  {"id": "cavalry", "image": "units/cavalry.png", "anchor_px": [32, 64], "shadow_baked": false, "battlefield_scale": 1.0}
 ]
 

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -270,7 +270,9 @@ def draw(combat, frame: int = 0) -> None:
                 if 0 <= index < len(frames):
                     img = frames[index]
         if img:
-            target_h = int(rect.height * unit.stats.battlefield_scale)
+            target_h = int(
+                combat.hex_width * unit.stats.battlefield_scale * combat.zoom
+            )
             w, h = img.get_size()
             if h != target_h:
                 scale = target_h / h


### PR DESCRIPTION
## Summary
- scale combat unit rendering using hex width, battlefield_scale, and zoom
- add explicit battlefield_scale values to unit definitions

## Testing
- `pytest tests/test_combat_unit_sort.py -q`
- `pytest -q` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68aba56727008321901875fb60751085