### PR TITLE
test: centralize combat setup via fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,8 @@
 import importlib.util
 import os
 import sys
+import math
 import pytest
-
-# Ensure the project root is on the path so modules can be imported in tests
-ROOT = os.path.dirname(os.path.dirname(__file__))
-if ROOT not in sys.path:
-    sys.path.insert(0, ROOT)
 
 # Provide a lightweight pygame stub so tests run without the real library
 _STUB = os.path.join(os.path.dirname(__file__), "pygame_stub", "__init__.py")
@@ -15,6 +11,14 @@ pygame = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(pygame)
 # Override any existing pygame module so tests always use the stub
 sys.modules["pygame"] = pygame
+
+# Ensure the project root is on the path so modules can be imported in tests
+ROOT = os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+import constants
+from core.combat import Combat, water_battlefield_template
 
 
 @pytest.fixture(autouse=True)
@@ -29,4 +33,44 @@ def _restore_pygame_module():
     sys.modules["pygame"] = pygame
     yield
     sys.modules["pygame"] = pygame
+
+
+@pytest.fixture
+def simple_combat():
+    """Return a factory that builds a minimal :class:`Combat` instance.
+
+    The factory accepts optional ``hero_units`` and ``enemy_units`` lists and
+    any additional keyword arguments forwarded to :class:`Combat`.  A dummy
+    ``pygame.Surface`` and empty assets are used by default and a basic water
+    battlefield grid is supplied so no ``WorldMap`` interaction is required.
+    """
+
+    def _factory(hero_units=None, enemy_units=None, *, screen=None, assets=None,
+                 combat_map=None, **kwargs):
+        import pygame
+
+        pygame.init()
+        if screen is None:
+            hex_w = constants.COMBAT_HEX_SIZE
+            hex_h = int(constants.COMBAT_HEX_SIZE * math.sqrt(3) / 2)
+            screen = pygame.Surface(
+                (
+                    int(hex_w + (constants.COMBAT_GRID_WIDTH - 1) * hex_w * 3 / 4),
+                    int(hex_h * constants.COMBAT_GRID_HEIGHT + hex_h / 2),
+                )
+            )
+        if assets is None:
+            assets = {}
+        if combat_map is None:
+            combat_map = water_battlefield_template()
+        return Combat(
+            screen,
+            assets,
+            hero_units or [],
+            enemy_units or [],
+            combat_map=combat_map,
+            **kwargs,
+        )
+
+    return _factory
 

--- a/tests/test_combat_ai.py
+++ b/tests/test_combat_ai.py
@@ -1,34 +1,16 @@
 import os
-import math
-import pygame
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
 from core.entities import Unit, SWORDSMAN_STATS, DRAGON_STATS, MAGE_STATS
-from core.combat import Combat
 from core.combat_ai import ai_take_turn, allied_ai_turn, select_spell, _a_star
 import constants
 
-pygame.init()
 
-
-def _create_combat(hero_units, enemy_units):
-    hex_w = constants.COMBAT_HEX_SIZE
-    hex_h = int(constants.COMBAT_HEX_SIZE * math.sqrt(3) / 2)
-    screen = pygame.Surface(
-        (
-            int(hex_w + (constants.COMBAT_GRID_WIDTH - 1) * hex_w * 3 / 4),
-            int(hex_h * constants.COMBAT_GRID_HEIGHT + hex_h / 2),
-        )
-    )
-    assets = {}
-    return Combat(screen, assets, hero_units, enemy_units)
-
-
-def test_ai_attacks_nearest_enemy():
+def test_ai_attacks_nearest_enemy(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy])
+    combat = simple_combat([hero], [enemy])
     hero_unit = combat.hero_units[0]
     enemy_unit = combat.enemy_units[0]
     combat.move_unit(hero_unit, 0, 0)
@@ -37,11 +19,11 @@ def test_ai_attacks_nearest_enemy():
     assert enemy_unit.current_hp < enemy_unit.stats.max_hp
 
 
-def test_target_priority_by_threat():
+def test_target_priority_by_threat(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     enemy1 = Unit(SWORDSMAN_STATS, 1, 'enemy')
     enemy2 = Unit(DRAGON_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy1, enemy2])
+    combat = simple_combat([hero], [enemy1, enemy2])
     hero_unit = combat.hero_units[0]
     e1 = combat.enemy_units[0]
     e2 = combat.enemy_units[1]
