### PR TITLE
Refactor tests to use shared pygame stub fixture

### DIFF
--- a/tests/pygame_stub/__init__.py
+++ b/tests/pygame_stub/__init__.py
@@ -2,6 +2,12 @@ class Surface:
     def __init__(self, size, flags=0):  # flags ignored
         self._width, self._height = size
 
+    def convert_alpha(self):
+        return self
+
+    def get_size(self):
+        return (self._width, self._height)
+
     def get_width(self):
         return self._width
 
@@ -15,6 +21,8 @@ class Surface:
         """Dummy fill method for tests."""
         pass
 
+    def copy(self):
+        return Surface((self._width, self._height))
     def get_rect(self, **kwargs):  # noqa: D401 - dummy method
         """Return a simple rect covering the surface."""
         return Rect(0, 0, self._width, self._height)
@@ -100,7 +108,7 @@ class font:
         return font._init
 
     @staticmethod
-    def SysFont(name, size):
+    def SysFont(name, size, *args, **kwargs):
         class DummyFont:
             def render(self, text, aa, colour):
                 return Surface((10, 10))

--- a/tests/test_active_actor_movement.py
+++ b/tests/test_active_actor_movement.py
@@ -1,8 +1,8 @@
 from tests.test_army_actions import setup_game
 
 
-def setup_extended(monkeypatch):
-    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
+def setup_extended(monkeypatch, pygame_stub):
+    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch, pygame_stub)
     from core.world import WorldMap
     wm = WorldMap(
         width=4,
@@ -22,8 +22,8 @@ def setup_extended(monkeypatch):
     return game, constants, Army, Unit, S_STATS
 
 
-def test_selection_moves_correct_actor(monkeypatch):
-    game, constants, Army, Unit, S_STATS = setup_extended(monkeypatch)
+def test_selection_moves_correct_actor(monkeypatch, pygame_stub):
+    game, constants, Army, Unit, S_STATS = setup_extended(monkeypatch, pygame_stub)
     army = Army(0, 0, [Unit(S_STATS, 1, "hero")], ap=5)
     game.world.player_armies.append(army)
 
@@ -62,8 +62,8 @@ def test_selection_moves_correct_actor(monkeypatch):
     assert (game.hero.x, game.hero.y) == (2, 0)
 
 
-def test_path_clears_on_selection_and_end_turn(monkeypatch):
-    game, constants, Army, Unit, S_STATS = setup_extended(monkeypatch)
+def test_path_clears_on_selection_and_end_turn(monkeypatch, pygame_stub):
+    game, constants, Army, Unit, S_STATS = setup_extended(monkeypatch, pygame_stub)
     army = Army(0, 0, [Unit(S_STATS, 1, "hero")], ap=5)
     game.world.player_armies.append(army)
 

--- a/tests/test_army_treasure_combat.py
+++ b/tests/test_army_treasure_combat.py
@@ -6,8 +6,8 @@ from tests.test_army_actions import setup_game
 from ui.widgets.hero_list import HeroList
 
 
-def test_army_without_hero_treasure_and_combat(monkeypatch):
-    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
+def test_army_without_hero_treasure_and_combat(monkeypatch, pygame_stub):
+    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch, pygame_stub)
 
     # Replace Army.update_portrait to avoid file loading
     def fake_update_portrait(self):

--- a/tests/test_army_visibility.py
+++ b/tests/test_army_visibility.py
@@ -1,8 +1,8 @@
 from tests.test_army_actions import setup_game
 
 
-def test_army_movement_updates_visibility(monkeypatch):
-    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
+def test_army_movement_updates_visibility(monkeypatch, pygame_stub):
+    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch, pygame_stub)
     from core.world import WorldMap
 
     wm = WorldMap(

--- a/tests/test_boat_exchange.py
+++ b/tests/test_boat_exchange.py
@@ -1,20 +1,28 @@
 import types
 import sys
 
-from tests.test_open_town import make_pygame_stub
 
-
-def test_boat_garrison_exchange(monkeypatch):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+def test_boat_garrison_exchange(monkeypatch, pygame_stub):
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
+    monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.entities import Hero, Unit, SWORDSMAN_STATS, Boat
     from ui.boat_screen import BoatScreen
 
     hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])
     boat = Boat("barge", 1, 0, 4, 7, owner=0, garrison=[Unit(SWORDSMAN_STATS, 2, "hero")])
     game = types.SimpleNamespace(hero=hero)
-    screen = pygame_stub.display.set_mode((200, 200))
+    screen = pg.display.set_mode((200, 200))
     bs = BoatScreen(screen, game, boat)
     bs.drag_src = ("hero", 0)
     bs.drag_unit = hero.army[0]

