### PR TITLE
Fix combat panel spacing to respect side margin

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -60,6 +60,7 @@ def draw(combat, frame: int = 0) -> None:
     grid_h = int(combat.grid_pixel_height * combat.zoom)
     side_margin = 64
     top_margin = 128
+    combat.side_margin = side_margin
     combat.top_margin = top_margin
     combat.offset_x = HUD_MARGIN + side_margin
     combat.offset_y = screen_h - bottom_min - HUD_MARGIN - grid_h

--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -49,8 +49,9 @@ class CombatHUD:
         combat,
     ) -> Tuple[pygame.Rect, pygame.Rect]:
         """Return rectangles for the side and bottom panels."""
+        x = grid_rect.x + grid_rect.width + combat.side_margin + MARGIN
         right = pygame.Rect(
-            grid_rect.x + grid_rect.width + MARGIN,
+            x,
             grid_rect.y - combat.top_margin,
             PANEL_W,
             grid_rect.height + combat.top_margin,


### PR DESCRIPTION
## Summary
- track side margin on the combat object when rendering the battlemap
- place right-hand combat panel after side margin for symmetric layout

## Testing
- `SDL_VIDEODRIVER=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3875e3bc832185e80a0619bac874