### PR TITLE
Use cached fixtures with pre-generated maps

### DIFF
--- a/tests/test_enemy_ai.py
+++ b/tests/test_enemy_ai.py
@@ -1,9 +1,10 @@
 import random
+import copy
+from pathlib import Path
 
 import pygame
 import pytest
 
-from mapgen.continents import generate_continent_map
 from core.world import WorldMap
 from core.game import Game
 from core.ai.faction_ai import FactionAI
@@ -14,10 +15,15 @@ from core import economy
 
 
 @pytest.fixture(scope="module")
-def plaine_world() -> WorldMap:
+def _plaine_world_base() -> WorldMap:
     random.seed(0)
-    rows = generate_continent_map(30, 30, seed=0)
-    return WorldMap(map_data=rows)
+    path = Path(__file__).parent / "fixtures" / "mini_continent_map.txt"
+    return WorldMap.from_file(str(path))
+
+
+@pytest.fixture
+def plaine_world(_plaine_world_base) -> WorldMap:
+    return copy.deepcopy(_plaine_world_base)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- load pre-generated world maps from `tests/fixtures/` instead of generating them in tests
- add module-scoped fixtures that cache maps and return copies for each test
- simplify map-based tests to work with compact fixtures

## Testing
- `pytest tests/test_enemy_ai.py::test_enemy_starting_area_has_town -q -m slow`
- `pytest tests/test_world_navigation.py::test_plaine_map_is_land_heavy tests/test_world_navigation.py::test_marine_map_features_and_starting_islands -q -m slow`
- `pytest tests/test_world_ai.py::test_marine_maps_have_guardian_clusters_and_fewer_roamers -q -m slow`
- `pytest tests/test_starting_area.py::test_starting_area_has_buildings_and_town tests/test_starting_area.py::test_building_images_loaded tests/test_starting_area.py::test_marine_islands_have_required_buildings -q -m slow`

------
https://chatgpt.com/codex/tasks/task_e_68ac618c6dd88321baad28ba67a94d79