### PR TITLE
Respect combat top margin in HUD layout

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -59,6 +59,7 @@ def draw(combat, frame: int = 0) -> None:
     grid_h = int(combat.grid_pixel_height * combat.zoom)
     side_margin = 64
     top_margin = 128
+    combat.top_margin = top_margin
     combat.offset_x = HUD_MARGIN + side_margin
     combat.offset_y = screen_h - bottom_min - HUD_MARGIN - grid_h
     shadow_surf = pygame.Surface((tile_w, tile_h), pygame.SRCALPHA)

--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -46,17 +46,18 @@ class CombatHUD:
         self,
         screen: pygame.Surface,
         grid_rect: pygame.Rect,
+        combat,
     ) -> Tuple[pygame.Rect, pygame.Rect]:
         """Return rectangles for the side and bottom panels."""
         right = pygame.Rect(
             grid_rect.x + grid_rect.width + MARGIN,
-            grid_rect.y,
+            grid_rect.y - combat.top_margin,
             PANEL_W,
-            grid_rect.height,
+            grid_rect.height + combat.top_margin,
         )
         bottom = pygame.Rect(
             grid_rect.x,
-            grid_rect.y + grid_rect.height + MARGIN,
+            grid_rect.y - combat.top_margin + grid_rect.height + MARGIN,
             grid_rect.width,
             BUTTON_H + 8,
         )
@@ -71,7 +72,7 @@ class CombatHUD:
         grid_h = int(combat.grid_pixel_height * combat.zoom)
         grid_rect = pygame.Rect(combat.offset_x, combat.offset_y, grid_w, grid_h)
 
-        right, bottom = self._panel_rects(screen, grid_rect)
+        right, bottom = self._panel_rects(screen, grid_rect, combat)
 
         # Backgrounds
         screen.fill(theme.PALETTE.get("panel", (32, 34, 40)), right)


### PR DESCRIPTION
## Summary
- expose calculated top margin on `combat` so other modules can query it
- offset HUD panel positions using `combat.top_margin` to sit flush beside battlefield image

## Testing
- `pytest -q` *(fails: process killed)*
- `pytest tests/test_overlay_rendering.py::test_combat_overlay_uses_additive_blending -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2aa015108321848d03bb21eb2455