### PR TITLE
Add journal and hero UI methods and improve menu layout

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -2962,6 +2962,46 @@ class Game:
         quit_to_menu, self.screen = screen.run()
         return quit_to_menu
 
+    # ------------------------------------------------------------------
+    # Journal & Hero screens
+    # ------------------------------------------------------------------
+
+    def open_journal(self) -> None:
+        """Open the quest journal.
+
+        The project does not yet provide a dedicated journal interface, so
+        the method simply notifies the user.  A full implementation can hook
+        into :class:`state.quests.QuestManager` to display active quests.
+        """
+
+        self._notify("Journal not implemented")
+
+    def open_skill_tree(self, tab: str = "skills") -> bool:
+        """Convenience wrapper opening the hero screen on the skills tab."""
+
+        return self.open_hero_screen(tab)
+
+    def open_hero_screen(self, tab: str = "stats") -> bool:
+        """Open the hero screen with ``tab`` active.
+
+        Parameters
+        ----------
+        tab:
+            Name of the tab to activate (``"stats"`` or ``"skills"``).
+
+        Returns
+        -------
+        bool
+            ``True`` if the player exited to the main menu.
+        """
+
+        screen = InventoryScreen(
+            self.screen, self.assets, self.hero, self.clock, self.open_pause_menu
+        )
+        screen.active_tab = tab
+        quit_to_menu, self.screen = screen.run()
+        return quit_to_menu
+
     def open_town(
         self,
         town: Optional[Town] = None,


### PR DESCRIPTION
## Summary
- Add `open_journal`, `open_skill_tree`, and `open_hero_screen` helper methods on the `Game` class
- Wire main screen buttons to new game methods
- Layout menu buttons in up to two columns when vertical space is insufficient

## Testing
- `pytest tests/test_main_screen_layout.py tests/test_main_screen_events.py tests/test_buttons_column.py -q` *(hangs, no output)*

------
https://chatgpt.com/codex/tasks/task_e_68adba62ebd0832195f93eb67db917b4