### PR TITLE
Reduce pytest log verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ run one at a time. Run the parallelisable tests with:
 pytest -n auto -m "not serial"
 ```
 
+In continuous integration environments, add `--log-file=pytest.log` to
+write test logs to a file when needed.
+
 Execute the remaining serial tests separately with:
 
 ```bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,6 @@ markers =
     combat: tests with long AI loops
     serial: tests that cannot run in parallel
 addopts = -m "not slow"
+log_file =
+log_file_level = WARNING
+log_auto_indent = False


### PR DESCRIPTION
## Summary
- Disable pytest's default log file and set `log_file_level` to WARNING
- Document how to enable `--log-file=pytest.log` when running tests in CI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8d53f21c8321bb8ccd08c6124e69