### PR TITLE
Add precommit test target and config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: precommit-test
+        name: Run tests
+        entry: make precommit-test
+        language: system
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: fast-test
+.PHONY: fast-test precommit-test
 
 fast-test:
 	pytest --testmon -m "not slow"
+
+precommit-test:
+	pytest --maxfail=1 -m "not slow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8"
 dependencies = ["pygame"]
 
 [project.optional-dependencies]
-dev = ["black", "flake8", "pytest", "pytest-xdist", "pytest-testmon"]
+dev = ["black", "flake8", "pre-commit", "pytest", "pytest-xdist", "pytest-testmon"]
 
 [project.scripts]
 fantaisie = "main:main"


### PR DESCRIPTION
## Summary
- add `precommit-test` make target running `pytest --maxfail=1 -m "not slow"`
- configure pre-commit to run the `precommit-test` target
- include `pre-commit` in dev dependencies

## Testing
- `pytest --maxfail=1 -m "not slow"` *(fails: tests/test_combat_ai.py::test_select_spell_prefers_fireball_for_cluster)*
- `pre-commit run --files Makefile pyproject.toml .pre-commit-config.yaml` *(fails: tests/test_combat_ai.py::test_select_spell_prefers_fireball_for_cluster)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6213f6083219ff39be27e513905