@@ -53,10 +35,10 @@ def test_target_priority_by_threat():
     assert e1.current_hp == e1.stats.max_hp
 
 
-def test_ai_mage_casts_fireball_when_out_of_range():
+def test_ai_mage_casts_fireball_when_out_of_range(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     mage = Unit(MAGE_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [mage])
+    combat = simple_combat([hero], [mage])
     hero_unit = combat.hero_units[0]
     mage_unit = combat.enemy_units[0]
     combat.move_unit(hero_unit, 5, 0)
@@ -65,11 +47,11 @@ def test_ai_mage_casts_fireball_when_out_of_range():
     assert hero_unit.current_hp < hero_unit.stats.max_hp
 
 
-def test_select_spell_prefers_fireball_for_cluster():
+def test_select_spell_prefers_fireball_for_cluster(simple_combat):
     mage = Unit(MAGE_STATS, 1, 'hero')
     enemy1 = Unit(SWORDSMAN_STATS, 1, 'enemy')
     enemy2 = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([mage], [enemy1, enemy2])
+    combat = simple_combat([mage], [enemy1, enemy2])
     mage_unit = combat.hero_units[0]
     e1 = combat.enemy_units[0]
     e2 = combat.enemy_units[1]
@@ -83,10 +65,10 @@ def test_select_spell_prefers_fireball_for_cluster():
     assert e2.current_hp < e2.stats.max_hp
 
 
-def test_hex_neighbors_within_bounds():
+def test_hex_neighbors_within_bounds(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy])
+    combat = simple_combat([hero], [enemy])
     center_neighbors = combat.hex_neighbors(5, 5)
     assert len(center_neighbors) == 6
     edge_neighbors = combat.hex_neighbors(0, 0)
@@ -96,10 +78,10 @@ def test_hex_neighbors_within_bounds():
         assert 0 <= ny < constants.COMBAT_GRID_HEIGHT
 
 
-def test_hex_distance_and_diagonal_attack():
+def test_hex_distance_and_diagonal_attack(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy])
+    combat = simple_combat([hero], [enemy])
     hero_unit = combat.hero_units[0]
     enemy_unit = combat.enemy_units[0]
     combat.move_unit(hero_unit, 2, 2)
@@ -109,10 +91,10 @@ def test_hex_distance_and_diagonal_attack():
     assert enemy_unit.current_hp < enemy_unit.stats.max_hp
 
 
-def test_ai_hex_pathfinding():
+def test_ai_hex_pathfinding(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy])
+    combat = simple_combat([hero], [enemy])
     path = _a_star((0, 0), (3, 3), set())
     assert path[-1] == (3, 3)
     prev = (0, 0)

--- a/tests/test_combat_show_stats_screen.py
+++ b/tests/test_combat_show_stats_screen.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 import pygame
 import theme
 
-from core.combat import Combat
 from core.entities import Unit, SWORDSMAN_STATS
 from ui import combat_summary
 
@@ -33,11 +32,11 @@ class DummyScreen:
         return (self._w, self._h)
 
 
-def _run_show_stats(monkeypatch):
+def _run_show_stats(monkeypatch, simple_combat):
     screen = DummyScreen((800, 600))
     hero = Unit(SWORDSMAN_STATS, 1, "hero")
     enemy = Unit(SWORDSMAN_STATS, 1, "enemy")
-    combat = Combat(screen, {}, [hero], [enemy])
+    combat = simple_combat([hero], [enemy], screen=screen)
 
     image_calls: list[Unit] = []
 
@@ -131,31 +130,31 @@ def _run_show_stats(monkeypatch):
     return screen, rendered, image_calls
 
 
-def test_show_stats_no_background_fill(monkeypatch):
-    screen, _, _ = _run_show_stats(monkeypatch)
+def test_show_stats_no_background_fill(monkeypatch, simple_combat):
+    screen, _, _ = _run_show_stats(monkeypatch, simple_combat)
     assert screen.fills == []
 
 
-def test_show_stats_renders_heading(monkeypatch):
-    _, rendered, _ = _run_show_stats(monkeypatch)
+def test_show_stats_renders_heading(monkeypatch, simple_combat):
+    _, rendered, _ = _run_show_stats(monkeypatch, simple_combat)
     assert any(text in ("Victoire", "Défaite") for text in rendered)
 
 
