### PR TITLE
Centralize terrain movement costs

### DIFF
--- a/assets/biomes/biomes.json
+++ b/assets/biomes/biomes.json
@@ -16,7 +16,6 @@
       "garnet_shard",
       "torn_battle_banner"
     ],
-    "terrain_cost": 1,
     "vision_bonus": 0,
     "passable": true,
     "overlays": []
@@ -38,7 +37,6 @@
       "scarlet_herb_a"
 
     ],
-    "terrain_cost": 1,
     "vision_bonus": 0,
     "passable": true,
     "overlays": []
@@ -61,7 +59,6 @@
       "garnet_shard",
       "basalt_spire"
     ],
-    "terrain_cost": 2,
     "vision_bonus": 0,
     "passable": true,
     "overlays": [

--- a/constants.py
+++ b/constants.py
@@ -106,6 +106,17 @@ IMPASSABLE_BIOMES = {"mountain", "river"}
 # passable but movement is restricted to units currently embarked on a naval
 # vessel.
 WATER_BIOMES = {"ocean"}
+TERRAIN_COSTS = {
+    "terre": 1.0,
+    "plain": 1.0,
+    "forest": 1.0,
+    "volcanic": 1.25,
+    "underground": 1.0,
+    "road": 1.0,
+    "desert": 1.25,
+    "snow": 1.5,
+    "swamp": 1.75,
+}
 ROAD_COST = 1  # AP cost when moving along a road
 TILE_SIZE = 64  # pixel size of each square on the exploration map
 # Rendering layers – lower indices are drawn first

--- a/core/entities.py
+++ b/core/entities.py
@@ -269,7 +269,7 @@ class UnitCarrier(Protocol):
 
     x: int
     y: int
-    ap: int
+    ap: float
     units: List[Unit]
     name: str
     portrait: Any | None
@@ -286,8 +286,8 @@ class Army(UnitCarrier):
     x: int
     y: int
     units: List[Unit] = field(default_factory=list)
-    ap: int = 0
-    max_ap: int = 0
+    ap: float = 0.0
+    max_ap: float = 0.0
     name: str = "Army"
     portrait: Any | None = None
 
@@ -350,12 +350,12 @@ class Boat(UnitCarrier):
     capacity: int
     owner: int | None
     garrison: List[Unit] = field(default_factory=list)
-    ap: int = 0
+    ap: float = 0.0
     name: str = "Boat"
     portrait: Any | None = None
 
     def __post_init__(self) -> None:
-        self.ap = self.movement
+        self.ap = float(self.movement)
 
     @property
     def units(self) -> List[Unit]:  # Alias required by UnitCarrier

--- a/core/game.py
+++ b/core/game.py
@@ -486,7 +486,7 @@ class Game:
         # Cached path for rendering movement arrows
         self.path: List[Tuple[int, int]] = []
         # Cumulative AP cost for each step in ``self.path``
-        self.path_costs: List[int] = []
+        self.path_costs: List[float] = []
         self.path_target: Optional[Tuple[int, int]] = None
         # Pre-tinted arrow images used for path visualisation
         self.arrow_green: Optional[pygame.Surface] = None
@@ -1041,9 +1041,9 @@ class Game:
         if start == goal:
             return ()
 
-        frontier: List[Tuple[int, Tuple[int, int]]] = [(0, start)]
+        frontier: List[Tuple[float, Tuple[int, int]]] = [(0.0, start)]
         came_from: Dict[Tuple[int, int], Optional[Tuple[int, int]]] = {start: None}
-        cost_so_far: Dict[Tuple[int, int], int] = {start: 0}
+        cost_so_far: Dict[Tuple[int, int], float] = {start: 0.0}
         actor = getattr(self, "active_actor", getattr(self, "hero", None))
         has_boat = isinstance(actor, Hero) and getattr(actor, "naval_unit", None) is not None
 
@@ -1095,10 +1095,10 @@ class Game:
                         continue
                 biome = BiomeCatalog.get(tile.biome)
                 if getattr(tile, "road", False):
-                    step_cost = constants.ROAD_COST
+                    step_cost = float(constants.ROAD_COST)
                 else:
-                    step_cost = biome.terrain_cost if biome else 1
-                extra = 0
+                    step_cost = float(biome.terrain_cost if biome else 1)
+                extra = 0.0
                 if has_boat:
                     cur_tile = self.world.grid[y][x]
                     cur_water = cur_tile.biome in constants.WATER_BIOMES
@@ -1167,16 +1167,16 @@ class Game:
         )
         if not self.world.in_bounds(mx, my):
             return