--- a/tests/test_boat_spawn.py
+++ b/tests/test_boat_spawn.py
@@ -1,13 +1,21 @@
 import types
 import sys
 
-from tests.test_open_town import make_pygame_stub
 
-
-def test_shipyard_purchases_spawn_boat(monkeypatch):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+def test_shipyard_purchases_spawn_boat(monkeypatch, pygame_stub):
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
+    monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
     from core.entities import Hero
     from core.buildings import Shipyard

--- a/tests/test_main_screen_events.py
+++ b/tests/test_main_screen_events.py
@@ -69,22 +69,19 @@ def test_buttons_column_visible(size):
     assert gap == 8
 
 
-def test_highlight_moves_when_selecting_army(monkeypatch):
+def test_highlight_moves_when_selecting_army(monkeypatch, pygame_stub):
     """Selecting an army from the list moves the world highlight."""
 
-    from tests.test_army_actions import make_pygame_stub
     from state import event_bus as eb
     from ui.widgets.hero_list import HeroList
     from core.game import Game
 
-    # Use pygame stub to avoid needing a real display
-    pygame_stub = make_pygame_stub()
-    pygame_stub.BLEND_RGBA_ADD = 0
-    pygame_stub.transform.rotate = lambda surf, angle: surf
+    pg = pygame_stub(transform=SimpleNamespace(rotate=lambda surf, angle: surf))
+    pg.BLEND_RGBA_ADD = 0
     # Replace pygame module references in imported modules
-    monkeypatch.setattr("ui.main_screen.pygame", pygame_stub)
-    monkeypatch.setattr("ui.widgets.hero_list.pygame", pygame_stub)
-    monkeypatch.setattr("core.game.pygame", pygame_stub)
+    monkeypatch.setattr("ui.main_screen.pygame", pg)
+    monkeypatch.setattr("ui.widgets.hero_list.pygame", pg)
+    monkeypatch.setattr("core.game.pygame", pg)
 
     # Fresh event bus for isolation
     bus = eb.EventBus()
@@ -100,7 +97,7 @@ def test_highlight_moves_when_selecting_army(monkeypatch):
             self.y = y
             self.ap = 5
             self.army = []
-            self.portrait = pygame_stub.Surface((HeroList.CARD_SIZE, HeroList.CARD_SIZE))
+            self.portrait = pg.Surface((HeroList.CARD_SIZE, HeroList.CARD_SIZE))
 
     hero = DummyActor("Hero", 0, 0)
     army = DummyActor("Army", 1, 0)
@@ -114,7 +111,7 @@ def test_highlight_moves_when_selecting_army(monkeypatch):
 
         def draw(self, surface, assets, heroes, armies, sel, frame):
             selected.append(sel)
