### PR TITLE
docs: document selective pytest options

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ pytest -q -n auto -m "slow or worldgen or combat"
 In continuous integration environments, add `--log-file=pytest.log` to
 write test logs to a file when needed.
 
+### Focused test runs
+
+Pytest provides several options to iterate quickly during development:
+
+* `pytest --testmon` runs only the tests impacted by your recent changes.
+* `pytest --lf` re-executes only the tests that failed in the previous run.
+* `pytest --randomly-seed=0` (requires the `pytest-randomly` plugin) fixes the
+  random seed to help detect order-dependent failures.
+
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- document focused test run flags in the README

## Testing
- `pytest` *(fails: tests/test_building_asset_warning.py::test_missing_building_sprite_logs_warning)*

------
https://chatgpt.com/codex/tasks/task_e_68accd54c28c8321b5d3791d5b512414