### PR TITLE
Reduce map sizes in slow tests

### DIFF
--- a/tests/test_random_map_generation.py
+++ b/tests/test_random_map_generation.py
@@ -57,7 +57,7 @@ def test_resource_and_building_placement():
 @pytest.mark.slow
 def test_river_generation_and_shoreline():
     random.seed(0)
-    rows = generate_continent_map(30, 20, seed=0, biome_chars="GM")
+    rows = generate_continent_map(10, 8, seed=0, biome_chars="GM")
     grid = [[row[i] for i in range(0, len(row), 2)] for row in rows]
     assert any("R" in row for row in grid)
     height = len(grid)

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -142,7 +142,7 @@ def test_roamer_patrols():
 @pytest.mark.slow
 def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
     random.seed(0)
-    rows_marine = generate_continent_map(30, 30, seed=0, map_type="marine")
+    rows_marine = generate_continent_map(15, 15, seed=0, map_type="marine")
     world_marine = WorldMap(map_data=rows_marine)
     for row in world_marine.grid:
         for tile in row:
@@ -154,7 +154,7 @@ def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
         1 for row in world_marine.grid for t in row if t.biome not in constants.WATER_BIOMES
     )
     land_ratio = land_tiles / total_tiles
-    base = max(1, free_land // (30 if land_ratio < 0.5 else 18))
+    base = max(1, free_land // (15 if land_ratio < 0.5 else 9))
     roamer_count = base // 3
     guardian_count = base - roamer_count
     world_marine._generate_clusters(random, guardian_count, roamer_count)
@@ -173,7 +173,7 @@ def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
         )
 
     random.seed(0)
-    rows_plaine = generate_continent_map(30, 30, seed=0, map_type="plaine")
+    rows_plaine = generate_continent_map(15, 15, seed=0, map_type="plaine")
     world_plaine = WorldMap(map_data=rows_plaine)
     for row in world_plaine.grid:
         for tile in row:
@@ -185,7 +185,7 @@ def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
         1 for row in world_plaine.grid for t in row if t.biome not in constants.WATER_BIOMES
     )
     land_ratio_p = land_tiles_p / total_tiles_p
-    base_p = max(1, free_land_p // (30 if land_ratio_p < 0.5 else 18))
+    base_p = max(1, free_land_p // (15 if land_ratio_p < 0.5 else 9))
     roamer_count_p = base_p // 3
     guardian_count_p = base_p - roamer_count_p
     world_plaine._generate_clusters(random, guardian_count_p, roamer_count_p)


### PR DESCRIPTION
## Summary
- shrink continent generation in world AI test to 15x15 and adjust cluster scaling
- use smaller 10x8 map for river generation test

## Testing
- `pytest tests/test_world_ai.py::test_marine_maps_have_guardian_clusters_and_fewer_roamers tests/test_random_map_generation.py::test_river_generation_and_shoreline -m slow -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac307ccbec8321b7a982aaf1a65401