-            return pygame_stub.Surface((1, 1))
+            return pg.Surface((1, 1))
 
     game = Game.__new__(Game)
     screen = SimpleNamespace(

--- a/tests/test_open_town.py
+++ b/tests/test_open_town.py
@@ -2,84 +2,52 @@ import sys
 import types
 
 
-def make_pygame_stub():
-    class Rect:
-        def __init__(self, x, y, w, h):
-            self.x, self.y, self.width, self.height = x, y, w, h
-
-        def collidepoint(self, pos):
-            return True
-
-    class DummySurface:
-        def __init__(self, size=(10, 10), flags=0):
-            self._size = size
-
-        def get_size(self):
-            return self._size
-
-        def fill(self, *args, **kwargs):
-            pass
-
-        def blit(self, *args, **kwargs):
-            pass
-
-    class DummyFont:
-        def render(self, *args, **kwargs):
-            return DummySurface()
-
+def setup_game(monkeypatch, pygame_stub, towns):
     event_queue = [types.SimpleNamespace(type=2, key=117)]
 
     def get_events():
         return [event_queue.pop()] if event_queue else []
 
-    pygame_stub = types.SimpleNamespace(
-        Surface=DummySurface,
-        Rect=Rect,
-        SRCALPHA=1,
+    pg = pygame_stub(
         KEYDOWN=2,
         MOUSEBUTTONDOWN=1,
         K_u=117,
         K_ESCAPE=27,
-        event=types.SimpleNamespace(get=get_events),
-        draw=types.SimpleNamespace(rect=lambda *a, **k: None),
         transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
-        display=types.SimpleNamespace(
-            flip=lambda: None,
-            set_mode=lambda size, flags=0: DummySurface(size, flags),
-        ),
-        font=types.SimpleNamespace(SysFont=lambda *a, **k: DummyFont()),
-        time=types.SimpleNamespace(Clock=lambda: types.SimpleNamespace(tick=lambda fps: None)),
     )
-    return pygame_stub
+    monkeypatch.setattr(pg.event, "get", get_events)
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
+    monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
 
-
-def setup_game(monkeypatch, towns):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
     from core.game import Game
     from core.buildings import Town
+
     game = Game.__new__(Game)
-    game.screen = pygame_stub.Surface((200, 200))
-    game.clock = pygame_stub.time.Clock()
+    game.screen = pg.Surface((200, 200))
+    game.clock = pg.time.Clock()
     world = types.SimpleNamespace(towns=lambda: towns)
     game.world = world
-    game.assets = {"town": pygame_stub.Surface((10, 10))}
+    game.assets = {"town": pg.Surface((10, 10))}
     return game
 
 
-def test_open_town_prints_when_no_town(monkeypatch, capsys):
-    game = setup_game(monkeypatch, [])
+
+def test_open_town_prints_when_no_town(monkeypatch, pygame_stub, capsys):
+    game = setup_game(monkeypatch, pygame_stub, [])
     game.open_town()
     out = capsys.readouterr()
     assert "No town available" in out.out
 
 
-def test_open_town_creates_overlay(monkeypatch):
+def test_open_town_creates_overlay(monkeypatch, pygame_stub):
     from core.buildings import Town
     t = Town("A")
     t.owner = 0
-    game = setup_game(monkeypatch, [t])
+    game = setup_game(monkeypatch, pygame_stub, [t])
     # Monkeypatch TownOverlay to observe creation
     created = {}
     class DummyOverlay:
@@ -94,11 +62,21 @@ def test_open_town_creates_overlay(monkeypatch):
     assert created['towns'] == [t]
 
 
-def test_open_town_handles_property_world(monkeypatch):
+def test_open_town_handles_property_world(monkeypatch, pygame_stub):
     """Ensure ``open_town`` works when ``world.towns`` is a property."""
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
+    monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.game import Game
     from core.buildings import Town
 
@@ -114,10 +92,10 @@ def test_open_town_handles_property_world(monkeypatch):
             return self._towns
 
     game = Game.__new__(Game)
-    game.screen = pygame_stub.Surface((200, 200))
-    game.clock = pygame_stub.time.Clock()
+    game.screen = pg.Surface((200, 200))
+    game.clock = pg.time.Clock()
     game.world = World([t])
-    game.assets = {"town": pygame_stub.Surface((10, 10))}
+    game.assets = {"town": pg.Surface((10, 10))}
 
     created = {}
 

--- a/tests/test_sea_chain.py
+++ b/tests/test_sea_chain.py
@@ -3,8 +3,8 @@ from tests.test_army_actions import setup_game
 from state.event_bus import EVENT_BUS, ON_SEA_CHAIN_PROGRESS
 
 
-def test_sea_chain_full_path(monkeypatch):
-    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
+def test_sea_chain_full_path(monkeypatch, pygame_stub):
+    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch, pygame_stub)
     # make all tiles water
     for x in range(3):
         game.world.grid[0][x].biome = "ocean"

--- a/tests/test_spawn_army.py
+++ b/tests/test_spawn_army.py
@@ -3,14 +3,24 @@ import sys
 
 import pytest
 
-from tests.test_open_town import make_pygame_stub
-
 
 @pytest.mark.serial
-def test_drag_from_garrison_creates_army(monkeypatch):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+def test_drag_from_garrison_creates_army(monkeypatch, pygame_stub):
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setattr(pg.Surface, "convert_alpha", lambda self: self)
+    monkeypatch.setitem(sys.modules, "pygame", pg)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
+    monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
     from core.entities import Hero, Unit, SWORDSMAN_STATS
     from core.buildings import Town
@@ -37,7 +47,7 @@ def test_drag_from_garrison_creates_army(monkeypatch):
         def set_heroes(self, heroes):
             self.heroes = heroes
     game.main_screen = types.SimpleNamespace(hero_list=DummyHeroList())
-    screen = pygame_stub.display.set_mode((1, 1))
+    screen = pg.display.set_mode((1, 1))
     ts = TownScreen(screen, game, town, None, None, (0, 0))
     ts.town.garrison.append(Unit(SWORDSMAN_STATS, 1, "hero"))
     ts.drag_src = ("garrison", 0)
@@ -46,14 +56,25 @@ def test_drag_from_garrison_creates_army(monkeypatch):
     assert len(game.world.player_armies) == 1
     assert game.main_screen.hero_list.heroes[-1] is game.world.player_armies[0]
 
-def test_hero_army_exchange_merge_delete(monkeypatch):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+def test_hero_army_exchange_merge_delete(monkeypatch, pygame_stub):
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setattr(pg.Surface, "convert_alpha", lambda self: self)
+    monkeypatch.setitem(sys.modules, "pygame", pg)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
+    monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
     from core.entities import Hero, Army, Unit, SWORDSMAN_STATS, ARCHER_STATS
     from core.game import Game
-    import types
     from ui.hero_exchange_screen import HeroExchangeScreen
 
     game = Game.__new__(Game)
@@ -78,7 +99,7 @@ def test_hero_army_exchange_merge_delete(monkeypatch):
             self.heroes = list(heroes)
     game.main_screen = types.SimpleNamespace(hero_list=DummyHeroList())
 
-    screen = pygame_stub.display.set_mode((200, 200))
+    screen = pg.display.set_mode((200, 200))
     ex = HeroExchangeScreen(screen, hero, army)
 
     # Exchange archer from hero to army
@@ -109,10 +130,22 @@ def test_hero_army_exchange_merge_delete(monkeypatch):
 
 
 @pytest.mark.serial
-def test_army_reintegrated_removes_ghost(monkeypatch):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+def test_army_reintegrated_removes_ghost(monkeypatch, pygame_stub):
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setattr(pg.Surface, "convert_alpha", lambda self: self)
+    monkeypatch.setitem(sys.modules, "pygame", pg)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
+    monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
     from core.entities import Hero, Unit, SWORDSMAN_STATS
     from core.buildings import Town
@@ -149,7 +182,7 @@ def test_army_reintegrated_removes_ghost(monkeypatch):
 
     game.refresh_army_list = refresh
 
-    screen = pygame_stub.display.set_mode((1, 1))
+    screen = pg.display.set_mode((1, 1))
     ts = TownScreen(screen, game, town, None, None, (0, 0))
     ts.town.garrison.append(Unit(SWORDSMAN_STATS, 1, "hero"))
 

--- a/tests/test_town_overlay.py
+++ b/tests/test_town_overlay.py
@@ -2,66 +2,36 @@ import sys
 import types
 
 import pytest
+import sys
+import types
 
 
-def make_pygame_stub():
-    class Rect:
-        def __init__(self, x, y, w, h):
-            self.x, self.y, self.width, self.height = x, y, w, h
-
-        def collidepoint(self, pos):
-            return True
-
-    class DummySurface:
-        def __init__(self, size=(10, 10), flags=0):
-            self._size = size
-
-        def get_size(self):
-            return self._size
-
-        def fill(self, *args, **kwargs):
-            pass
-
-        def blit(self, *args, **kwargs):
-            pass
-
-        def copy(self):
-            return DummySurface(self._size)
-
-    pygame_stub = types.SimpleNamespace(
-        Surface=DummySurface,
-        Rect=Rect,
-        SRCALPHA=1,
+def setup_overlay(monkeypatch, pygame_stub):
+    pg = pygame_stub(
         K_u=117,
         K_ESCAPE=27,
         KEYDOWN=2,
         MOUSEBUTTONDOWN=1,
         transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
-        draw=types.SimpleNamespace(rect=lambda *a, **k: None),
-        event=types.SimpleNamespace(get=lambda: []),
-        display=types.SimpleNamespace(flip=lambda: None),
     )
-    return pygame_stub
-
-
-def setup_overlay(monkeypatch):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height()))
+    monkeypatch.setitem(sys.modules, "pygame", pg)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
     import theme
     from ui.town_overlay import TownOverlay
     from core.buildings import Town
     towns = [Town("A"), Town("B")]
     for t in towns:
         t.owner = 0
