### PR TITLE
Fix bottom panel position on combat screen

### DIFF
--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -58,7 +58,7 @@ class CombatHUD:
         )
         bottom = pygame.Rect(
             grid_rect.x,
-            grid_rect.y - combat.top_margin + grid_rect.height + MARGIN,
+            grid_rect.y + grid_rect.height + MARGIN,
             grid_rect.width,
             BUTTON_H + 8,
         )


### PR DESCRIPTION
## Summary
- place bottom panel below combat image by basing its y-coordinate solely on the grid

## Testing
- `pytest tests/test_combat_spellbook_button.py -vv`
- `pytest` *(fails: hangs at tests/test_combat_show_stats_screen.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3b5e6f8c83219cbe2eaffe0f2031