### PR TITLE
test: isolate AI difficulty

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,15 @@ def _reset_event_bus():
     EVENT_BUS.reset()
 
 
+@pytest.fixture(autouse=True)
+def _restore_ai_difficulty():
+    """Reset :data:`constants.AI_DIFFICULTY` after each test."""
+
+    saved = constants.AI_DIFFICULTY
+    yield
+    constants.AI_DIFFICULTY = saved
+
+
 @pytest.fixture
 def simple_combat():
     """Return a factory that builds a minimal :class:`Combat` instance.

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -79,8 +79,8 @@ def test_enemy_captures_town_from_adjacent():
     assert enemy.ap == start_ap - 1
 
 
-def test_enemy_targets_hero_after_resource_collected():
-    constants.AI_DIFFICULTY = "Novice"
+def test_enemy_targets_hero_after_resource_collected(monkeypatch):
+    monkeypatch.setattr(constants, "AI_DIFFICULTY", "Novice")
     game, enemy = _create_game_with_resource()
     Game.move_enemy_heroes(game)
     assert (enemy.x, enemy.y) == (0, 1)
@@ -88,8 +88,8 @@ def test_enemy_targets_hero_after_resource_collected():
     assert step in [(0, 0), (1, 1)]
 
 
-def test_enemy_targets_hero_after_building_capture():
-    constants.AI_DIFFICULTY = "Intermédiaire"
+def test_enemy_targets_hero_after_building_capture(monkeypatch):
+    monkeypatch.setattr(constants, "AI_DIFFICULTY", "Intermédiaire")
     world = _make_world(3, 1)
     hero = Hero(2, 0, [Unit(SWORDSMAN_STATS, 1, 'hero')])
     enemy = EnemyHero(0, 0, [Unit(SWORDSMAN_STATS, 1, 'enemy')])


### PR DESCRIPTION
## Summary
- add autouse fixture resetting `constants.AI_DIFFICULTY`
- patch AI difficulty in world AI tests using monkeypatch

## Testing
- `pytest tests/test_world_ai.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac562da0248321a23019dd3a1dabe5