-def test_show_stats_columns(monkeypatch):
-    screen, _, _ = _run_show_stats(monkeypatch)
+def test_show_stats_columns(monkeypatch, simple_combat):
+    screen, _, _ = _run_show_stats(monkeypatch, simple_combat)
     width = screen.get_width()
     xs = [dest[0] for dest in screen.blit_calls if isinstance(dest, tuple)]
     assert any(x < width // 2 for x in xs)
     assert any(x > width // 2 for x in xs)
 
 
-def test_reward_section_before_table(monkeypatch):
-    _, rendered, _ = _run_show_stats(monkeypatch)
+def test_reward_section_before_table(monkeypatch, simple_combat):
+    _, rendered, _ = _run_show_stats(monkeypatch, simple_combat)
     assert rendered.index("Expérience gagnée : 0") < rendered.index("Unité")
 
 
-def test_header_uses_unit_images(monkeypatch):
-    _, _, calls = _run_show_stats(monkeypatch)
+def test_header_uses_unit_images(monkeypatch, simple_combat):
+    _, _, calls = _run_show_stats(monkeypatch, simple_combat)
     # One hero and one enemy unit -> header and table rows for each side
     assert len(calls) == 4
 

--- a/tests/test_combat_unit_sort.py
+++ b/tests/test_combat_unit_sort.py
@@ -1,5 +1,5 @@
 import pygame
-from core.combat import Combat
+import pygame
 from core.entities import UnitStats, Unit
 from core import combat_render
 from tests.test_overlay_rendering import _ensure_stub_functions
@@ -24,7 +24,7 @@ def _make_unit(name: str, side: str = "hero") -> Unit:
     return Unit(stats, 1, side)
 
 
-def test_units_drawn_in_coordinate_order(monkeypatch):
+def test_units_drawn_in_coordinate_order(monkeypatch, simple_combat):
     _ensure_stub_functions(monkeypatch)
     screen = pygame.Surface((800, 600))
 
@@ -35,7 +35,7 @@ def test_units_drawn_in_coordinate_order(monkeypatch):
 
     assets = {"u1": pygame.Surface((10, 10)), "u2": pygame.Surface((10, 10)), "u3": pygame.Surface((10, 10))}
 
-    combat = Combat(screen, assets, [u1, u2, u3], [])
+    combat = simple_combat([u1, u2, u3], [], screen=screen, assets=assets)
 
     # Place units in an unsorted order
     combat.units[0].x, combat.units[0].y = 1, 0  # u1

--- a/tests/test_luck_log.py
+++ b/tests/test_luck_log.py
@@ -4,31 +4,14 @@ from dataclasses import replace
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
-import pygame
-
 from core.entities import Unit, SWORDSMAN_STATS
-from core.combat import Combat
-import constants
-
-pygame.init()
 
 
-def _create_combat(hero_units, enemy_units):
-    screen = pygame.Surface(
-        (
-            constants.COMBAT_GRID_WIDTH * constants.COMBAT_TILE_SIZE,
-            constants.COMBAT_GRID_HEIGHT * constants.COMBAT_TILE_SIZE,
-        )
-    )
-    assets = {}
-    return Combat(screen, assets, hero_units, enemy_units)
-
-
-def test_positive_luck_logs(monkeypatch):
+def test_positive_luck_logs(monkeypatch, simple_combat):
     hero_stats = replace(SWORDSMAN_STATS, luck=1)
     hero = Unit(hero_stats, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy])
+    combat = simple_combat([hero], [enemy])
     attacker = combat.hero_units[0]
     defender = combat.enemy_units[0]
     monkeypatch.setattr(random, 'random', lambda: 0.0)
@@ -36,11 +19,11 @@ def test_positive_luck_logs(monkeypatch):
     assert combat.log[-1] == 'Lucky strike by Swordsman!'
 
 
-def test_negative_luck_logs(monkeypatch):
+def test_negative_luck_logs(monkeypatch, simple_combat):
     hero_stats = replace(SWORDSMAN_STATS, luck=-1)
     hero = Unit(hero_stats, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy])
+    combat = simple_combat([hero], [enemy])
     attacker = combat.hero_units[0]
     defender = combat.enemy_units[0]
     monkeypatch.setattr(random, 'random', lambda: 0.0)

