### PR TITLE
Use monkeypatch.setitem to restore KEYMAP in tests

### DIFF
--- a/tests/test_world_renderer_keymap.py
+++ b/tests/test_world_renderer_keymap.py
@@ -17,7 +17,7 @@ class DummyWorld:
 def test_handle_event_uses_settings_keymap(monkeypatch):
     monkeypatch.setattr(pygame, "KEYDOWN", 1, raising=False)
     monkeypatch.setattr(pygame, "K_f", 70, raising=False)
-    settings.KEYMAP["pan_left"] = ["K_f"]
+    monkeypatch.setitem(settings.KEYMAP, "pan_left", ["K_f"])
     renderer = WorldRenderer({})
     renderer.surface = pygame.Surface((100, 100))
     renderer.world = DummyWorld()


### PR DESCRIPTION
## Summary
- use monkeypatch.setitem for `settings.KEYMAP['pan_left']` in world renderer test to restore original keymap

## Testing
- `pytest tests/test_world_renderer_keymap.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac56f0b7ec8321802d95da530b2ff6