-    game = types.SimpleNamespace(world=types.SimpleNamespace(towns=lambda: towns), assets={"town": pygame_stub.Surface((10, 10))})
-    overlay = TownOverlay(pygame_stub.Surface((200, 200)), game)
+    game = types.SimpleNamespace(world=types.SimpleNamespace(towns=lambda: towns), assets={"town": pg.Surface((10, 10))})
+    overlay = TownOverlay(pg.Surface((200, 200)), game)
     return overlay, theme
 
 
 @pytest.mark.serial
-def test_overlay_lists_all_towns_and_uses_palette(monkeypatch):
-    overlay, theme = setup_overlay(monkeypatch)
+def test_overlay_lists_all_towns_and_uses_palette(monkeypatch, pygame_stub):
+    overlay, theme = setup_overlay(monkeypatch, pygame_stub)
     overlay.draw()
     assert len(overlay.town_rects) == 2
     assert overlay.BG == theme.PALETTE["background"]
@@ -71,7 +41,7 @@ def test_overlay_lists_all_towns_and_uses_palette(monkeypatch):
 
 
 @pytest.mark.serial
-def test_click_opens_town_screen(monkeypatch):
+def test_click_opens_town_screen(monkeypatch, pygame_stub):
     event_queue = [
         [],
         [types.SimpleNamespace(type=1, button=1, pos=(0, 0))],
@@ -80,11 +50,19 @@ def test_click_opens_town_screen(monkeypatch):
     def get_events():
         return event_queue.pop(0) if event_queue else []
 
-    pygame_stub = make_pygame_stub()
-    pygame_stub.event = types.SimpleNamespace(get=get_events)
-    pygame_stub.time = types.SimpleNamespace(Clock=lambda: types.SimpleNamespace(tick=lambda fps: None))
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+    pg = pygame_stub(
+        K_u=117,
+        K_ESCAPE=27,
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+        event=types.SimpleNamespace(get=get_events),
+        time=types.SimpleNamespace(Clock=lambda: types.SimpleNamespace(tick=lambda fps: None)),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height()))
+    monkeypatch.setitem(sys.modules, "pygame", pg)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
 
     from core.game import Game
     from core.buildings import Town

