### PR TITLE
Add icons to inventory tabs

### DIFF
--- a/assets/icons/icons.json
+++ b/assets/icons/icons.json
@@ -70,6 +70,9 @@
   "nav_hero_screen": { "sheet": "ui/icons/ui_nav_sheet.png", "coords": [1, 2], "tile": [512, 512] },
   "nav_inventory": { "sheet": "ui/icons/ui_nav_sheet.png", "coords": [2, 2], "tile": [512, 512] },
   "nav_skill_tree": { "sheet": "ui/icons/ui_nav_sheet.png", "coords": [0, 3], "tile": [512, 512] },
+  "stats_tab": { "sheet": "ui/icons/ui_nav_sheet.png", "coords": [1, 2], "tile": [512, 512] },
+  "inventory_tab": { "sheet": "ui/icons/ui_nav_sheet.png", "coords": [2, 2], "tile": [512, 512] },
+  "skills_tab": { "sheet": "ui/icons/ui_nav_sheet.png", "coords": [0, 3], "tile": [512, 512] },
   "nav_end_day": { "sheet": "ui/icons/ui_nav_sheet.png", "coords": [1, 3], "tile": [512, 512] },
   "nav_pause": { "sheet": "ui/icons/ui_nav_sheet.png", "coords": [2, 3], "tile": [512, 512] },
 


### PR DESCRIPTION
## Summary
- add stats/inventory/skills tab icons to icon manifest
- load and render tab icons in `InventoryScreen` with text fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac90c4615c832185ef712edf549b02