### PR TITLE
Raise default resolution to 1080p and refine window scaling

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -24,8 +24,8 @@ Default screen settings.  When a custom map file is loaded, the actual
 window size will be determined dynamically based on the map dimensions.
 """
 # These values are used as a fallback when no map file is provided.
-WINDOW_WIDTH = 1280
-WINDOW_HEIGHT = 720
+WINDOW_WIDTH = 1920
+WINDOW_HEIGHT = 1080
 
 # Height reserved for the UI/hud at the bottom of the screen (in pixels)
 UI_HEIGHT = 120

--- a/main.py
+++ b/main.py
@@ -25,14 +25,17 @@ def _compute_window_size() -> tuple[int, int]:
     window_width = constants.WINDOW_WIDTH
     window_height = constants.WINDOW_HEIGHT
     max_cols = rows = None
+    map_width = map_height = None
     if os.path.isfile(map_path):
         with open(map_path, "r", encoding="utf-8") as f:
             lines = [line.rstrip("\n") for line in f]
         if lines:
             max_cols = max(len(line) for line in lines)
             rows = len(lines)
-            window_width = max_cols * constants.TILE_SIZE
-            window_height = rows * constants.TILE_SIZE + constants.UI_HEIGHT
+            map_width = max_cols * constants.TILE_SIZE
+            map_height = rows * constants.TILE_SIZE + constants.UI_HEIGHT
+            window_width = max(window_width, map_width)
+            window_height = max(window_height, map_height)
     display_info = pygame.display.Info()
     screen_w, screen_h = display_info.current_w, display_info.current_h
     if window_width > screen_w or window_height > screen_h:
@@ -40,12 +43,16 @@ def _compute_window_size() -> tuple[int, int]:
         constants.TILE_SIZE = max(1, int(constants.TILE_SIZE * scale))
         constants.COMBAT_TILE_SIZE = max(1, int(constants.COMBAT_TILE_SIZE * scale))
         constants.UI_HEIGHT = int(constants.UI_HEIGHT * scale)
-        if max_cols and rows:
-            window_width = min(screen_w, max_cols * constants.TILE_SIZE)
-            window_height = min(screen_h, rows * constants.TILE_SIZE + constants.UI_HEIGHT)
+        width_from_default = not map_width or map_width <= constants.WINDOW_WIDTH
+        height_from_default = not map_height or map_height <= constants.WINDOW_HEIGHT
+        if width_from_default:
+            window_width = int(constants.WINDOW_WIDTH * scale)
         else:
-            window_width = int(window_width * scale)
-            window_height = int(window_height * scale)
+            window_width = min(screen_w, max_cols * constants.TILE_SIZE)
+        if height_from_default:
+            window_height = int(constants.WINDOW_HEIGHT * scale)
+        else:
+            window_height = min(screen_h, rows * constants.TILE_SIZE + constants.UI_HEIGHT)
     else:
         window_width = min(window_width, screen_w)
         window_height = min(window_height, screen_h)


### PR DESCRIPTION
## Summary
- default window set to 1920×1080
- window sizing now retains defaults unless screen is smaller and only scales when necessary

## Testing
- `SDL_VIDEODRIVER=dummy pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68abaca894048321b319e5d234b29b5f