### PR TITLE
tests: set environment variables for fast headless runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,13 @@ import random
 import pytest
 from types import SimpleNamespace
 
+# Ensure specific environment variables for tests
+@pytest.fixture(scope="session", autouse=True)
+def _configure_test_environment():
+    os.environ.setdefault("FG_FAST_TESTS", "1")
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    yield
+
 # Provide a lightweight pygame stub so tests run without the real library
 _STUB = os.path.join(os.path.dirname(__file__), "pygame_stub", "__init__.py")
 spec = importlib.util.spec_from_file_location("pygame", _STUB)


### PR DESCRIPTION
## Summary
- ensure tests run in fast, headless mode by default

## Testing
- `pytest tests/test_attack_defence_multiplier.py -q`
- `pytest -q` *(fails: 8 failed, 155 passed, 1 skipped, 17 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68acc39d5a708321b3d0db7e5ecd06a9