### PR TITLE
Use xdist by default and document test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,29 +176,29 @@ feature codes—along with example continent layouts—is documented in
 The project includes a small automated test suite that exercises map
 generation, combat rules and save/load behaviour. Most tests can be run in
 parallel; a few that rely on global state are marked with ``serial`` and must
-run one at a time. Run the parallelisable tests with:
+run one at a time.
+
+Run the main test suite (excluding slow, worldgen and combat cases) with:
 
 ```bash
-pytest -n auto -m "not slow"
+pytest -q -n auto -m "not slow and not worldgen and not combat"
+```
+
+Tests marked ``serial`` must be executed separately:
+
+```bash
+pytest -q -n 1 -m serial
+```
+
+Slow and specialised tests covering world generation and extended combat are
+skipped by default. Run them explicitly with:
+
+```bash
+pytest -q -n auto -m "slow or worldgen or combat"
 ```
 
 In continuous integration environments, add `--log-file=pytest.log` to
 write test logs to a file when needed.
-
-Tests marked ``serial`` are excluded from the above command and must be run
-separately with:
-
-```bash
-pytest -m serial
-```
-
-Slow tests that perform extensive world generation or long AI loops are marked
-with `slow` and either `worldgen` or `combat`. These are skipped by default.
-Run them explicitly (for example in CI) with:
-
-```bash
-pytest -m slow
-```
 
 
 ## Configuration

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ markers =
     worldgen: tests involving large-scale map generation
     combat: tests with long AI loops
     serial: tests that cannot run in parallel
-addopts = -m "not slow and not serial"
+addopts = -q -n auto --dist=loadgroup -m "not slow and not worldgen and not combat and not serial" --durations=20 --maxfail=1
 log_file =
 log_file_level = WARNING
 log_auto_indent = False


### PR DESCRIPTION
## Summary
- run pytest with xdist by default and filter out slow, worldgen, combat, and serial tests
- document how to invoke the main, serial, and slow/worldgen/combat test suites

## Testing
- `pre-commit run --files README.md pytest.ini` *(fails: tests/test_combat_ai.py::test_select_spell_prefers_fireball_for_cluster; tests/test_encounter_priority.py::test_enemy_before_treasure)*
- `pytest -q` *(fails: tests/test_encounter_priority.py::test_enemy_before_treasure; tests/test_icon_manifest_files_exist.py::test_icon_files_exist)*

------
https://chatgpt.com/codex/tasks/task_e_68acc86b6d608321934ea6572e41a1dc