### PR TITLE
Serialize hero items and harden save/load paths

### DIFF
--- a/tests/test_hero_serialization.py
+++ b/tests/test_hero_serialization.py
@@ -5,7 +5,14 @@ pygame_stub = types.SimpleNamespace()
 sys.modules.setdefault("pygame", pygame_stub)
 
 from core.game import Game
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import (
+    Hero,
+    Unit,
+    SWORDSMAN_STATS,
+    Item,
+    EquipmentSlot,
+    HeroStats,
+)
 from core.world import WorldMap
 
 
@@ -17,8 +24,21 @@ def test_serialization_roundtrip():
     hero.mana = 2
     hero.ap = 3
     hero.resources["wood"] = 5
-    hero.inventory = [Unit(SWORDSMAN_STATS, 5, "hero")]
-    hero.equipment = {"Head": Unit(SWORDSMAN_STATS, 1, "hero")}
+    hero.inventory = [
+        Item("potion", "Potion", None, "common", "", False, 1, HeroStats(0, 0, 0, 0, 0, 0, 0, 0, 0))
+    ]
+    hero.equipment = {
+        EquipmentSlot.HEAD: Item(
+            "helm",
+            "Helm",
+            EquipmentSlot.HEAD,
+            "common",
+            "",
+            False,
+            1,
+            HeroStats(0, 0, 0, 0, 0, 0, 0, 0, 0),
+        )
+    }
     hero.skill_tree["strength"] = 1
     hero.apply_bonuses_to_army()
     game.hero = hero

--- a/tests/test_save_load_roundtrip.py
+++ b/tests/test_save_load_roundtrip.py
@@ -6,7 +6,14 @@ pygame_stub = types.SimpleNamespace()
 sys.modules.setdefault("pygame", pygame_stub)
 
 from core.game import Game
-from core.entities import Unit, SWORDSMAN_STATS, Hero
+from core.entities import (
+    Unit,
+    SWORDSMAN_STATS,
+    Hero,
+    Item,
+    EquipmentSlot,
+    HeroStats,
+)
 from core.world import WorldMap
 from core.buildings import create_building
 
@@ -31,8 +38,21 @@ def test_save_load_roundtrip(tmp_path):
     game.hero.mana = 2
     game.hero.ap = 1
     game.hero.resources["wood"] = 4
-    game.hero.inventory = [Unit(SWORDSMAN_STATS, 3, "hero")]
-    game.hero.equipment = {"Head": Unit(SWORDSMAN_STATS, 1, "hero")}
+    game.hero.inventory = [
+        Item("potion", "Potion", None, "common", "", False, 1, HeroStats(0, 0, 0, 0, 0, 0, 0, 0, 0))
+    ]
+    game.hero.equipment = {
+        EquipmentSlot.HEAD: Item(
+            "helm",
+            "Helm",
+            EquipmentSlot.HEAD,
+            "common",
+            "",
+            False,
+            1,
+            HeroStats(0, 0, 0, 0, 0, 0, 0, 0, 0),
+        )
+    }
     game.hero.skill_tree["strength"] = 1
     game.hero.apply_bonuses_to_army()
 


### PR DESCRIPTION
## Summary
- Add `_item_to_dict` and `_item_from_dict` helpers and use them to save/load hero inventory and equipment
- Ensure save directories exist and validate save file path before loading
- Fix default save path creation and update tests for item-based inventory

## Testing
- `pytest tests/test_save_load_roundtrip.py tests/test_hero_serialization.py -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2f0d51c8321864ff0851a797f72