-        def calc_costs(p: List[Tuple[int, int]]) -> List[int]:
-            costs: List[int] = []
-            total = 0
+        def calc_costs(p: List[Tuple[int, int]]) -> List[float]:
+            costs: List[float] = []
+            total = 0.0
             for x, y in p:
                 tile = self.world.grid[y][x]
                 biome = BiomeCatalog.get(tile.biome)
                 if getattr(tile, "road", False):
-                    step_cost = constants.ROAD_COST
+                    step_cost = float(constants.ROAD_COST)
                 else:
-                    step_cost = biome.terrain_cost if biome else 1
+                    step_cost = float(biome.terrain_cost if biome else 1)
                 total += step_cost
                 costs.append(total)
             return costs
@@ -1722,8 +1722,10 @@ class Game:
                 return
         tile = self.world.grid[ny][nx]
         biome = BiomeCatalog.get(tile.biome)
-        step_cost = constants.ROAD_COST if getattr(tile, "road", False) else (
-            biome.terrain_cost if biome else 1
+        step_cost = float(
+            constants.ROAD_COST if getattr(tile, "road", False) else (
+                biome.terrain_cost if biome else 1
+            )
         )
         if actor.ap < step_cost:
             return
@@ -1954,18 +1956,18 @@ class Game:
         tile = self.world.grid[ny][nx]
         biome = BiomeCatalog.get(tile.biome)
         if getattr(tile, "road", False):
-            step_cost = constants.ROAD_COST
+            step_cost = float(constants.ROAD_COST)
         else:
-            step_cost = biome.terrain_cost if biome else 1
+            step_cost = float(biome.terrain_cost if biome else 1)
         has_boat = getattr(self.hero, "naval_unit", None) is not None
         prev_tile = self.world.grid[prev_y][prev_x]
-        extra = 0
+        extra = 0.0
         landed = False
         if has_boat:
             cur_water = prev_tile.biome in constants.WATER_BIOMES
             next_water = tile.biome in constants.WATER_BIOMES
             if cur_water != next_water:
-                extra = 1
+                extra = 1.0
                 if cur_water and not next_water:
                     landed = True
         if self.hero.ap < step_cost + extra:
@@ -2821,7 +2823,7 @@ class Game:
             tile = self.world.grid[sy][sx]
             if tile.building and isinstance(tile.building, Town) and not tile.building.passable:
                 biome = BiomeCatalog.get(tile.biome)
-                step_cost = (
+                step_cost = float(
                     constants.ROAD_COST
                     if getattr(tile, "road", False)
                     else (biome.terrain_cost if biome else 1)

--- a/core/vision.py
+++ b/core/vision.py
@@ -34,7 +34,7 @@ def compute_vision(
 
     visible: Set[Tuple[int, int]] = set()
     start = (actor.x, actor.y)
-    queue: list[Tuple[int, Tuple[int, int]]] = [(0, start)]
+    queue: list[Tuple[float, Tuple[int, int]]] = [(0.0, start)]
     visited: Set[Tuple[int, int]] = set()
     while queue:
         cost, (x, y) = heapq.heappop(queue)
@@ -51,11 +51,11 @@ def compute_vision(
             tile = world.grid[ny][nx]
             biome = BiomeCatalog.get(tile.biome)
             if getattr(tile, "road", False):
-                move_cost = constants.ROAD_COST
+                move_cost = float(constants.ROAD_COST)
             elif biome is not None:
-                move_cost = getattr(biome, "terrain_cost", 1)
+                move_cost = float(getattr(biome, "terrain_cost", 1))
             else:
-                move_cost = 1
+                move_cost = 1.0
             new_cost = cost + move_cost
             if new_cost > radius:
                 continue

--- a/loaders/biomes.py
+++ b/loaders/biomes.py
@@ -20,7 +20,7 @@ class Biome:
     variants: int
     colour: Tuple[int, int, int]
     flora: List[str]
-    terrain_cost: int = 1
+    terrain_cost: float = 1.0
     passable: bool = True
     overlays: List[str] = field(default_factory=list)
     vision_bonus: int = 0
@@ -63,7 +63,9 @@ class BiomeCatalog:
                 variants=int(entry.get("variants", 1)),
                 colour=tuple(colour),
                 flora=list(entry.get("flora", [])),
-                terrain_cost=int(entry.get("terrain_cost", entry.get("movement_cost", 1))),
+                terrain_cost=float(
+                    constants.TERRAIN_COSTS.get(entry.get("type", ""), 1.0)
+                ),
                 passable=bool(entry.get("passable", True)),
                 overlays=list(entry.get("overlays", [])),
                 vision_bonus=int(entry.get("vision_bonus", 0)),

--- a/tests/test_multi_terrain_movement.py
+++ b/tests/test_multi_terrain_movement.py
@@ -20,20 +20,34 @@ def setup_game(monkeypatch, pygame_stub):
     from core.world import WorldMap
     from core.entities import Hero, Unit, SWORDSMAN_STATS
     from core.game import Game
-    from loaders.biomes import BiomeCatalog
+    from loaders.biomes import BiomeCatalog, Biome
     from loaders.core import Context
     import constants, os
     repo_root = os.path.dirname(os.path.dirname(__file__))
     ctx = Context(repo_root=repo_root, search_paths=["assets"], asset_loader=None)
     BiomeCatalog.load(ctx)
+    # Add custom swamp biome using constants table
+    swamp_biome = Biome(
+        id="swamp",
+        type="swamp",
+        description="",
+        path="",
+        variants=1,
+        colour=(0, 0, 0),
+        flora=[],
+        terrain_cost=constants.TERRAIN_COSTS["swamp"],
+    )
+    BiomeCatalog._biomes["swamp"] = swamp_biome
     game = Game.__new__(Game)
-    wm = WorldMap(width=2, height=1, biome_weights={"scarletia_volcanic": 1.0}, num_obstacles=0, num_treasures=0, num_enemies=0)
-    for x in range(2):
+    wm = WorldMap(width=3, height=1, biome_weights={"scarletia_echo_plain": 1.0}, num_obstacles=0, num_treasures=0, num_enemies=0)
+    for x in range(3):
         wm.grid[0][x].obstacle = False
+    wm.grid[0][1].biome = "scarletia_volcanic"
+    wm.grid[0][2].biome = "swamp"
     game.world = wm
-    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, 'hero')])
-    hero.ap = 5
-    hero.max_ap = 5
+    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])
+    hero.ap = 10
+    hero.max_ap = 10
     game.hero = hero
     game.offset_x = 0
     game.offset_y = 0
