### PR TITLE
Refactor UI buttons to use IconButton widgets

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -51,6 +51,7 @@ from core.spell import (
     Spell as SpellDef,
 )
 from core.faction import FactionDef
+from ui.widgets.icon_button import IconButton
 
 # Units with explicit hero/enemy image overrides. Other units default to an
 # asset whose identifier matches ``UnitStats.name``.
@@ -198,8 +199,8 @@ class Combat:
         self.selected_unit: Optional[Unit] = None
         # Action chosen by the player during the hero's turn
         self.selected_action: Optional[str] = None
-        # Rectangles for action buttons, populated during render.draw()
-        self.action_buttons: Dict[str, pygame.Rect] = {}
+        # Icon buttons for combat actions, populated during render.draw()
+        self.action_buttons: Dict[str, IconButton] = {}
         # When casting a spell, store the caster and wait for target selection
         self.casting_spell: bool = False
         self.spell_caster: Optional[Unit] = None
@@ -267,7 +268,7 @@ class Combat:
         self._dragging = False
         # Automatic control flag and button
         self.auto_mode: bool = False
-        self.auto_button: Optional[pygame.Rect] = None
+        self.auto_button: Optional[IconButton] = None
         # Damage statistics for post battle summary
         self.damage_stats: Dict[Unit, Dict[str, int]] = {
             u: {"dealt": 0, "taken": 0} for u in self.units

--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -378,28 +378,12 @@ def handle_button_click(combat, current_unit, pos: Tuple[int, int]) -> bool:
     Returns ``True`` if the click was consumed by the UI.
     """
     mx, my = pos
-    if combat.auto_button and combat.auto_button.collidepoint(mx, my):
-        combat.auto_mode = not combat.auto_mode
+    if combat.auto_button and combat.auto_button.rect.collidepoint(mx, my):
+        combat.auto_button.callback()
         return True
 
-    for action, rect in combat.action_buttons.items():
-        if rect.collidepoint(mx, my):
-            if action == "spellbook":
-                if combat.hero_spells:
-                    combat.show_spellbook()
-                    return True
-                return False
-            elif combat.selected_action == "spell":
-                if action == "back":
-                    combat.selected_action = None
-                    break
-                combat.start_spell(current_unit, action)
-            elif action == "wait":
-                current_unit.acted = True
-                combat.advance_turn()
-                combat.selected_unit = None
-                combat.selected_action = None
-            else:
-                combat.selected_action = action
+    for btn in combat.action_buttons.values():
+        if btn.enabled and btn.rect.collidepoint(mx, my):
+            btn.callback()
             return True
     return False

--- a/tests/test_combat_spellbook_button.py
+++ b/tests/test_combat_spellbook_button.py
@@ -1,25 +1,29 @@
 from core.combat_render import handle_button_click
 
 
-class DummyRect:
-    def __init__(self, x=0, y=0, w=10, h=10):
-        self.x, self.y, self.w, self.h = x, y, w, h
-
-    def collidepoint(self, px, py):
-        return self.x <= px < self.x + self.w and self.y <= py < self.y + self.h
-
-
 class DummyCombat:
     def __init__(self, hero_spells):
-        self.action_buttons = {"spellbook": DummyRect(0, 0, 10, 10)}
-        self.auto_button = None
-        self.auto_mode = False
-        self.selected_action = None
+        import pygame
+        from ui.widgets.icon_button import IconButton
+
         self.hero_spells = hero_spells
         self.show_called = False
 
-    def show_spellbook(self):
-        self.show_called = True
+        def open_spellbook() -> None:
+            if self.hero_spells:
+                self.show_called = True
+
+        self.action_buttons = {
+            "spellbook": IconButton(
+                pygame.Rect(0, 0, 10, 10),
+                "action_cast",
+                open_spellbook,
+                enabled=bool(hero_spells),
+            )
+        }
+        self.auto_button = None
+        self.auto_mode = False
+        self.selected_action = None
 
     def advance_turn(self):
         pass
@@ -41,3 +45,4 @@ def test_spellbook_ignored_when_empty():
     current_unit = DummyUnit()
     assert not handle_button_click(combat, current_unit, (5, 5))
     assert not combat.show_called
+


### PR DESCRIPTION
## Summary
- replace combat HUD rectangles with IconButton instances and callbacks
- rework main screen menu bar to use IconButton icons
- convert inventory tabs into IconButton widgets

## Testing
- `pre-commit run --files core/combat.py core/combat_screen.py core/combat_render.py ui/main_screen.py ui/inventory_screen.py tests/test_combat_spellbook_button.py` *(fails: Missing asset / tile_variants during Game initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68accbed63d08321a1d51c75dd1d4d28