### PR TITLE
Support battlefield scaling for units

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -62,8 +62,10 @@ def draw(combat, frame: int = 0) -> None:
     combat.top_margin = top_margin
     combat.offset_x = HUD_MARGIN + side_margin
     combat.offset_y = screen_h - bottom_min - HUD_MARGIN - grid_h
-    shadow_surf = pygame.Surface((tile_w, tile_h), pygame.SRCALPHA)
-    pygame.draw.ellipse(shadow_surf, (0, 0, 0, 100), shadow_surf.get_rect())
+    # Base shadow used for unit rendering; scaled per unit according to its
+    # battlefield size.
+    base_shadow = pygame.Surface((tile_w, tile_h), pygame.SRCALPHA)
+    pygame.draw.ellipse(base_shadow, (0, 0, 0, 100), base_shadow.get_rect())
     overlay = pygame.Surface(combat.screen.get_size(), pygame.SRCALPHA)
 
     # Draw battlefield background
@@ -286,7 +288,14 @@ def draw(combat, frame: int = 0) -> None:
             x = rect.center[0] - w // 2
             y = rect.bottom - h
             if not combat.unit_shadow_baked.get(key or "", False):
-                combat.screen.blit(shadow_surf, rect.topleft)
+                shadow_w = int(tile_w * unit.stats.battlefield_scale)
+                shadow_h = int(tile_h * unit.stats.battlefield_scale)
+                shadow = base_shadow
+                if shadow.get_size() != (shadow_w, shadow_h):
+                    shadow = pygame.transform.scale(base_shadow, (shadow_w, shadow_h))
+                shadow_x = rect.center[0] - shadow_w // 2
+                shadow_y = rect.bottom - shadow_h
+                combat.screen.blit(shadow, (shadow_x, shadow_y))
             combat.screen.blit(img, (x, y))
         else:
             colour = (

--- a/core/entities.py
+++ b/core/entities.py
@@ -695,6 +695,7 @@ SWORDSMAN_STATS = UnitStats(
     role="Sturdy melee combatant for the front line",
     unit_type="non-magic",
     mana=1,
+    battlefield_scale=1.0,
 )
 
 ARCHER_STATS = UnitStats(
@@ -719,6 +720,7 @@ ARCHER_STATS = UnitStats(
     role="Mobile shooter, effective against low-Def. range targets",
     unit_type="non-magic",
     mana=1,
+    battlefield_scale=1.0,
 )
 
 MAGE_STATS = UnitStats(
@@ -743,6 +745,7 @@ MAGE_STATS = UnitStats(
     role="Versatile spellcaster wielding powerful magic",
     unit_type="magic",
     mana=10,
+    battlefield_scale=1.0,
 )
 
 CAVALRY_STATS = UnitStats(
@@ -767,6 +770,7 @@ CAVALRY_STATS = UnitStats(
     role="Fast attacker that excels at charging",
     unit_type="non-magic",
     mana=1,
+    battlefield_scale=1.0,
 )
 
 DRAGON_STATS = UnitStats(
@@ -791,6 +795,7 @@ DRAGON_STATS = UnitStats(
     role="Flying powerhouse with devastating breath",
     unit_type="magic",
     mana=5,
+    battlefield_scale=1.75,
 )
 
 PRIEST_STATS = UnitStats(
@@ -815,6 +820,7 @@ PRIEST_STATS = UnitStats(
     role="Support caster able to heal allies",
     unit_type="magic",
     mana=10,
+    battlefield_scale=1.0,
 )
 
 # Units that can be recruited in towns
@@ -859,6 +865,7 @@ FUMEROLLE_LIZARD_STATS = UnitStats(
     role="Skirmisher rapide, harcèlement feu à courte portée",
     unit_type="beast-elemental",
     mana=1,
+    battlefield_scale=1.0,
 )
 
 # Ombreloup des feuilles — faible, très mobile, embuscade
@@ -888,6 +895,7 @@ SHADOWLEAF_WOLF_STATS = UnitStats(
     role="Assassin de brousse, projection/embuscade",
     unit_type="beast",
     mana=0,
+    battlefield_scale=1.0,
 )
 
 # Corbeau sanglier — plus fort, heurte/renverse
@@ -917,6 +925,7 @@ BOAR_RAVEN_STATS = UnitStats(
     role="Briseur de ligne, charge et repousser",
     unit_type="beast",
     mana=0,
+    battlefield_scale=1.0,
 )
 
 # Hurlombe — faible en PV, esprit volant, cri terrifiant
@@ -946,6 +955,7 @@ HURLOMBE_STATS = UnitStats(
     role="Contrôle mental léger, harcèlement mobile",
     unit_type="undead-spirit",
     mana=2,
+    battlefield_scale=1.0,
 )
 
 # Serpent des récifs — créature marine ne vivant que dans l'océan
@@ -974,6 +984,7 @@ REEF_SERPENT_STATS = UnitStats(
     role="Prédateur marin à l'étreinte constrictive",
     unit_type="beast",
     mana=0,
+    battlefield_scale=1.75,
 )
 
 

--- a/loaders/units_loader.py
+++ b/loaders/units_loader.py
@@ -30,10 +30,14 @@ def load_units(ctx: Context, manifest: str = "units/units.json") -> Dict[str, di
         require_keys(entry, ["id", "stats"])
         unit = dict(entry)
         unit["abilities"] = _parse_abilities(entry.get("abilities", []))
+        # ``battlefield_scale`` may be defined either inside the ``stats``
+        # mapping or at the root of the unit entry.  Ensure the value ends up
+        # in the ``UnitStats`` constructor regardless of where it is specified.
+        bfs = unit.pop("battlefield_scale", None)
         stats = dict(entry["stats"])
-        stats["battlefield_scale"] = entry.get(
-            "battlefield_scale", stats.get("battlefield_scale", 1.0)
-        )
+        if bfs is not None:
+            stats["battlefield_scale"] = bfs
+        stats.setdefault("battlefield_scale", 1.0)
         unit["stats"] = UnitStats(**stats)
         units[unit["id"]] = unit
     return units


### PR DESCRIPTION
## Summary
- ensure unit loaders propagate `battlefield_scale` into `UnitStats`
- explicitly set `battlefield_scale` for all unit definitions
- scale unit sprites and shadows in combat rendering using `battlefield_scale`

## Testing
- `python - <<'PY' ...` (loader round-trip)
- `python - <<'PY' ...` (render scaling)
- `pytest tests/test_combat_unit_sort.py`
- `pytest tests/test_combat_stats.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ca5540c83219132bff8b99f11db