### PR TITLE
Skip asset loading for fast tests

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -585,6 +585,9 @@ class Game:
 
     def load_assets(self) -> None:
         """Load all images referenced in constants.  If a file is missing, skip it."""
+        if os.environ.get("FG_FAST_TESTS") == "1":
+            self._asset_paths = {}
+            return
         # Build a mapping of relative path -> full path by walking all
         # directories known to the asset manager.  Paths earlier in
         # ``search_paths`` take precedence, ensuring externally supplied assets


### PR DESCRIPTION
## Summary
- avoid expensive asset discovery when FG_FAST_TESTS is enabled

## Testing
- `pre-commit run --files core/game.py` *(fails: tests/test_combat_ai.py::test_select_spell_prefers_fireball_for_cluster)*

------
https://chatgpt.com/codex/tasks/task_e_68acc394b8d08321b49dde8caa11d147