### PR TITLE
Add reusable IconButton UI widget

### DIFF
--- a/tests/test_icon_button.py
+++ b/tests/test_icon_button.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+import pygame as pg
+
+from ui.widgets.icon_button import (
+    IconButton,
+    KEYDOWN,
+    MOUSEBUTTONDOWN,
+    MOUSEBUTTONUP,
+)
+
+
+def test_icon_button_click(monkeypatch):
+    called = []
+    rect = pg.Rect(0, 0, 32, 32)
+    btn = IconButton(rect, "end_turn", lambda: called.append(True))
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    down = SimpleNamespace(type=MOUSEBUTTONDOWN, pos=(1, 1), button=1)
+    up = SimpleNamespace(type=MOUSEBUTTONUP, pos=(1, 1), button=1)
+    btn.handle(down)
+    btn.handle(up)
+    assert called == [True]
+
+
+def test_icon_button_hotkey():
+    called = []
+    rect = pg.Rect(0, 0, 32, 32)
+    hotkey = 42
+    btn = IconButton(rect, "end_turn", lambda: called.append(True), hotkey=hotkey)
+    evt = SimpleNamespace(type=KEYDOWN, key=hotkey)
+    btn.handle(evt)
+    assert called == [True]

--- a/ui/widgets/__init__.py
+++ b/ui/widgets/__init__.py
@@ -1,3 +1,4 @@
 """Widget components for the UI."""
 
 from .buttons_column import ButtonsColumn  # noqa: F401
+from .icon_button import IconButton  # noqa: F401

--- a/ui/widgets/icon_button.py
+++ b/ui/widgets/icon_button.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Simple clickable icon button with optional hotkey."""
+
+from typing import Callable, Optional
+
+import pygame
+
+from .. import theme
+from loaders import icon_loader as IconLoader
+
+# Event type fallbacks for environments using the pygame stub
+MOUSEMOTION = getattr(pygame, "MOUSEMOTION", 3)
+MOUSEBUTTONDOWN = getattr(pygame, "MOUSEBUTTONDOWN", 1)
+MOUSEBUTTONUP = getattr(pygame, "MOUSEBUTTONUP", 5)
+KEYDOWN = getattr(pygame, "KEYDOWN", 2)
+
+
+class IconButton:
+    """Display a clickable icon that invokes ``callback`` when activated."""
+
+    def __init__(
+        self,
+        rect: pygame.Rect,
+        icon_id: str,
+        callback: Callable[[], None],
+        hotkey: Optional[int] = None,
+        tooltip: str = "",
+    ) -> None:
+        self.rect = rect
+        self.icon_id = icon_id
+        self.callback = callback
+        self.hotkey = hotkey
+        self.tooltip = tooltip
+        self.hovered = False
+        self.pressed = False
+        self.font = theme.get_font(16)
+
+    # ------------------------------------------------------------------
+    def draw(self, surface: pygame.Surface) -> None:
+        """Render the button to ``surface``."""
+
+        bg = theme.PALETTE["panel"]
+        if self.pressed:
+            bg = theme.PALETTE["accent"]
+        surface.fill(bg, self.rect)
+
+        frame_state = "highlight" if (self.hovered or self.pressed) else "normal"
+        theme.draw_frame(surface, self.rect, frame_state)
+
+        icon = IconLoader.get(self.icon_id, self.rect.w)
+        if icon is not None:
+            icon_rect = icon.get_rect()
+            icon_rect.center = self.rect.center
+            surface.blit(icon, icon_rect)
+        elif self.font:
+            letter = self.icon_id[:1].upper()
+            text = self.font.render(letter, True, theme.PALETTE["text"])
+            text_rect = text.get_rect()
+            text_rect.center = self.rect.center
+            surface.blit(text, text_rect)
+
+    # ------------------------------------------------------------------
+    def handle(self, event: pygame.event.Event) -> bool:
+        """Process a pygame event returning ``True`` if it was handled."""
+
+        if event.type == MOUSEMOTION:
+            self.hovered = self.rect.collidepoint(getattr(event, "pos", (0, 0)))
+        elif event.type == MOUSEBUTTONDOWN and getattr(event, "button", 0) == 1:
+            if self.rect.collidepoint(getattr(event, "pos", (0, 0))):
+                self.pressed = True
+                return True
+        elif event.type == MOUSEBUTTONUP and getattr(event, "button", 0) == 1:
+            if self.pressed:
+                self.pressed = False
+                if self.rect.collidepoint(getattr(event, "pos", (0, 0))):
+                    if self.callback:
+                        self.callback()
+                    return True
+        elif event.type == KEYDOWN and self.hotkey is not None:
+            if getattr(event, "key", None) == self.hotkey:
+                if self.callback:
+                    self.callback()
+                return True
+        return False
+
+    # ------------------------------------------------------------------
+    def get_tooltip(self) -> str:
+        """Return the tooltip string for the button."""
+
+        return self.tooltip


### PR DESCRIPTION
## Summary
- add `IconButton` widget that draws icons and handles clicks & hotkeys
- expose `IconButton` via `ui.widgets`
- test `IconButton` interactions

## Testing
- `pytest tests/test_icon_button.py -q`
- `pytest -q` *(fails: test_select_spell_prefers_fireball_for_cluster, test_enemy_before_treasure, test_positive_luck_logs, test_negative_luck_logs, test_retaliation_limited_to_one, interrupted at tests/test_open_town.py:58)*

------
https://chatgpt.com/codex/tasks/task_e_68acb34613348321b919cfc1a7febfa0