--- a/tests/test_town_recruitment.py
+++ b/tests/test_town_recruitment.py
@@ -5,10 +5,11 @@ import pygame
 import importlib, sys
 import types
 
+import sys
+import types
 from core.buildings import Town
 from core.world import WorldMap
 from core.entities import Hero
-from tests.test_open_town import make_pygame_stub
 
 
 def _create_game_with_town():
@@ -89,10 +90,20 @@ def test_recruit_into_visiting_army():
     assert not town.garrison
 
 
-def test_townscreen_recruit_with_hero_goes_to_garrison(monkeypatch):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+def test_townscreen_recruit_with_hero_goes_to_garrison(monkeypatch, pygame_stub):
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setitem(sys.modules, "pygame", pg)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
     from ui.town_screen import TownScreen
 
     town = Town()
@@ -104,7 +115,7 @@ def test_townscreen_recruit_with_hero_goes_to_garrison(monkeypatch):
     town.next_week()
 
     game = types.SimpleNamespace(hero=hero)
-    screen = pygame_stub.display.set_mode((1, 1))
+    screen = pg.display.set_mode((1, 1))
     ts = TownScreen(screen, game, town, None, None, (0, 0))
     ts.recruit_open = True
     ts.recruit_unit = 'Swordsman'
@@ -125,10 +136,20 @@ def test_townscreen_recruit_with_hero_goes_to_garrison(monkeypatch):
     assert hero.gold == 1000 - 50
 
 
-def test_townscreen_recruit_visiting_army(monkeypatch):
-    pygame_stub = make_pygame_stub()
-    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
-    monkeypatch.setitem(sys.modules, "pygame.draw", pygame_stub.draw)
+def test_townscreen_recruit_visiting_army(monkeypatch, pygame_stub):
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setitem(sys.modules, "pygame", pg)
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
     from ui.town_screen import TownScreen
     from core.entities import Army
 
@@ -142,7 +163,7 @@ def test_townscreen_recruit_visiting_army(monkeypatch):
 
     visiting = Army(0, 0, [], ap=4)
     game = types.SimpleNamespace(hero=hero)
-    screen = pygame_stub.display.set_mode((1, 1))
+    screen = pg.display.set_mode((1, 1))
     ts = TownScreen(screen, game, town, visiting, None, (0, 0))
     ts.recruit_open = True
     ts.recruit_unit = 'Swordsman'

--- a/tests/test_town_visibility.py
+++ b/tests/test_town_visibility.py
@@ -1,8 +1,8 @@
 from tests.test_army_actions import setup_game
 
 
-def test_town_reveals_tiles(monkeypatch):
-    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch)
+def test_town_reveals_tiles(monkeypatch, pygame_stub):
+    game, constants, Army, Unit, S_STATS = setup_game(monkeypatch, pygame_stub)
     from core.world import WorldMap
     from core.buildings import Town
 


### PR DESCRIPTION
## Summary
- add configurable `pygame_stub` fixture in tests
- unify tests to rely on shared pygame stub

## Testing
- `pytest tests/test_placeholder_modules.py tests/test_resolutions.py tests/test_resources.py tests/test_sea_chain.py tests/test_spawn_army.py tests/test_town_overlay.py tests/test_town_recruitment.py tests/test_town_visibility.py tests/test_world_navigation.py` *(fails: AttributeError: 'NoneType' object has no attribute 'hero', assert failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9415f70c8321b0b52aa75a3015da