### PR TITLE
Ensure dead stacks are cleaned up after combat

### DIFF
--- a/tests/test_combat_cleanup.py
+++ b/tests/test_combat_cleanup.py
@@ -1,0 +1,31 @@
+import pygame
+
+from core.entities import Unit, SWORDSMAN_STATS
+import audio
+import core.combat_render as combat_render
+
+
+def test_combat_clears_dead_stacks(monkeypatch, simple_combat):
+    hero = Unit(SWORDSMAN_STATS, 3, 'hero')
+    enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
+    combat = simple_combat([hero], [enemy])
+    combat.auto_mode = True
+    combat._auto_resolve_done = True
+
+    monkeypatch.setattr(pygame.event, 'get', lambda: [])
+    monkeypatch.setattr(pygame.display, 'flip', lambda: None)
+    monkeypatch.setattr(pygame.time, 'wait', lambda ms: None)
+
+    class DummyClock:
+        def tick(self, fps):
+            pass
+
+    monkeypatch.setattr(pygame.time, 'Clock', lambda: DummyClock())
+    monkeypatch.setattr(combat_render, 'draw', lambda *a, **k: None)
+    monkeypatch.setattr(audio, 'play_sound', lambda *a, **k: None)
+
+    hero_wins, _ = combat.run()
+    assert hero_wins
+    assert combat.enemy_units == []
+    assert all(u.count > 0 for u in combat.hero_units)
+    assert all(u.count > 0 for u in combat.units)


### PR DESCRIPTION
## Summary
- purge defeated units from combat state and grant loot without showing the stats screen
- update game armies based on combat survivors and refresh map UI
- add regression test covering combat cleanup

## Testing
- `pre-commit run --files core/combat.py core/game.py tests/test_combat_cleanup.py` *(fails: command not found)*
- `pytest tests/test_combat_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_68ade1fd66cc8321a9fc1e4d8cf99f58