### PR TITLE
Mark starting area test as serial

### DIFF
--- a/tests/test_starting_area.py
+++ b/tests/test_starting_area.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from core.world import WorldMap
 
+pytestmark = pytest.mark.serial
+
 @pytest.fixture(scope="module")
 def _plaine_world_base() -> WorldMap:
     random.seed(0)


### PR DESCRIPTION
## Summary
- mark tests that manipulate `sys.modules['pygame']` as serial

## Testing
- `pre-commit run --files tests/test_starting_area.py` *(fails: test_missing_building_sprite_logs_warning, test_select_spell_prefers_fireball_for_cluster)*
- `pytest -n auto` *(fails: test_missing_building_sprite_logs_warning, test_select_spell_prefers_fireball_for_cluster)*

------
https://chatgpt.com/codex/tasks/task_e_68acce653a848321bf31a242844eac47