@@ -41,7 +55,7 @@ def setup_game(monkeypatch, pygame_stub):
     game.path = []
     game.move_queue = []
     game.path_target = None
-    game.compute_path = lambda *a, **k: [(1, 0)]
+    game.compute_path = lambda *a, **k: [(1, 0), (2, 0)]
     game._publish_resources = lambda: None
     game.main_screen = types.SimpleNamespace(widgets={})
     game.ui_panel_rect = types.SimpleNamespace(y=1000)
@@ -50,15 +64,12 @@ def setup_game(monkeypatch, pygame_stub):
     return game, constants
 
 
-def test_terrain_cost_deducted(monkeypatch, pygame_stub):
+def test_multi_terrain_ap_cost(monkeypatch, pygame_stub):
     game, constants = setup_game(monkeypatch, pygame_stub)
     game.try_move_hero(1, 0)
-    assert game.hero.ap == pytest.approx(3.75)
-    assert (game.hero.x, game.hero.y) == (1, 0)
-
-def test_road_cost_bonus(monkeypatch, pygame_stub):
-    game, constants = setup_game(monkeypatch, pygame_stub)
-    game.world.grid[0][1].road = True
     game.try_move_hero(1, 0)
-    assert game.hero.ap == 5 - constants.ROAD_COST
-    assert (game.hero.x, game.hero.y) == (1, 0)
+    expected = 10 - (
+        constants.TERRAIN_COSTS["volcanic"] + constants.TERRAIN_COSTS["swamp"]
+    )
+    assert game.hero.ap == pytest.approx(expected)
+    assert (game.hero.x, game.hero.y) == (2, 0)

--- a/tests/test_vision_bonus.py
+++ b/tests/test_vision_bonus.py
@@ -18,7 +18,7 @@ def test_vision_bonus_extends_visibility(monkeypatch):
         variants=1,
         colour=(0, 0, 0),
         flora=[],
-        terrain_cost=1,
+        terrain_cost=1.0,
         passable=True,
         overlays=[],
         vision_bonus=2,


### PR DESCRIPTION
## Summary
- Centralize terrain movement multipliers in `constants.TERRAIN_COSTS`
- Load biome movement costs from the unified table and handle pathfinding/AP as floats
- Cover movement across mixed terrains with a new test

## Testing
- `pytest tests/test_movement_cost.py tests/test_multi_terrain_movement.py tests/test_vision_bonus.py`
- `pytest` *(full suite)*


------
https://chatgpt.com/codex/tasks/task_e_68addc7111bc8321bcb4ae9861102953