### PR TITLE
Trigger FOW updates and refresh minimap on movement

### DIFF
--- a/ui/minimap.py
+++ b/ui/minimap.py
@@ -1,0 +1,3 @@
+from .widgets.minimap import Minimap, MOUSEBUTTONDOWN, MOUSEBUTTONUP, MOUSEMOTION
+
+__all__ = ["Minimap", "MOUSEBUTTONDOWN", "MOUSEBUTTONUP", "MOUSEMOTION"]


### PR DESCRIPTION
## Summary
- centralize fog-of-war recomputation in `core/vision.update_player_visibility`
- update `Game` to invoke vision FOW recalculation after moves and turns
- allow minimap to resize and keep fog overlay, re-exported as `ui.minimap`
- cover minimap resize and movement integration with tests

## Testing
- `pytest tests/test_world_ai.py tests/test_minimap.py -q -n0`


------
https://chatgpt.com/codex/tasks/task_e_68ade4ad6454832193c64da809053982