--- a/tests/test_min_range_and_retaliation.py
+++ b/tests/test_min_range_and_retaliation.py
@@ -4,29 +4,13 @@ os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 
 from dataclasses import replace
 
-import constants
 from core.entities import Unit, ARCHER_STATS, SWORDSMAN_STATS
-from core.combat import Combat
 
 
-def _create_combat(hero_units, enemy_units):
-    import pygame
-
-    pygame.init()
-    screen = pygame.Surface(
-        (
-            constants.COMBAT_GRID_WIDTH * constants.COMBAT_TILE_SIZE,
-            constants.COMBAT_GRID_HEIGHT * constants.COMBAT_TILE_SIZE,
-        )
-    )
-    assets = {}
-    return Combat(screen, assets, hero_units, enemy_units)
-
-
-def test_archer_min_range_excludes_adjacent():
+def test_archer_min_range_excludes_adjacent(simple_combat):
     archer = Unit(ARCHER_STATS, 1, "hero")
     enemy = Unit(SWORDSMAN_STATS, 1, "enemy")
-    combat = _create_combat([archer], [enemy])
+    combat = simple_combat([archer], [enemy])
     a = combat.hero_units[0]
     e = combat.enemy_units[0]
     combat.move_unit(a, 0, 0)
@@ -38,7 +22,7 @@ def test_archer_min_range_excludes_adjacent():
     assert (2, 0) in squares
 
 
-def test_retaliation_limited_to_one():
+def test_retaliation_limited_to_one(simple_combat):
     stats = replace(
         SWORDSMAN_STATS,
         attack_min=1,
@@ -53,7 +37,7 @@ def test_retaliation_limited_to_one():
     )
     attacker = Unit(stats, 1, "hero")
     defender = Unit(stats, 1, "enemy")
-    combat = _create_combat([attacker], [defender])
+    combat = simple_combat([attacker], [defender])
     a = combat.hero_units[0]
     d = combat.enemy_units[0]
     combat.move_unit(a, 0, 0)

--- a/tests/test_morale.py
+++ b/tests/test_morale.py
@@ -4,31 +4,14 @@ from dataclasses import replace
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
-import pygame
-
 from core.entities import Unit, SWORDSMAN_STATS
-from core.combat import Combat
-import constants
-
-pygame.init()
 
 
-def _create_combat(hero_units, enemy_units):
-    screen = pygame.Surface(
-        (
-            constants.COMBAT_GRID_WIDTH * constants.COMBAT_TILE_SIZE,
-            constants.COMBAT_GRID_HEIGHT * constants.COMBAT_TILE_SIZE,
-        )
-    )
-    assets = {}
-    return Combat(screen, assets, hero_units, enemy_units)
-
-
-def test_positive_morale_grants_extra_turn(monkeypatch):
+def test_positive_morale_grants_extra_turn(monkeypatch, simple_combat):
     hero_stats = replace(SWORDSMAN_STATS, morale=1)
     hero = Unit(hero_stats, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy])
+    combat = simple_combat([hero], [enemy])
     hero_unit = combat.hero_units[0]
     enemy_unit = combat.enemy_units[0]
     combat.turn_order = [hero_unit, enemy_unit]
@@ -44,11 +27,11 @@ def test_positive_morale_grants_extra_turn(monkeypatch):
     assert combat.turn_order[combat.current_index] is hero_unit
 
 
-def test_negative_morale_skips_turn(monkeypatch):
+def test_negative_morale_skips_turn(monkeypatch, simple_combat):
     hero_stats = replace(SWORDSMAN_STATS, morale=-1)
     hero = Unit(hero_stats, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = _create_combat([hero], [enemy])
+    combat = simple_combat([hero], [enemy])
     hero_unit = combat.hero_units[0]
     enemy_unit = combat.enemy_units[0]
     combat.turn_order = [hero_unit, enemy_unit]

--- a/tests/test_overlay_rendering.py
+++ b/tests/test_overlay_rendering.py
@@ -37,6 +37,30 @@ def _ensure_stub_functions(monkeypatch):
             property(lambda self: (self.width, self.height)),
             raising=False,
         )
