### PR TITLE
feat(ui): allow custom icon sizes

### DIFF
--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -78,10 +78,12 @@ class MainScreen:
         self.menu_buttons: List[IconButton] = []
 
         def add_btn(icon_id: str, callback) -> None:
-            rect = pygame.Rect(0, 0, 48, 48)
+            rect = pygame.Rect(0, 0, *MENU_BUTTON_SIZE)
             cb = callback if callable(callback) else (lambda: None)
             tooltip = icon_id.replace("poi_", "").replace("_", " ").title()
-            self.menu_buttons.append(IconButton(rect, icon_id, cb, tooltip=tooltip))
+            self.menu_buttons.append(
+                IconButton(rect, icon_id, cb, tooltip=tooltip, size=MENU_BUTTON_SIZE)
+            )
 
         add_btn("poi_menu", getattr(game, "open_pause_menu", None))
         add_btn("poi_settings", getattr(game, "open_options", None))

--- a/ui/widgets/buttons_column.py
+++ b/ui/widgets/buttons_column.py
@@ -45,7 +45,14 @@ class ButtonsColumn:
             tooltip: str,
         ) -> None:
             rect = pygame.Rect(0, len(self.buttons) * (self.BUTTON_SIZE[1] + self.PADDING), *self.BUTTON_SIZE)
-            btn = IconButton(rect, icon_id, callback or (lambda: None), hotkey=hotkey, tooltip=tooltip)
+            btn = IconButton(
+                rect,
+                icon_id,
+                callback or (lambda: None),
+                hotkey=hotkey,
+                tooltip=tooltip,
+                size=self.BUTTON_SIZE,
+            )
             self.buttons.append(ButtonEntry(name, btn))
 
         add_button(
@@ -112,6 +119,7 @@ class ButtonsColumn:
                 cb or (lambda: None),
                 hotkey=hotkey,
                 tooltip=tooltip,
+                size=self.BUTTON_SIZE,
             )
             self.buttons.append(ButtonEntry(name, btn))
 

--- a/ui/widgets/icon_button.py
+++ b/ui/widgets/icon_button.py
@@ -26,6 +26,7 @@ class IconButton:
         callback: Callable[[], None],
         hotkey: Optional[int] = None,
         tooltip: str = "",
+        size: tuple[int, int] | None = None,
         enabled: bool = True,
     ) -> None:
         self.rect = rect
@@ -33,6 +34,7 @@ class IconButton:
         self.callback = callback
         self.hotkey = hotkey
         self.tooltip = tooltip
+        self.size = rect.size if size is None else size
         self.hovered = False
         self.pressed = False
         self.enabled = enabled
@@ -52,7 +54,9 @@ class IconButton:
         surface.fill(bg, self.rect)
         theme.draw_frame(surface, self.rect, frame_state)
 
-        icon = IconLoader.get(self.icon_id, self.rect.w)
+        width, height = self.size
+        size_min = min(width, height)
+        icon = IconLoader.get(self.icon_id, size_min)
         if icon is not None:
             icon_rect = icon.get_rect()
             icon_rect.center = self.rect.center


### PR DESCRIPTION
## Summary
- allow IconButton to accept explicit icon dimensions and scale icons using the smallest side
- propagate explicit button sizes in ButtonsColumn and main menu

## Testing
- `pytest -q` *(fails: tests/test_building_asset_warning.py::test_missing_building_sprite_logs_warning)*
- `FG_FAST_TESTS=0 pytest tests/test_building_asset_warning.py::test_missing_building_sprite_logs_warning -q -n0`
- `pytest tests/test_icon_button.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acdd9e3ddc8321b5eb8b3e262908b1