### PR TITLE
Add pytest make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
-.PHONY: fast-test precommit-test
+.PHONY: fast all-fast serial long fast-test precommit-test
 
-fast-test:
-	pytest --testmon -m "not slow"
+fast:
+	pytest -q
 
-precommit-test:
-	pytest --maxfail=1 -m "not slow"
+fast-test: fast
+
+all-fast:
+	pytest -q -n auto --dist=loadgroup -m "not slow and not worldgen and not combat and not serial"
+
+precommit-test: all-fast
+
+serial:
+	pytest -q -n 1 -m serial
+
+long:
+	pytest -q -n auto -m "slow or worldgen or combat"


### PR DESCRIPTION
## Summary
- replace Makefile with common pytest targets
- keep legacy fast-test and precommit-test aliases

## Testing
- ⚠️ `make fast` *(fails: tests/test_building_asset_warning.py::test_missing_building_sprite_logs_warning)*

------
https://chatgpt.com/codex/tasks/task_e_68accd4a3cb883219a881a715b22a1ee