### PR TITLE
Use IconButton.collidepoint and remove rect usage

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -378,12 +378,12 @@ def handle_button_click(combat, current_unit, pos: Tuple[int, int]) -> bool:
     Returns ``True`` if the click was consumed by the UI.
     """
     mx, my = pos
-    if combat.auto_button and combat.auto_button.rect.collidepoint(mx, my):
+    if combat.auto_button and combat.auto_button.collidepoint((mx, my)):
         combat.auto_button.callback()
         return True
 
     for btn in combat.action_buttons.values():
-        if btn.enabled and btn.rect.collidepoint(mx, my):
+        if btn.enabled and btn.collidepoint((mx, my)):
             btn.callback()
             return True
     return False

--- a/ui/inventory_screen.py
+++ b/ui/inventory_screen.py
@@ -542,7 +542,7 @@ class InventoryScreen:
                     if e.button == 1:
                         # Tabs
                         for name, btn in self.tab_buttons.items():
-                            if btn.rect.collidepoint(pos):
+                            if btn.collidepoint(pos):
                                 btn.callback()
                                 break
                         else:

--- a/ui/widgets/buttons_column.py
+++ b/ui/widgets/buttons_column.py
@@ -141,7 +141,7 @@ class ButtonsColumn:
         if getattr(event, "type", None) == MOUSEMOTION:
             idx: Optional[int] = None
             for i, entry in enumerate(self.buttons):
-                if entry.button.rect.collidepoint(getattr(event, "pos", (0, 0))):
+                if entry.button.collidepoint(getattr(event, "pos", (0, 0))):
                     idx = i
                     break
             if idx != self.hover_index:
@@ -157,7 +157,7 @@ class ButtonsColumn:
     def get_tooltip(self, pos: Tuple[int, int], rect: pygame.Rect) -> Optional[str]:
         self._position_buttons(rect)
         for entry in self.buttons:
-            if entry.button.rect.collidepoint(pos) and entry.button.enabled:
+            if entry.button.collidepoint(pos) and entry.button.enabled:
                 return entry.button.tooltip
         return None
 

--- a/ui/widgets/icon_button.py
+++ b/ui/widgets/icon_button.py
@@ -41,6 +41,10 @@ class IconButton:
         self.font = theme.get_font(16)
 
     # ------------------------------------------------------------------
+    def collidepoint(self, pos: tuple[int, int]) -> bool:
+        return self.rect.collidepoint(pos)
+
+    # ------------------------------------------------------------------
     def draw(self, surface: pygame.Surface) -> None:
         """Render the button to ``surface``."""
 
@@ -75,15 +79,15 @@ class IconButton:
         if not self.enabled:
             return False
         if event.type == MOUSEMOTION:
-            self.hovered = self.rect.collidepoint(getattr(event, "pos", (0, 0)))
+            self.hovered = self.collidepoint(getattr(event, "pos", (0, 0)))
         elif event.type == MOUSEBUTTONDOWN and getattr(event, "button", 0) == 1:
-            if self.rect.collidepoint(getattr(event, "pos", (0, 0))):
+            if self.collidepoint(getattr(event, "pos", (0, 0))):
                 self.pressed = True
                 return True
         elif event.type == MOUSEBUTTONUP and getattr(event, "button", 0) == 1:
             if self.pressed:
                 self.pressed = False
-                if self.rect.collidepoint(getattr(event, "pos", (0, 0))):
+                if self.collidepoint(getattr(event, "pos", (0, 0))):
                     if self.callback:
                         self.callback()
                     return True


### PR DESCRIPTION
## Summary
- add collidepoint helper method to IconButton
- use IconButton.collidepoint in combat render, button column, and inventory screen

## Testing
- `pre-commit run --files ui/widgets/icon_button.py core/combat_render.py ui/widgets/buttons_column.py ui/inventory_screen.py` *(fails: Missing asset warning test)*
- `python - <<'PY'
from core.combat_render import handle_button_click
import pygame
from ui.widgets.icon_button import IconButton

class Combat:
    def __init__(self):
        self.action_buttons={}
        self.auto_button=IconButton(pygame.Rect(0,0,10,10),'',self.disable)
    def disable(self):
        self.auto_button=None

c=Combat()
handle_button_click(c,None,(5,5))
handle_button_click(c,None,(5,5))
print('done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aceaca4f688321bd213ec58afb695c