### PR TITLE
Lazy icon conversion after display initialization

### DIFF
--- a/tests/pygame_stub/__init__.py
+++ b/tests/pygame_stub/__init__.py
@@ -142,15 +142,21 @@ class draw:
 
 class display:
     _surface = Surface((800, 600))
+    _init = True
 
     @staticmethod
     def set_mode(size, flags=0):
         display._surface = Surface(size)
+        display._init = True
         return display._surface
 
     @staticmethod
     def get_surface():
         return display._surface
+
+    @staticmethod
+    def get_init():
+        return display._init
 
     @staticmethod
     def Info():
@@ -167,6 +173,7 @@ class display:
     @staticmethod
     def flip():
         pass
+
     @staticmethod
     def toggle_fullscreen():
         return True

--- a/tests/test_icon_loader.py
+++ b/tests/test_icon_loader.py
@@ -64,3 +64,43 @@ def test_missing_icon_placeholder(monkeypatch):
     icon_loader.reload()
     surf = icon_loader.get("unknown", 20)
     assert surf.get_size() == (20, 20)
+
+
+def test_lazy_conversion_after_display_init(monkeypatch):
+    pygame.init()
+    _prepare_pygame(monkeypatch)
+
+    icon_dir = Path("assets/icons")
+    icon_dir.mkdir(parents=True, exist_ok=True)
+    (icon_dir / "end_turn.png").touch()
+
+    convert_calls = []
+
+    class CountingSurface(pygame.Surface):
+        def __init__(self, size):
+            super().__init__(size)
+
+        def convert_alpha(self):
+            convert_calls.append(True)
+            return self
+
+    def load(_path: str) -> pygame.Surface:
+        return CountingSurface((8, 8))
+
+    monkeypatch.setattr(pygame.image, "load", load, raising=False)
+    monkeypatch.setattr(pygame.display, "get_init", lambda: False)
+
+    icon_loader.reload()
+
+    icon_loader.get("end_turn", 32)
+    assert convert_calls == []
+
+    monkeypatch.setattr(pygame.display, "get_init", lambda: True)
+
+    surf2 = icon_loader.get("end_turn", 16)
+    assert len(convert_calls) == 1
+    assert surf2.get_size() == (16, 16)
+
+    surf3 = icon_loader.get("end_turn", 24)
+    assert len(convert_calls) == 1
+    assert surf3.get_size() == (24, 24)


### PR DESCRIPTION
## Summary
- Load icons without conversion before `pygame.display` is ready and convert lazily once it initializes
- Log when a placeholder surface is used due to missing or bad assets
- Add `display.get_init` to pygame stub and test lazy icon conversion after display init

## Testing
- `pre-commit run --files loaders/icon_loader.py tests/pygame_stub/__init__.py tests/test_icon_loader.py` *(failed: tests/test_combat_ai.py::test_select_spell_prefers_fireball_for_cluster)*
- `pytest tests/test_icon_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68acc5dadc088321b91e98a345fe65fe