### PR TITLE
Mark ocean-related tests as worldgen

### DIFF
--- a/tests/test_marine_ocean_features.py
+++ b/tests/test_marine_ocean_features.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.worldgen
+
 from pathlib import Path
 
 import constants

--- a/tests/test_ocean_enemy_spawn.py
+++ b/tests/test_ocean_enemy_spawn.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.worldgen
+
 import os
 import tempfile
 

--- a/tests/test_shipyard_placement.py
+++ b/tests/test_shipyard_placement.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.worldgen
+
 from pathlib import Path
 
 from core.world import WorldMap

--- a/tests/test_world_map_from_file.py
+++ b/tests/test_world_map_from_file.py
@@ -1,3 +1,6 @@
+import pytest
+pytestmark = pytest.mark.worldgen
+
 import os
 import tempfile
 


### PR DESCRIPTION
## Summary
- categorize several ocean/world map tests as `worldgen`

## Testing
- `pytest -q -m worldgen tests/test_marine_ocean_features.py tests/test_ocean_enemy_spawn.py tests/test_shipyard_placement.py tests/test_world_map_from_file.py -n0`
- `make fast-test` *(fails: tests/test_building_asset_warning.py::test_missing_building_sprite_logs_warning - assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68accc2a49b08321b8d62ce7097e304d