### PR TITLE
Run world AI and resource tests in parallel

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -11,8 +11,6 @@ from core.entities import Hero, Unit, SWORDSMAN_STATS
 from core.buildings import create_building
 from core.game import Game
 
-
-@pytest.mark.serial
 def test_place_resources_and_collect(rng, monkeypatch):
     monkeypatch.setattr("random.shuffle", rng.shuffle)
     wm = WorldMap(

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -10,8 +10,6 @@ import random
 import copy
 from pathlib import Path
 
-pytestmark = pytest.mark.serial
-
 @pytest.fixture(scope="module")
 def _marine_world_base() -> WorldMap:
     random.seed(0)
@@ -105,7 +103,6 @@ def test_enemy_captures_town_from_adjacent():
     assert enemy.ap == start_ap - 1
 
 
-@pytest.mark.serial
 def test_enemy_targets_hero_after_resource_collected(monkeypatch):
     monkeypatch.setattr(constants, "AI_DIFFICULTY", "Novice")
     game, enemy = _create_game_with_resource()


### PR DESCRIPTION
## Summary
- Remove `serial` markers from world AI tests
- Remove `serial` marker from resource placement tests

## Testing
- `pytest -n auto tests/test_world_ai.py tests/test_resources.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac92dede3483219236742800444a84