### PR TITLE
Add icon loader with caching and tests

### DIFF
--- a/loaders/icon_loader.py
+++ b/loaders/icon_loader.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Load icon surfaces from JSON mapping with caching and reload support."""
+
+import json
+from pathlib import Path
+from typing import Dict
+
+import pygame
+
+# Load icon mapping once at import time
+_ROOT = Path(__file__).resolve().parent.parent
+_ASSETS_DIR = _ROOT / "assets"
+_ICONS_DIR = _ASSETS_DIR / "icons"
+
+with open(_ICONS_DIR / "icons.json", "r", encoding="utf-8") as f:
+    _ICON_MAP: Dict[str, str | dict] = json.load(f)
+
+# Cache for loaded pygame surfaces
+_CACHE: Dict[str, pygame.Surface] = {}
+
+
+def _placeholder_surface() -> pygame.Surface:
+    surf = pygame.Surface((1, 1))
+    surf.fill((100, 100, 100))
+    return surf
+
+
+def get(icon_id: str, size: int) -> pygame.Surface:
+    """Return the surface for ``icon_id`` scaled to ``size``.
+
+    If the icon file is missing or fails to load, a grey placeholder surface
+    of the requested size is returned instead.
+    """
+
+    if icon_id not in _CACHE:
+        entry = _ICON_MAP.get(icon_id)
+        filename = None
+        if isinstance(entry, str):
+            filename = entry
+        elif isinstance(entry, dict):
+            filename = entry.get("file")
+        if isinstance(filename, str):
+            path = _ICONS_DIR / filename
+            if not path.is_file():
+                # Support paths relative to the assets directory
+                path = _ASSETS_DIR / filename
+            try:
+                surf = pygame.image.load(path).convert_alpha()
+            except Exception:
+                surf = _placeholder_surface()
+        else:
+            surf = _placeholder_surface()
+        _CACHE[icon_id] = surf
+
+    surf = _CACHE[icon_id]
+    if surf.get_size() != (size, size):
+        return pygame.transform.smoothscale(surf, (size, size))
+    return surf
+
+
+def reload() -> None:
+    """Clear the internal surface cache."""
+
+    _CACHE.clear()

--- a/tests/test_icon_loader.py
+++ b/tests/test_icon_loader.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from pathlib import Path
+
+import pygame
+
+import loaders.icon_loader as icon_loader
+
+
+def _prepare_pygame(monkeypatch):
+    """Install minimal image and transform modules for the pygame stub."""
+
+    def load(_path: str) -> pygame.Surface:
+        return pygame.Surface((8, 8))
+
+    def smoothscale(surf: pygame.Surface, size: tuple[int, int]) -> pygame.Surface:
+        return pygame.Surface(size)
+
+    monkeypatch.setattr(pygame, "image", SimpleNamespace(load=load), raising=False)
+    monkeypatch.setattr(
+        pygame, "transform", SimpleNamespace(smoothscale=smoothscale), raising=False
+    )
+
+
+def test_get_and_reload(monkeypatch):
+    pygame.init()
+    _prepare_pygame(monkeypatch)
+
+    # ensure test icon exists
+    icon_dir = Path("assets/icons/icons")
+    icon_dir.mkdir(parents=True, exist_ok=True)
+    img_path = icon_dir / "end_turn.png"
+    img_path.touch()
+
+    icon_loader.reload()
+
+    surf1 = icon_loader.get("end_turn", 32)
+    assert isinstance(surf1, pygame.Surface)
+    assert surf1.get_size() == (32, 32)
+
+    def raise_load(path):
+        raise AssertionError("should not load again")
+
+    monkeypatch.setattr(pygame.image, "load", raise_load)
+    surf2 = icon_loader.get("end_turn", 16)
+    assert surf2.get_size() == (16, 16)
+
+    icon_loader.reload()
+    loaded = False
+
+    def fake_load(path):
+        nonlocal loaded
+        loaded = True
+        return pygame.Surface((8, 8))
+
+    monkeypatch.setattr(pygame.image, "load", fake_load)
+    surf3 = icon_loader.get("end_turn", 24)
+    assert loaded
+    assert surf3.get_size() == (24, 24)
+
+
+def test_missing_icon_placeholder(monkeypatch):
+    pygame.init()
+    _prepare_pygame(monkeypatch)
+    icon_loader.reload()
+    surf = icon_loader.get("unknown", 20)
+    assert surf.get_size() == (20, 20)


### PR DESCRIPTION
## Summary
- implement icon_loader to cache pygame Surfaces and load mapping from assets/icons/icons.json
- provide reload() to clear icon cache and return gray placeholder when missing
- cover loader behavior with new tests

## Testing
- `pytest tests/test_icon_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca22bbbc483219a7e76ddef8b8bd7