### PR TITLE
Mark slow map generation tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    slow: tests with heavy map generation or AI
+addopts = -m "not slow"

--- a/tests/test_continent_generation.py
+++ b/tests/test_continent_generation.py
@@ -1,8 +1,10 @@
 import random
 
+import pytest
 from mapgen.continents import generate_continent_map
 
 
+@pytest.mark.slow
 def test_generate_continent_map_contains_land_and_ocean():
     random.seed(0)
     width, height = 20, 15
@@ -15,6 +17,7 @@ def test_generate_continent_map_contains_land_and_ocean():
     assert land_chars  # at least one land tile
 
 
+@pytest.mark.slow
 def test_biome_adjacency_respects_rules():
     random.seed(0)
     width, height = 20, 15

--- a/tests/test_enemy_ai.py
+++ b/tests/test_enemy_ai.py
@@ -1,6 +1,7 @@
 import random
 
 import pygame
+import pytest
 
 from mapgen.continents import generate_continent_map
 from core.world import WorldMap
@@ -12,6 +13,7 @@ from state.game_state import GameState
 from core import economy
 
 
+@pytest.mark.slow
 def test_enemy_starting_area_has_town():
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0)

--- a/tests/test_marine_ocean_features.py
+++ b/tests/test_marine_ocean_features.py
@@ -1,10 +1,12 @@
 import random
 
+import pytest
 from mapgen.continents import generate_continent_map
 from core.world import WorldMap
 import constants
 
 
+@pytest.mark.slow
 def test_marine_world_scattered_ocean_features():
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0, map_type="marine")

--- a/tests/test_random_map_generation.py
+++ b/tests/test_random_map_generation.py
@@ -1,5 +1,6 @@
 import random
 
+import pytest
 from core.world import WorldMap
 import constants
 from mapgen.continents import generate_continent_map
@@ -53,6 +54,7 @@ def test_resource_and_building_placement():
     assert buildings == ["buildings/mine/mine_0.png"]
 
 
+@pytest.mark.slow
 def test_river_generation_and_shoreline():
     random.seed(0)
     rows = generate_continent_map(30, 20, seed=0, biome_chars="GM")

--- a/tests/test_shipyard_placement.py
+++ b/tests/test_shipyard_placement.py
@@ -1,5 +1,6 @@
 import random
 
+import pytest
 from mapgen.continents import generate_continent_map
 from core.world import WorldMap
 
@@ -13,6 +14,7 @@ def _shipyard_positions(world: WorldMap):
     ]
 
 
+@pytest.mark.slow
 def test_starting_area_has_shipyard_when_near_water():
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0)
@@ -22,6 +24,7 @@ def test_starting_area_has_shipyard_when_near_water():
     assert any(abs(x - htx) + abs(y - hty) <= 5 for x, y in shipyards)
 
 
+@pytest.mark.slow
 def test_each_continent_has_shipyard():
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0)

--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -1,9 +1,11 @@
 import random
 
+import pytest
 from mapgen.continents import generate_continent_map
 from core.world import WorldMap
 
 
+@pytest.mark.slow
 def test_starting_area_has_buildings_and_town():
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0)
@@ -37,6 +39,7 @@ def test_starting_area_has_buildings_and_town():
     assert abs(sx - tx) + abs(sy - ty) == 1
     assert world.grid[sy][sx].building is None
 
+@pytest.mark.slow
 def test_building_images_loaded():
     import sys
     import types
@@ -119,6 +122,7 @@ def test_building_images_loaded():
         sys.modules.pop("pygame.draw", None)
 
 
+@pytest.mark.slow
 def test_marine_islands_have_required_buildings():
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0, map_type="marine")

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -6,6 +6,7 @@ import core.exploration_ai as exploration_ai
 import constants
 from core.ai.creature_ai import GuardianAI, RoamingAI
 import random
+import pytest
 from mapgen.continents import generate_continent_map
 
 
@@ -138,6 +139,7 @@ def test_roamer_patrols():
     assert moved
 
 
+@pytest.mark.slow
 def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
     random.seed(0)
     rows_marine = generate_continent_map(30, 30, seed=0, map_type="marine")

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -5,6 +5,7 @@ from core.entities import Boat
 from loaders.boat_loader import BoatDef
 import audio
 import random
+import pytest
 
 from mapgen.continents import generate_continent_map
 from core.world import WorldMap
@@ -110,6 +111,7 @@ def _generate_world(map_type: str) -> WorldMap:
     return WorldMap(map_data=rows)
 
 
+@pytest.mark.slow
 def test_plaine_map_is_land_heavy():
     world = _generate_world("plaine")
     total = world.width * world.height
@@ -122,6 +124,7 @@ def test_plaine_map_is_land_heavy():
     assert land / total > 0.6
 
 
+@pytest.mark.slow
 def test_marine_map_features_and_starting_islands():
     world = _generate_world("marine")
     total = world.width * world.height


### PR DESCRIPTION
## Summary
- flag heavy map generation and AI tests with `@pytest.mark.slow`
- add pytest.ini with `slow` marker and default to skip them

## Testing
- `pytest tests/test_enemy_ai.py::test_enemy_starting_area_has_town -q`
- `pytest tests/test_hero_list.py::test_hero_list_scroll_and_select -q`
- `pytest -m slow tests/test_enemy_ai.py::test_enemy_starting_area_has_town -q`
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2e4887848321ae01c6b2b0dcd198