### PR TITLE
Use icon buttons for navigation

### DIFF
--- a/ui/inventory_screen.py
+++ b/ui/inventory_screen.py
@@ -188,6 +188,11 @@ class InventoryScreen:
         # Tab buttons
         self.tab_buttons: Dict[str, IconButton] = {}
         th = self.tabs_rect.height // len(self.TAB_NAMES)
+        icon_map = {
+            "stats": "nav_hero_screen",
+            "inventory": "nav_inventory",
+            "skills": "nav_skill_tree",
+        }
         for i, name in enumerate(self.TAB_NAMES):
             rect = pygame.Rect(
                 self.tabs_rect.x + 6,
@@ -195,9 +200,10 @@ class InventoryScreen:
                 self.tabs_rect.width - 12,
                 th - 12,
             )
+            icon_id = icon_map.get(name, f"{name}_tab")
             btn = IconButton(
                 rect,
-                f"{name}_tab",
+                icon_id,
                 lambda n=name: setattr(self, "active_tab", n),
                 tooltip=name.title(),
             )

--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -80,17 +80,22 @@ class MainScreen:
         def add_btn(icon_id: str, callback) -> None:
             rect = pygame.Rect(0, 0, *MENU_BUTTON_SIZE)
             cb = callback if callable(callback) else (lambda: None)
-            tooltip = icon_id.replace("poi_", "").replace("_", " ").title()
+            tooltip = icon_id.replace("nav_", "").replace("_", " ").title()
             self.menu_buttons.append(
                 IconButton(rect, icon_id, cb, tooltip=tooltip, size=MENU_BUTTON_SIZE)
             )
 
-        add_btn("poi_menu", getattr(game, "open_pause_menu", None))
-        add_btn("poi_settings", getattr(game, "open_options", None))
-        add_btn("poi_save", None)
-        add_btn("poi_load", None)
-        add_btn("poi_journal", getattr(game, "open_journal", None))
-        add_btn("poi_town", getattr(game, "open_town", None))
+        # Navigation / menu buttons
+        add_btn("nav_menu", self.open_menu)
+        add_btn("nav_settings", getattr(game, "open_options", None))
+        add_btn("nav_save", self.save_game)
+        add_btn("nav_load", self.load_game)
+        add_btn("nav_skill_tree", self.open_skill_tree)
+        add_btn("nav_journal", self.open_journal)
+        add_btn("nav_hero_screen", self.prev_hero)
+        add_btn("nav_town", self.next_town)
+        add_btn("nav_end_day", self.end_day)
+        add_btn("nav_pause", self.toggle_pause)
 
         self.army_panel = HeroArmyPanel(hero=getattr(game, "hero", None))
         self.turn_bar = TurnBar(
@@ -98,6 +103,60 @@ class MainScreen:
         )
         self.compute_layout(game.screen.get_width(), game.screen.get_height())
         EVENT_BUS.subscribe(ON_SEA_CHAIN_PROGRESS, self._on_sea_chain_progress)
+
+    # ------------------------------------------------------------------
+    # Button callbacks
+    # ------------------------------------------------------------------
+    def open_menu(self) -> None:
+        cb = getattr(self.game, "open_pause_menu", None) or getattr(
+            self.game, "open_menu", None
+        )
+        if cb:
+            cb()
+
+    def save_game(self) -> None:
+        cb = getattr(self.game, "save_game", None)
+        path = getattr(self.game, "default_save_path", None)
+        profile = getattr(self.game, "default_profile_path", None)
+        if cb and path:
+            cb(path, profile)
+
+    def load_game(self) -> None:
+        cb = getattr(self.game, "load_game", None)
+        path = getattr(self.game, "default_save_path", None)
+        profile = getattr(self.game, "default_profile_path", None)
+        if cb and path:
+            cb(path, profile)
+
+    def open_skill_tree(self) -> None:
+        cb = getattr(self.game, "open_skill_tree", None)
+        if cb:
+            cb()
+
+    def open_journal(self) -> None:
+        cb = getattr(self.game, "open_journal", None)
+        if cb:
+            cb()
+
+    def prev_hero(self) -> None:
+        cb = getattr(self.game, "prev_hero", None)
+        if cb:
+            cb()
+
+    def next_town(self) -> None:
+        cb = getattr(self.game, "next_town", None)
+        if cb:
+            cb()
+
+    def end_day(self) -> None:
+        cb = getattr(self.game, "end_day", None)
+        if cb:
+            cb()
+
+    def toggle_pause(self) -> None:
+        cb = getattr(self.game, "toggle_pause", None)
+        if cb:
+            cb()
 
     # ------------------------------------------------------------------
     # Layout


### PR DESCRIPTION
## Summary
- Replace text-based menu controls with icon buttons and add callbacks for saving, loading, journal, skill tree, and other actions.
- Switch inventory tabs to use navigation icons.

## Testing
- `pre-commit run --files ui/main_screen.py ui/inventory_screen.py` *(interrupted)*
- `pytest -q` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ad828fd0e08321bdaf2b2dd56526ce