### PR TITLE
refactor: reuse world map fixtures in tests

### DIFF
--- a/tests/test_enemy_ai.py
+++ b/tests/test_enemy_ai.py
@@ -13,11 +13,16 @@ from state.game_state import GameState
 from core import economy
 
 
-@pytest.mark.slow
-def test_enemy_starting_area_has_town():
+@pytest.fixture(scope="module")
+def plaine_world() -> WorldMap:
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0)
-    world = WorldMap(map_data=rows)
+    return WorldMap(map_data=rows)
+
+
+@pytest.mark.slow
+def test_enemy_starting_area_has_town(plaine_world):
+    world = plaine_world
     assert world.enemy_starting_area is not None
     x0, y0, size = world.enemy_starting_area
     def base(name: str) -> str:

--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -5,11 +5,23 @@ from mapgen.continents import generate_continent_map
 from core.world import WorldMap
 
 
-@pytest.mark.slow
-def test_starting_area_has_buildings_and_town():
+@pytest.fixture(scope="module")
+def plaine_world() -> WorldMap:
     random.seed(0)
     rows = generate_continent_map(30, 30, seed=0)
-    world = WorldMap(map_data=rows)
+    return WorldMap(map_data=rows)
+
+
+@pytest.fixture(scope="module")
+def marine_world() -> WorldMap:
+    random.seed(0)
+    rows = generate_continent_map(30, 30, seed=0, map_type="marine")
+    return WorldMap(map_data=rows)
+
+
+@pytest.mark.slow
+def test_starting_area_has_buildings_and_town(plaine_world):
+    world = plaine_world
     assert world.starting_area is not None
     x0, y0, size = world.starting_area
     assert 5 <= size <= 10
@@ -40,7 +52,7 @@ def test_starting_area_has_buildings_and_town():
     assert world.grid[sy][sx].building is None
 
 @pytest.mark.slow
-def test_building_images_loaded():
+def test_building_images_loaded(plaine_world):
     import sys
     import types
 
@@ -93,12 +105,9 @@ def test_building_images_loaded():
     sys.modules["pygame.draw"] = pygame_stub.draw
 
     try:
-        from mapgen.continents import generate_continent_map
         from loaders.asset_manager import AssetManager
         from loaders.building_loader import BUILDINGS
-        random.seed(0)
-        rows = generate_continent_map(30, 30, seed=0)
-        world = WorldMap(map_data=rows)
+        world = plaine_world
         assets = AssetManager(repo_root=".")
         for asset in BUILDINGS.values():
             files = asset.file_list()
@@ -123,10 +132,8 @@ def test_building_images_loaded():
 
 
 @pytest.mark.slow
-def test_marine_islands_have_required_buildings():
-    random.seed(0)
-    rows = generate_continent_map(30, 30, seed=0, map_type="marine")
-    world = WorldMap(map_data=rows)
+def test_marine_islands_have_required_buildings(marine_world):
+    world = marine_world
     assert world.starting_area is not None
     assert world.enemy_starting_area is not None
     continents = world._find_continents()

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -12,6 +12,20 @@ from core.world import WorldMap
 import constants
 
 
+@pytest.fixture(scope="module")
+def plaine_world() -> WorldMap:
+    random.seed(0)
+    rows = generate_continent_map(30, 30, seed=0, map_type="plaine")
+    return WorldMap(map_data=rows)
+
+
+@pytest.fixture(scope="module")
+def marine_world() -> WorldMap:
+    random.seed(0)
+    rows = generate_continent_map(30, 30, seed=0, map_type="marine")
+    return WorldMap(map_data=rows)
+
+
 def setup_water_game(monkeypatch):
     game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
     game.compute_path = GameClass.compute_path.__get__(game, GameClass)
@@ -105,15 +119,9 @@ def test_disembark_requires_adjacent_land(monkeypatch):
     assert game.world.grid[0][0].boat is None
 
 
-def _generate_world(map_type: str) -> WorldMap:
-    random.seed(0)
-    rows = generate_continent_map(30, 30, seed=0, map_type=map_type)
-    return WorldMap(map_data=rows)
-
-
 @pytest.mark.slow
-def test_plaine_map_is_land_heavy():
-    world = _generate_world("plaine")
+def test_plaine_map_is_land_heavy(plaine_world):
+    world = plaine_world
     total = world.width * world.height
     land = sum(
         1
@@ -125,8 +133,8 @@ def test_plaine_map_is_land_heavy():
 
 
 @pytest.mark.slow
-def test_marine_map_features_and_starting_islands():
-    world = _generate_world("marine")
+def test_marine_map_features_and_starting_islands(marine_world):
+    world = marine_world
     total = world.width * world.height
     water = sum(
         1


### PR DESCRIPTION
## Summary
- reuse seeded `WorldMap` fixtures across world generation heavy tests
- avoid repeated map generation in starting area, world navigation, and enemy AI tests

## Testing
- `pytest tests/test_starting_area.py tests/test_world_navigation.py tests/test_enemy_ai.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac40aa5c188321b5b2c10b5e6741d5