### PR TITLE
Always display spellbook button

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -335,7 +335,10 @@ def handle_button_click(combat, current_unit, pos: Tuple[int, int]) -> bool:
     for action, rect in combat.action_buttons.items():
         if rect.collidepoint(mx, my):
             if action == "spellbook":
-                combat.show_spellbook()
+                if combat.hero_spells:
+                    combat.show_spellbook()
+                    return True
+                return False
             elif combat.selected_action == "spell":
                 if action == "back":
                     combat.selected_action = None

--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -145,13 +145,13 @@ class CombatHUD:
             screen.blit(lab, lab.get_rect(center=auto_button.center))
             y = auto_button.bottom + 6
 
-            if combat.hero_spells:
-                r = pygame.Rect(right.x + 10, y, right.width - 20, BUTTON_H)
-                pygame.draw.rect(screen, (52, 55, 63), r)
-                pygame.draw.rect(screen, LINE, r, 1)
-                txt = self.small.render("Spellbook", True, theme.PALETTE["text"])
-                screen.blit(txt, txt.get_rect(center=r.center))
-                action_buttons["spellbook"] = r
+            r = pygame.Rect(right.x + 10, y, right.width - 20, BUTTON_H)
+            colour = (52, 55, 63) if combat.hero_spells else (40, 42, 48)
+            pygame.draw.rect(screen, colour, r)
+            pygame.draw.rect(screen, LINE, r, 1)
+            txt = self.small.render("Spellbook", True, theme.PALETTE["text"])
+            screen.blit(txt, txt.get_rect(center=r.center))
+            action_buttons["spellbook"] = r
         # ---- Action bar (bottom) ----
         x = bottom.x + 8
 

--- a/tests/test_combat_spellbook_button.py
+++ b/tests/test_combat_spellbook_button.py
@@ -1,0 +1,43 @@
+from core.combat_render import handle_button_click
+
+
+class DummyRect:
+    def __init__(self, x=0, y=0, w=10, h=10):
+        self.x, self.y, self.w, self.h = x, y, w, h
+
+    def collidepoint(self, px, py):
+        return self.x <= px < self.x + self.w and self.y <= py < self.y + self.h
+
+
+class DummyCombat:
+    def __init__(self, hero_spells):
+        self.action_buttons = {"spellbook": DummyRect(0, 0, 10, 10)}
+        self.auto_button = None
+        self.auto_mode = False
+        self.selected_action = None
+        self.hero_spells = hero_spells
+        self.show_called = False
+
+    def show_spellbook(self):
+        self.show_called = True
+
+    def advance_turn(self):
+        pass
+
+
+class DummyUnit:
+    acted = False
+
+
+def test_spellbook_opens_when_spells():
+    combat = DummyCombat({"fire": object()})
+    current_unit = DummyUnit()
+    assert handle_button_click(combat, current_unit, (5, 5))
+    assert combat.show_called
+
+
+def test_spellbook_ignored_when_empty():
+    combat = DummyCombat({})
+    current_unit = DummyUnit()
+    assert not handle_button_click(combat, current_unit, (5, 5))
+    assert not combat.show_called


### PR DESCRIPTION
## Summary
- Always draw spellbook button and gray it out when no spells are available
- Ignore clicks on disabled spellbook button and open spellbook only when spells exist
- Add tests covering combat spellbook button behaviour

## Testing
- `pytest tests/test_combat_spellbook_button.py -q`
- `pytest -q` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68aba7d8d7a88321925b38df210b0a2b