### PR TITLE
Gate heavy game asset loading behind FG_FAST_TESTS

### DIFF
--- a/tests/test_coast_assets.py
+++ b/tests/test_coast_assets.py
@@ -1,55 +1,72 @@
 import sys
 import types
 
+
 class Rect:
     def __init__(self, x, y, w, h):
         self.x, self.y, self.width, self.height = x, y, w, h
         self.bottom = y + h
+
     def collidepoint(self, pos):
         return False
+
 
 class DummySurface:
     def convert_alpha(self):
         return self
+
     def get_width(self):
         return 10
+
     def get_height(self):
         return 10
+
     def get_rect(self):
         return Rect(0, 0, 10, 10)
+
     def blit(self, *args, **kwargs):
         pass
+
     def fill(self, *args, **kwargs):
         pass
+
 
 def load(path):
     return DummySurface()
 
-pygame_stub = types.SimpleNamespace(
-    image=types.SimpleNamespace(load=load),
-    transform=types.SimpleNamespace(scale=lambda surf, size: surf, smoothscale=lambda surf, size: surf),
-    Surface=lambda size, flags=0: DummySurface(),
-    SRCALPHA=1,
-    Rect=Rect,
-    draw=types.SimpleNamespace(ellipse=lambda surf, color, rect: None),
-    time=types.SimpleNamespace(Clock=lambda: types.SimpleNamespace(tick=lambda fps: None)),
-    event=types.SimpleNamespace(get=lambda: []),
-    display=types.SimpleNamespace(flip=lambda: None),
-    init=lambda: None,
-    quit=lambda: None,
-)
 
-real_pygame = sys.modules.get("pygame")
-sys.modules["pygame"] = pygame_stub
-sys.modules.setdefault(
-    "audio", types.SimpleNamespace(init=lambda: None, play_sound=lambda *args, **kwargs: None)
-)
+def test_coast_assets_loaded(tmp_path, monkeypatch):
+    monkeypatch.setenv("FG_FAST_TESTS", "1")
 
-from core.game import Game
+    pygame_stub = types.SimpleNamespace(
+        image=types.SimpleNamespace(load=load),
+        transform=types.SimpleNamespace(
+            scale=lambda surf, size: surf, smoothscale=lambda surf, size: surf
+        ),
+        Surface=lambda size, flags=0: DummySurface(),
+        SRCALPHA=1,
+        Rect=Rect,
+        draw=types.SimpleNamespace(
+            ellipse=lambda surf, color, rect: None, rect=lambda *a, **k: None
+        ),
+        time=types.SimpleNamespace(
+            Clock=lambda: types.SimpleNamespace(tick=lambda fps: None)
+        ),
+        event=types.SimpleNamespace(get=lambda: []),
+        display=types.SimpleNamespace(flip=lambda: None),
+        init=lambda: None,
+        quit=lambda: None,
+    )
 
-sys.modules["pygame"] = real_pygame
+    monkeypatch.setitem(sys.modules, "pygame", pygame_stub)
+    monkeypatch.setitem(
+        sys.modules,
+        "audio",
+        types.SimpleNamespace(init=lambda: None, play_sound=lambda *a, **k: None),
+    )
 
-def test_coast_assets_loaded(tmp_path):
+    from core.game import Game
+
     map_path = tmp_path / "map.txt"
     map_path.write_text("G.W.\nG.W.\n")
     screen = types.SimpleNamespace(get_width=lambda: 100, get_height=lambda: 100)


### PR DESCRIPTION
## Summary
- Skip loading factions, battlefields, biome data, flora, resources, unit/boat definitions and audio when FG_FAST_TESTS=1
- Add fast-test stubs for coast asset and minimap fog tests

## Testing
- `python -m pre_commit run --files core/game.py tests/test_coast_assets.py tests/test_minimap.py` *(fails: tests/test_combat_ai.py::test_select_spell_prefers_fireball_for_cluster)*
- `pytest tests/test_coast_assets.py tests/test_minimap.py tests/test_combat_ai.py::test_select_spell_prefers_fireball_for_cluster -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc86718f48321986b7cbf82508417