### PR TITLE
Refactor icon loading to shared IconLoader

### DIFF
--- a/render/world_renderer.py
+++ b/render/world_renderer.py
@@ -6,10 +6,10 @@ import sys
 import queue
 import threading
 from collections import OrderedDict
-import json
-from pathlib import Path
 import pygame
-from typing import Dict, Optional, Tuple, Set, List, Sequence
+from typing import Optional, Tuple, Set, List, Sequence
+
+from loaders import icon_loader as IconLoader
 
 import constants
 import settings
@@ -76,19 +76,6 @@ class WorldRenderer:
             "corner": {c: assets.get(f"mask_{c}") for c in ("ne", "nw", "se", "sw")},
         }
         self._river_img = assets.get("terrain/river.png")
-
-        icons_file = (
-            Path(__file__).resolve().parents[1]
-            / "assets"
-            / "icons"
-            / "icons.json"
-        )
-        try:
-            with icons_file.open("r", encoding="utf8") as fh:
-                self._icon_manifest = json.load(fh)
-        except Exception:
-            self._icon_manifest = {}
-        self._icon_cache: Dict[Tuple[str, int], Optional[pygame.Surface]] = {}
 
     # ------------------------------------------------------------------
     # Cached biome chunk helpers
@@ -202,58 +189,6 @@ class WorldRenderer:
                 if start_cx <= cx < end_cx and start_cy <= cy < end_cy:
                     continue
                 self._queue_prefetch(cx, cy)
-
-    # ------------------------------------------------------------------
-    # Icon helper
-    def _load_icon(self, key: str, size: int) -> Optional[pygame.Surface]:
-        """Return icon ``key`` scaled to ``size`` or ``None`` on failure."""
-        cache_key = (key, size)
-        if cache_key in self._icon_cache:
-            return self._icon_cache[cache_key]
-
-        info = self._icon_manifest.get(key)
-        icon: Optional[pygame.Surface] = None
-        try:
-            assets_root = Path(__file__).resolve().parents[1]
-            if isinstance(info, str):
-                path = assets_root / info
-                if path.exists() and hasattr(pygame.image, "load"):
-                    icon = pygame.image.load(str(path))
-                    if hasattr(icon, "convert_alpha"):
-                        icon = icon.convert_alpha()
-            elif isinstance(info, dict) and "file" in info:
-                path = assets_root / info["file"]
-                if path.exists() and hasattr(pygame.image, "load"):
-                    icon = pygame.image.load(str(path))
-                    if hasattr(icon, "convert_alpha"):
-                        icon = icon.convert_alpha()
-            elif isinstance(info, dict) and "sheet" in info:
-                sheet_path = assets_root / info["sheet"]
-                coords = info.get("coords", [0, 0])
-                tile = info.get("tile", [0, 0])
-                if (
-                    sheet_path.exists()
-                    and tile[0]
-                    and tile[1]
-                    and hasattr(pygame.image, "load")
-                ):
-                    sheet = pygame.image.load(str(sheet_path))
-                    if hasattr(sheet, "convert_alpha"):
-                        sheet = sheet.convert_alpha()
-                    rect = pygame.Rect(
-                        coords[0] * tile[0],
-                        coords[1] * tile[1],
-                        tile[0],
-                        tile[1],
-                    )
-                    icon = sheet.subsurface(rect)
-            if icon and hasattr(pygame.transform, "scale"):
-                icon = pygame.transform.scale(icon, (size, size))
-        except Exception:
-            icon = None
-
-        self._icon_cache[cache_key] = icon
-        return icon
 
     # ------------------------------------------------------------------
     # Camera helpers
@@ -493,25 +428,11 @@ class WorldRenderer:
                 px = (x - start_x) * tile_size + offset_x
                 py = (y - start_y) * tile_size + offset_y
                 if tile.obstacle and tile.building is None:
-                    img = self._load_icon("obstacle", tile_size)
-                    if img:
-                        layers[constants.LAYER_OBJECTS].blit(img, (px, py))
-                    else:
-                        pygame.draw.rect(
-                            layers[constants.LAYER_OBJECTS],
-                            constants.GREY,
-                            (px, py, tile_size, tile_size),
-                        )
+                    img = IconLoader.get("obstacle", tile_size)
+                    layers[constants.LAYER_OBJECTS].blit(img, (px, py))
                 elif tile.treasure is not None:
-                    img = self._load_icon("treasure_chest", tile_size)
-                    if img:
-                        layers[constants.LAYER_OBJECTS].blit(img, (px, py))
-                    else:
-                        pygame.draw.rect(
-                            layers[constants.LAYER_OBJECTS],
-                            constants.YELLOW,
-                            (px, py, tile_size, tile_size),
-                        )
+                    img = IconLoader.get("treasure_chest", tile_size)
+                    layers[constants.LAYER_OBJECTS].blit(img, (px, py))
                 elif tile.building and tile.building not in drawn_buildings:
                     b = tile.building
                     drawn_buildings.add(b)

--- a/ui/inventory_screen.py
+++ b/ui/inventory_screen.py
@@ -10,9 +10,6 @@ Inventory & Hero screen – HoMM-like look:
 
 from __future__ import annotations
 from typing import Callable, Dict, List, Optional, Tuple, Set
-import json
-import os
-from pathlib import Path
 import pygame
 
 import constants
@@ -205,15 +202,6 @@ class InventoryScreen:
                 tooltip=name.title(),
             )
             self.tab_buttons[name] = btn
-
-        # Load icon manifest once
-        if not hasattr(self, "_icon_manifest"):
-            icons_path = os.path.join("assets", "icons", "icons.json")
-            try:
-                with open(icons_path, "r", encoding="utf8") as fh:
-                    self._icon_manifest = json.load(fh)
-            except Exception:  # pragma: no cover - file missing or invalid
-                self._icon_manifest = {}
 
         # Equipment slot grid (silhouette)
         cols, rows = 3, 4


### PR DESCRIPTION
## Summary
- Replace per-module icon manifest loading with `IconLoader.get`
- Remove bespoke icon caches and asset path joins for icons
- Use shared icon loader for UI widgets, town and combat screens, and world rendering

## Testing
- `pytest -q` *(fails: test_missing_building_sprite_logs_warning, test_select_spell_prefers_fireball_for_cluster)*

------
https://chatgpt.com/codex/tasks/task_e_68acd83089708321834af3aed2e779a7