### PR TITLE
test: reuse asset manager fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import sys
 import math
 import random
 import pytest
+from types import SimpleNamespace
 
 # Provide a lightweight pygame stub so tests run without the real library
 _STUB = os.path.join(os.path.dirname(__file__), "pygame_stub", "__init__.py")
@@ -22,6 +23,7 @@ if ROOT not in sys.path:
 import constants
 from core.combat import Combat, water_battlefield_template
 from state.event_bus import EVENT_BUS
+from loaders.asset_manager import AssetManager
 
 
 @pytest.fixture
@@ -62,6 +64,21 @@ def _restore_pygame_module():
     sys.modules["pygame"] = pygame
     yield
     sys.modules["pygame"] = pygame
+
+
+@pytest.fixture(scope="session")
+def asset_manager():
+    """Provide a reusable :class:`AssetManager` instance for tests."""
+
+    import pygame
+
+    if not hasattr(pygame, "image"):
+        pygame.image = SimpleNamespace(load=lambda path: pygame.Surface((1, 1)))
+
+    mgr = AssetManager(repo_root=".")
+    yield mgr
+    if hasattr(mgr, "close"):
+        mgr.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_building_asset_warning.py
+++ b/tests/test_building_asset_warning.py
@@ -2,18 +2,17 @@ import logging
 import os
 import pygame
 from core.game import Game
-from loaders.asset_manager import AssetManager
 from loaders.core import Context
 
 
-def test_missing_building_sprite_logs_warning(caplog):
+def test_missing_building_sprite_logs_warning(caplog, asset_manager):
     repo_root = os.path.dirname(os.path.dirname(__file__))
     game = Game.__new__(Game)
-    game.assets = AssetManager(repo_root)
+    game.assets = asset_manager
     game.ctx = Context(
         repo_root=repo_root,
         search_paths=[os.path.join(repo_root, "assets")],
-        asset_loader=game.assets,
+        asset_loader=asset_manager,
     )
     with caplog.at_level(logging.WARNING, logger="loaders.asset_manager"):
         Game.load_assets(game)

--- a/tests/test_building_surface_scale.py
+++ b/tests/test_building_surface_scale.py
@@ -5,16 +5,15 @@ import pygame
 
 import constants
 from core.buildings import create_building
-from loaders.asset_manager import AssetManager
 from loaders.building_loader import BuildingAsset, get_surface
 
 
-def test_high_res_building_scaled_width(monkeypatch):
-    repo_root = os.path.dirname(os.path.dirname(__file__))
-    mgr = AssetManager(repo_root)
+def test_high_res_building_scaled_width(monkeypatch, asset_manager):
+    mgr = asset_manager
 
     high_res = pygame.Surface((512, 256))
-    mgr[os.path.splitext("foo.png")[0]] = high_res
+    key = os.path.splitext("foo.png")[0]
+    mgr[key] = high_res
 
     asset = BuildingAsset(id="big", path="foo.png", footprint=[(0, 0), (1, 0)])
 
@@ -34,3 +33,4 @@ def test_high_res_building_scaled_width(monkeypatch):
     building = create_building("big", defs={"big": asset})
     ax, ay = asset.anchor_px
     assert building.anchor == (int(ax * scale), int(ay * scale))
+    mgr.pop(key, None)

--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -63,7 +63,7 @@ def test_starting_area_has_buildings_and_town(plaine_world):
 
 @pytest.mark.slow
 @pytest.mark.worldgen
-def test_building_images_loaded(plaine_world):
+def test_building_images_loaded(plaine_world, asset_manager):
     import sys
     import types
 
@@ -116,10 +116,9 @@ def test_building_images_loaded(plaine_world):
     sys.modules["pygame.draw"] = pygame_stub.draw
 
     try:
-        from loaders.asset_manager import AssetManager
         from loaders.building_loader import BUILDINGS
         world = plaine_world
-        assets = AssetManager(repo_root=".")
+        assets = asset_manager
         for asset in BUILDINGS.values():
             files = asset.file_list()
             if files:


### PR DESCRIPTION
## Summary
- provide session-scoped `asset_manager` fixture and share across tests
- update asset-dependent tests to use reusable fixture

## Testing
- `pytest tests/test_building_asset_warning.py tests/test_building_surface_scale.py -q`
- `pytest tests/test_starting_area.py::test_building_images_loaded -q -m slow`


------
https://chatgpt.com/codex/tasks/task_e_68aca2578fdc8321b6ad290d61abcbbc