### PR TITLE
Implement efficient WorldMap.clone and use in tests

### DIFF
--- a/tests/test_enemy_ai.py
+++ b/tests/test_enemy_ai.py
@@ -1,5 +1,4 @@
 import random
-import copy
 from pathlib import Path
 
 import pygame
@@ -23,7 +22,7 @@ def _plaine_world_base() -> WorldMap:
 
 @pytest.fixture
 def plaine_world(_plaine_world_base) -> WorldMap:
-    return copy.deepcopy(_plaine_world_base)
+    return _plaine_world_base.clone()
 
 
 @pytest.mark.slow

--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -1,6 +1,5 @@
 import pytest
 import random
-import copy
 from pathlib import Path
 
 from core.world import WorldMap
@@ -14,7 +13,7 @@ def _plaine_world_base() -> WorldMap:
 
 @pytest.fixture
 def plaine_world(_plaine_world_base) -> WorldMap:
-    return copy.deepcopy(_plaine_world_base)
+    return _plaine_world_base.clone()
 
 
 @pytest.fixture(scope="module")
@@ -26,7 +25,7 @@ def _marine_world_base() -> WorldMap:
 
 @pytest.fixture
 def marine_world(_marine_world_base) -> WorldMap:
-    return copy.deepcopy(_marine_world_base)
+    return _marine_world_base.clone()
 
 
 @pytest.mark.slow

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -7,7 +7,6 @@ import constants
 from core.ai.creature_ai import GuardianAI, RoamingAI
 import pytest
 import random
-import copy
 from pathlib import Path
 
 @pytest.fixture(scope="module")
@@ -19,7 +18,7 @@ def _marine_world_base() -> WorldMap:
 
 @pytest.fixture
 def marine_world(_marine_world_base) -> WorldMap:
-    return copy.deepcopy(_marine_world_base)
+    return _marine_world_base.clone()
 
 
 @pytest.fixture(scope="module")
@@ -31,7 +30,7 @@ def _plaine_world_base() -> WorldMap:
 
 @pytest.fixture
 def plaine_world(_plaine_world_base) -> WorldMap:
-    return copy.deepcopy(_plaine_world_base)
+    return _plaine_world_base.clone()
 
 
 def _make_world(width, height):

--- a/tests/test_world_navigation.py
+++ b/tests/test_world_navigation.py
@@ -4,7 +4,6 @@ from core.entities import Boat
 from loaders.boat_loader import BoatDef
 import pytest
 import random
-import copy
 from pathlib import Path
 
 from core.world import WorldMap
@@ -20,7 +19,7 @@ def _plaine_world_base() -> WorldMap:
 
 @pytest.fixture
 def plaine_world(_plaine_world_base) -> WorldMap:
-    return copy.deepcopy(_plaine_world_base)
+    return _plaine_world_base.clone()
 
 
 @pytest.fixture(scope="module")
@@ -32,7 +31,7 @@ def _marine_world_base() -> WorldMap:
 
 @pytest.fixture
 def marine_world(_marine_world_base) -> WorldMap:
-    return copy.deepcopy(_marine_world_base)
+    return _marine_world_base.clone()
 
 
 from tests.test_army_actions import setup_game


### PR DESCRIPTION
## Summary
- add a dedicated `WorldMap.clone()` for fast structured copies
- use `WorldMap.clone()` in world fixtures instead of `copy.deepcopy`

## Testing
- `pytest --durations=10`

------
https://chatgpt.com/codex/tasks/task_e_68ac9bc662908321a8ba742d2813ebc8