### PR TITLE
Use darker tone for combat grid overlay

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -129,8 +129,13 @@ def draw(combat, frame: int = 0) -> None:
     # Hex grid overlay
     for x in range(constants.COMBAT_GRID_WIDTH):
         for y in range(constants.COMBAT_GRID_HEIGHT):
+            if (
+                x in (0, constants.COMBAT_GRID_WIDTH - 1)
+                or y in (0, constants.COMBAT_GRID_HEIGHT - 1)
+            ):
+                continue
             rect = combat.cell_rect(x, y)
-            draw_hex(overlay, rect, constants.GREY, 25, width=1)
+            draw_hex(overlay, rect, theme.PALETTE["panel"], 15, width=1)
 
     # Highlight reachable squares when preparing a movement action
     if (


### PR DESCRIPTION
## Summary
- Soften combat hex grid overlay with panel palette color
- Skip outer grid border and reduce overlay opacity for subtle interior edges

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac4b719cbc832197c56a659ff58763