### PR TITLE
feat: show stack counts under units

### DIFF
--- a/core/status_utils.py
+++ b/core/status_utils.py
@@ -1,0 +1,27 @@
+"""Helpers for classifying combat status effects."""
+
+from __future__ import annotations
+
+BUFF_STATUSES = {"focus", "shield_block", "charge"}
+DEBUFF_STATUSES = {"burn", "fear_-1"}
+
+
+def categorize_status(name: str) -> str:
+    """Return the category for a status effect.
+
+    Parameters
+    ----------
+    name:
+        Identifier of the status effect.
+
+    Returns
+    -------
+    str
+        ``"buff"`` when the status is beneficial, ``"debuff"`` when harmful
+        and ``"neutral"`` for unclassified statuses.
+    """
+    if name in BUFF_STATUSES:
+        return "buff"
+    if name in DEBUFF_STATUSES:
+        return "debuff"
+    return "neutral"


### PR DESCRIPTION
## Summary
- display stack counts in a panel below each unit with optional buff/debuff indicators
- add helper to categorize status effects as buffs or debuffs

## Testing
- `flake8 --max-line-length=88 core/status_utils.py core/combat_render.py`
- `pytest tests/test_spells.py::test_buff_spell_increases_attack_bonus`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ecdccf48321b32674220e384d2e