### PR TITLE
Add test markers for worldgen and combat scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ generation, combat rules and save/load behaviour.  Run the tests with:
 pytest
 ```
 
+Slow tests that perform extensive world generation or long AI loops are marked with `slow` and either `worldgen` or `combat`. You can run a subset with:
+
+```bash
+pytest -m "not slow and not worldgen"
+```
+
+
 ## Configuration
 
 Runtime options are read from environment variables and the `settings.json`

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 markers =
     slow: tests with heavy map generation or AI
+    worldgen: tests involving large-scale map generation
+    combat: tests with long AI loops
 addopts = -m "not slow"

--- a/tests/test_enemy_ai.py
+++ b/tests/test_enemy_ai.py
@@ -21,6 +21,7 @@ def plaine_world() -> WorldMap:
 
 
 @pytest.mark.slow
+@pytest.mark.worldgen
 def test_enemy_starting_area_has_town(plaine_world):
     world = plaine_world
     assert world.enemy_starting_area is not None

--- a/tests/test_random_map_generation.py
+++ b/tests/test_random_map_generation.py
@@ -55,6 +55,7 @@ def test_resource_and_building_placement():
 
 
 @pytest.mark.slow
+@pytest.mark.worldgen
 def test_river_generation_and_shoreline():
     random.seed(0)
     rows = generate_continent_map(10, 8, seed=0, biome_chars="GM")

--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -20,6 +20,7 @@ def marine_world() -> WorldMap:
 
 
 @pytest.mark.slow
+@pytest.mark.worldgen
 def test_starting_area_has_buildings_and_town(plaine_world):
     world = plaine_world
     assert world.starting_area is not None
@@ -52,6 +53,7 @@ def test_starting_area_has_buildings_and_town(plaine_world):
     assert world.grid[sy][sx].building is None
 
 @pytest.mark.slow
+@pytest.mark.worldgen
 def test_building_images_loaded(plaine_world):
     import sys
     import types
@@ -132,6 +134,7 @@ def test_building_images_loaded(plaine_world):
 
 
 @pytest.mark.slow
+@pytest.mark.worldgen
 def test_marine_islands_have_required_buildings(marine_world):
     world = marine_world
     assert world.starting_area is not None

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -140,6 +140,8 @@ def test_roamer_patrols():
 
 
 @pytest.mark.slow
+@pytest.mark.worldgen
+@pytest.mark.combat
 def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
     random.seed(0)
     rows_marine = generate_continent_map(15, 15, seed=0, map_type="marine")

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -120,6 +120,7 @@ def test_disembark_requires_adjacent_land(monkeypatch):
 
 
 @pytest.mark.slow
+@pytest.mark.worldgen
 def test_plaine_map_is_land_heavy(plaine_world):
     world = plaine_world
     total = world.width * world.height
@@ -133,6 +134,7 @@ def test_plaine_map_is_land_heavy(plaine_world):
 
 
 @pytest.mark.slow
+@pytest.mark.worldgen
 def test_marine_map_features_and_starting_islands(marine_world):
     world = marine_world
     total = world.width * world.height


### PR DESCRIPTION
## Summary
- declare `worldgen` and `combat` pytest markers
- tag heavy map generation and AI loop tests with new markers alongside `slow`
- document running marker-based test subsets in README

## Testing
- `python -m pytest -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4610cd3c8321bf261c46e051c70c