+    if not hasattr(pygame.Rect, "left"):
+        def _get_left(self):
+            return self.x
+        def _set_left(self, value):
+            self.x = value
+        monkeypatch.setattr(pygame.Rect, "left", property(_get_left, _set_left), raising=False)
+    if not hasattr(pygame.Rect, "top"):
+        def _get_top(self):
+            return self.y
+        def _set_top(self, value):
+            self.y = value
+        monkeypatch.setattr(pygame.Rect, "top", property(_get_top, _set_top), raising=False)
+    if not hasattr(pygame.Rect, "centerx"):
+        def _get_centerx(self):
+            return self.center[0]
+        def _set_centerx(self, value):
+            self.x = value - self.width // 2
+        monkeypatch.setattr(pygame.Rect, "centerx", property(_get_centerx, _set_centerx), raising=False)
+    if not hasattr(pygame.Rect, "centery"):
+        def _get_centery(self):
+            return self.center[1]
+        def _set_centery(self, value):
+            self.y = value - self.height // 2
+        monkeypatch.setattr(pygame.Rect, "centery", property(_get_centery, _set_centery), raising=False)
 
 
 def test_world_overlay_uses_additive_blending(monkeypatch):

--- a/tests/test_units_abilities.py
+++ b/tests/test_units_abilities.py
@@ -3,8 +3,6 @@ import random
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
-import pygame
-
 from dataclasses import replace
 from core.entities import (
     Unit,
@@ -14,17 +12,8 @@ from core.entities import (
     PRIEST_STATS,
     apply_defence,
 )
-from core.combat import Combat
 from core import combat_ai
 import constants
-
-pygame.init()
-
-
-def _create_combat(hero_units, enemy_units):
-    screen = pygame.Surface((constants.COMBAT_GRID_WIDTH * constants.COMBAT_TILE_SIZE, constants.COMBAT_GRID_HEIGHT * constants.COMBAT_TILE_SIZE))
-    assets = {}
-    return Combat(screen, assets, hero_units, enemy_units)
 
 
 def test_unit_stats_have_abilities():
@@ -34,11 +23,11 @@ def test_unit_stats_have_abilities():
     assert 'passive_heal' in PRIEST_STATS.abilities
 
 
-def test_multi_shot_double_damage():
+def test_multi_shot_double_damage(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     dragon_stats = replace(DRAGON_STATS, abilities=[a for a in DRAGON_STATS.abilities if a != 'dragon_breath'])
     dragon = Unit(dragon_stats, 1, 'enemy')
-    combat = _create_combat([hero], [dragon])
+    combat = simple_combat([hero], [dragon])
     hero = combat.hero_units[0]
     dragon = combat.enemy_units[0]
     combat.move_unit(hero, 2, 2)
@@ -52,18 +41,18 @@ def test_multi_shot_double_damage():
     assert hero.current_hp == hero.stats.max_hp - expected
 
 
-def test_flying_reachable_all_board():
+def test_flying_reachable_all_board(simple_combat):
     dragon = Unit(DRAGON_STATS, 1, 'hero')
-    combat = _create_combat([dragon], [])
+    combat = simple_combat([dragon], [])
     reach = combat.reachable_squares(dragon)
     assert len(reach) == constants.COMBAT_GRID_WIDTH * constants.COMBAT_GRID_HEIGHT - 1
 
 
-def test_passive_heal_heals_ally():
+def test_passive_heal_heals_ally(simple_combat):
     priest = Unit(PRIEST_STATS, 1, 'hero')
     ally = Unit(SWORDSMAN_STATS, 1, 'hero')
     ally.current_hp = 10
-    combat = _create_combat([priest, ally], [])
+    combat = simple_combat([priest, ally], [])
     priest_unit = combat.hero_units[0]
     ally_unit = combat.hero_units[1]
     combat.apply_passive_abilities(priest_unit)


### PR DESCRIPTION
## Summary
- add `simple_combat` fixture for lightweight `Combat` instances
- refactor combat tests to use the shared fixture
- enhance test helpers for pygame Rect compatibility

## Testing
- `pytest tests/test_combat_ai.py -q`
- `pytest tests/test_combat_show_stats_screen.py -q`
- `pytest tests/test_combat_unit_sort.py -q`
- `pytest tests/test_luck_log.py -q`
- `pytest tests/test_min_range_and_retaliation.py -q`
- `pytest tests/test_morale.py -q`
- `pytest tests/test_units_abilities.py -q`
- `pytest tests/test_spells.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3d3f8064832182855471ef7e897f