### PR TITLE
Ajout de pytest-testmon et script de tests rapides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Guide de contribution
+
+Pour exécuter uniquement les tests affectés par vos modifications, utilisez le script :
+
+```
+make fast-test
+```
+
+Ce script lance `pytest --testmon -m "not slow"` afin d’exécuter uniquement les tests touchés
+tout en évitant ceux marqués comme lents.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: fast-test
+
+fast-test:
+	pytest --testmon -m "not slow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8"
 dependencies = ["pygame"]
 
 [project.optional-dependencies]
-dev = ["black", "flake8", "pytest", "pytest-xdist"]
+dev = ["black", "flake8", "pytest", "pytest-xdist", "pytest-testmon"]
 
 [project.scripts]
 fantaisie = "main:main"


### PR DESCRIPTION
## Summary
- ajoute `pytest-testmon` aux dépendances de dev
- ajoute la cible `fast-test` pour exécuter `pytest --testmon -m "not slow"`
- documente l'utilisation de `make fast-test` dans `CONTRIBUTING.md`

## Testing
- `make fast-test` *(échecs: AttributeError: module 'pygame' has no attribute 'math')*

------
https://chatgpt.com/codex/tasks/task_e_68acb212b0e08321a3a0fb5154328ad3