### PR TITLE
Use new stat icon identifiers

### DIFF
--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -56,13 +56,13 @@ class CombatHUD:
         }
         self.stat_icon_keys = {
             "hp": "stat_hp",
-            "mana": "round_mana",
-            "attack": "round_attack_range",
-            "defence": "round_defence_magic",
-            "speed": "resource_speed",
-            "initiative": "resource_speed",
-            "morale": "round_morale",
-            "luck": "round_luck",
+            "mana": "stat_mana",
+            "attack": "stat_attack_range",
+            "defence": "stat_defence_magic",
+            "speed": "stat_speed",
+            "initiative": "stat_initiative",
+            "morale": "stat_morale",
+            "luck": "stat_luck",
             # Elemental resistances
             "fire": "status_burn",
             "ice": "status_freeze",

--- a/ui/inventory_tabs/stats.py
+++ b/ui/inventory_tabs/stats.py
@@ -16,15 +16,15 @@ from ..inventory_screen import (
 )
 
 _STAT_ICON_IDS = {
-    "HP": "status_regeneration",
-    "Dmg": "round_attack_range",
-    "Spd": "status_haste",
-    "Init": "resource_speed",
-    "Def Melee": "action_defend",
-    "Def Ranged": "action_shoot",
-    "Def Magic": "round_defence_magic",
-    "Morale": "round_morale",
-    "Luck": "round_luck",
+    "HP": "stat_hp",
+    "Dmg": "stat_attack_range",
+    "Spd": "stat_speed",
+    "Init": "stat_initiative",
+    "Def Melee": "stat_defence_melee",
+    "Def Ranged": "stat_defence_ranged",
+    "Def Magic": "stat_defence_magic",
+    "Morale": "stat_morale",
+    "Luck": "stat_luck",
     # Elemental resistances
     "fire": "status_burn",
     "ice": "status_freeze",


### PR DESCRIPTION
## Summary
- replace obsolete round_* and resource_* icon keys with stat_* variants for combat HUD
- update inventory stats tab to use stat_* icons

## Testing
- `python - <<'PY'
from loaders import icon_loader as IconLoader
keys = ["stat_mana", "stat_speed", "stat_initiative", "stat_morale", "stat_luck", "stat_attack_range", "stat_defence_magic", "stat_defence_melee", "stat_defence_ranged", "stat_hp"]
for k in keys:
    icon = IconLoader.get(k, 18)
    print(k, bool(icon))
PY`
- `pytest` *(fails: tests/test_world_ai.py::test_enemy_targets_hero_after_resource_collected)*

------
https://chatgpt.com/codex/tasks/task_e_68adcac5990483219ecd25cdedf7e13b