### PR TITLE
Use deterministic RNG fixture in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import importlib.util
 import os
 import sys
 import math
+import random
 import pytest
 
 # Provide a lightweight pygame stub so tests run without the real library
@@ -53,6 +54,13 @@ def _restore_ai_difficulty():
     saved = constants.AI_DIFFICULTY
     yield
     constants.AI_DIFFICULTY = saved
+
+
+@pytest.fixture
+def rng():
+    """Return a deterministic random number generator."""
+
+    return random.Random(0)
 
 
 @pytest.fixture

--- a/tests/test_combat_stats.py
+++ b/tests/test_combat_stats.py
@@ -43,25 +43,21 @@ def test_apply_defence_has_minimum_one():
     assert apply_defence(5, unit, "magic") == 1
 
 
-def test_damage_output_positive_luck():
+def test_damage_output_positive_luck(rng):
     unit = _create_unit(luck=1)
-    rng = random.Random(0)
     assert unit.damage_output(rng) == 10
 
 
-def test_damage_output_negative_luck():
+def test_damage_output_negative_luck(rng):
     unit = _create_unit(luck=-1)
-    rng = random.Random(0)
     assert unit.damage_output(rng) == 2
 
 
-def test_damage_output_positive_morale():
+def test_damage_output_positive_morale(rng):
     unit = _create_unit(morale=1)
-    rng = random.Random(0)
     assert unit.damage_output(rng) == 10
 
 
-def test_damage_output_negative_morale():
+def test_damage_output_negative_morale(rng):
     unit = _create_unit(morale=-1)
-    rng = random.Random(0)
     assert unit.damage_output(rng) == 0

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,4 +1,3 @@
-import random
 import sys
 import types
 
@@ -11,8 +10,8 @@ from core.buildings import create_building
 from core.game import Game
 
 
-def test_place_resources_and_collect():
-    random.seed(0)
+def test_place_resources_and_collect(rng, monkeypatch):
+    monkeypatch.setattr("random.shuffle", rng.shuffle)
     wm = WorldMap(
         width=3,
         height=1,

--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -1,21 +1,16 @@
-import random
-
 import pytest
 from mapgen.continents import generate_continent_map
 from core.world import WorldMap
 
-
-@pytest.fixture(scope="module")
-def plaine_world() -> WorldMap:
-    random.seed(0)
-    rows = generate_continent_map(30, 30, seed=0)
+@pytest.fixture
+def plaine_world(rng) -> WorldMap:
+    rows = generate_continent_map(30, 30, seed=rng.randrange(2**32))
     return WorldMap(map_data=rows)
 
 
-@pytest.fixture(scope="module")
-def marine_world() -> WorldMap:
-    random.seed(0)
-    rows = generate_continent_map(30, 30, seed=0, map_type="marine")
+@pytest.fixture
+def marine_world(rng) -> WorldMap:
+    rows = generate_continent_map(30, 30, seed=rng.randrange(2**32), map_type="marine")
     return WorldMap(map_data=rows)
 
 

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -5,7 +5,6 @@ from core.game import Game
 import core.exploration_ai as exploration_ai
 import constants
 from core.ai.creature_ai import GuardianAI, RoamingAI
-import random
 import pytest
 from mapgen.continents import generate_continent_map
 
@@ -142,9 +141,9 @@ def test_roamer_patrols():
 @pytest.mark.slow
 @pytest.mark.worldgen
 @pytest.mark.combat
-def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
-    random.seed(0)
-    rows_marine = generate_continent_map(15, 15, seed=0, map_type="marine")
+def test_marine_maps_have_guardian_clusters_and_fewer_roamers(rng):
+    seed_marine = rng.randrange(2**32)
+    rows_marine = generate_continent_map(15, 15, seed=seed_marine, map_type="marine")
     world_marine = WorldMap(map_data=rows_marine)
     for row in world_marine.grid:
         for tile in row:
@@ -159,7 +158,7 @@ def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
     base = max(1, free_land // (15 if land_ratio < 0.5 else 9))
     roamer_count = base // 3
     guardian_count = base - roamer_count
-    world_marine._generate_clusters(random, guardian_count, roamer_count)
+    world_marine._generate_clusters(rng, guardian_count, roamer_count)
     guardians = [c for c in world_marine.creatures if isinstance(c, GuardianAI)]
     roamers = [c for c in world_marine.creatures if isinstance(c, RoamingAI)]
     for g in guardians:
@@ -174,8 +173,8 @@ def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
             for dy in (-1, 0, 1)
         )
 
-    random.seed(0)
-    rows_plaine = generate_continent_map(15, 15, seed=0, map_type="plaine")
+    seed_plaine = rng.randrange(2**32)
+    rows_plaine = generate_continent_map(15, 15, seed=seed_plaine, map_type="plaine")
     world_plaine = WorldMap(map_data=rows_plaine)
     for row in world_plaine.grid:
         for tile in row:
@@ -190,6 +189,6 @@ def test_marine_maps_have_guardian_clusters_and_fewer_roamers():
     base_p = max(1, free_land_p // (15 if land_ratio_p < 0.5 else 9))
     roamer_count_p = base_p // 3
     guardian_count_p = base_p - roamer_count_p
-    world_plaine._generate_clusters(random, guardian_count_p, roamer_count_p)
+    world_plaine._generate_clusters(rng, guardian_count_p, roamer_count_p)
     roamers_plain = [c for c in world_plaine.creatures if isinstance(c, RoamingAI)]
     assert len(roamers) < len(roamers_plain)

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -4,7 +4,6 @@ from core.game import Game as GameClass
 from core.entities import Boat
 from loaders.boat_loader import BoatDef
 import audio
-import random
 import pytest
 
 from mapgen.continents import generate_continent_map
@@ -12,17 +11,15 @@ from core.world import WorldMap
 import constants
 
 
-@pytest.fixture(scope="module")
-def plaine_world() -> WorldMap:
-    random.seed(0)
-    rows = generate_continent_map(30, 30, seed=0, map_type="plaine")
+@pytest.fixture
+def plaine_world(rng) -> WorldMap:
+    rows = generate_continent_map(30, 30, seed=rng.randrange(2**32), map_type="plaine")
     return WorldMap(map_data=rows)
 
 
-@pytest.fixture(scope="module")
-def marine_world() -> WorldMap:
-    random.seed(0)
-    rows = generate_continent_map(30, 30, seed=0, map_type="marine")
+@pytest.fixture
+def marine_world(rng) -> WorldMap:
+    rows = generate_continent_map(30, 30, seed=rng.randrange(2**32), map_type="marine")
     return WorldMap(map_data=rows)
 
 


### PR DESCRIPTION
## Summary
- add `rng` fixture returning a seeded `random.Random` instance for reproducible tests
- refactor tests to consume the fixture instead of the global `random` module

## Testing
- `pytest tests/test_combat_stats.py tests/test_resources.py tests/test_starting_area.py tests/test_world_navigation.py tests/test_world_ai.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac578445a08321a801ff0f5f9b17a3