### PR TITLE
Soften combat grid overlay color

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -123,7 +123,7 @@ def draw(combat, frame: int = 0) -> None:
     for x in range(constants.COMBAT_GRID_WIDTH):
         for y in range(constants.COMBAT_GRID_HEIGHT):
             rect = combat.cell_rect(x, y)
-            draw_hex(overlay, rect, constants.WHITE, 40, width=1)
+            draw_hex(overlay, rect, constants.GREY, 25, width=1)
 
     # Highlight reachable squares when preparing a movement action
     if (


### PR DESCRIPTION
## Summary
- Render combat grid using a grey hex outline with reduced transparency for less visual distraction.

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q` *(fails: test suite hangs at test_combat_show_stats_screen.py, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68abaf440cd88321829d7b88f3264219