### PR TITLE
Add demo scenario and loading test

### DIFF
--- a/assets/scenarios/demo.json
+++ b/assets/scenarios/demo.json
@@ -1,0 +1,21 @@
+{
+  "name": "demo",
+  "players": [
+    {"cities": [{"name": "PlayerTown", "x": 1, "y": 1}]}
+  ],
+  "ai": [
+    {"cities": [{"name": "EnemyTown", "x": 5, "y": 5}]}
+  ],
+  "mines": [
+    {"type": "gold", "x": 3, "y": 2},
+    {"type": "wood", "x": 6, "y": 4},
+    {"type": "ore", "x": 8, "y": 1}
+  ],
+  "encounters": [
+    {"type": "goblins", "x": 4, "y": 6},
+    {"type": "wolves", "x": 7, "y": 3}
+  ],
+  "artifacts": [
+    {"name": "Ancient Relic", "x": 2, "y": 5}
+  ]
+}

--- a/loaders/scenario_loader.py
+++ b/loaders/scenario_loader.py
@@ -13,6 +13,12 @@ weight and uses JSON for ease of authoring::
 
 Only the fields that are understood by the engine are processed; unknown keys
 are ignored to allow forward compatible extensions.
+
+For tests and demonstrations a small scenario is bundled with the project at
+``assets/scenarios/demo.json``.  It can be loaded directly::
+
+    from loaders.scenario_loader import load_scenario
+    data = load_scenario("assets/scenarios/demo.json")
 """
 
 from __future__ import annotations

--- a/tests/test_demo_scenario_loader.py
+++ b/tests/test_demo_scenario_loader.py
@@ -1,0 +1,14 @@
+from loaders.scenario_loader import load_scenario
+
+
+def test_demo_scenario_contents():
+    data = load_scenario("assets/scenarios/demo.json")
+    assert data["name"] == "demo"
+    assert len(data["players"]) == 1
+    assert len(data["players"][0]["cities"]) == 1
+    assert len(data["ai"]) == 1
+    assert len(data["ai"][0]["cities"]) == 1
+    assert len(data["mines"]) == 3
+    assert len(data["encounters"]) == 2
+    assert len(data["artifacts"]) == 1
+


### PR DESCRIPTION
## Summary
- add demo scenario JSON with player city, AI opponent, mines, encounters and artifact
- document demo scenario loading in scenario loader
- cover demo scenario with a loading test

## Testing
- `PYTEST_ADDOPTS=tests/test_demo_scenario_loader.py pre-commit run --files assets/scenarios/demo.json loaders/scenario_loader.py tests/test_demo_scenario_loader.py`
- `pytest tests/test_demo_scenario_loader.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68adec04d8ec832186604b9b573c0e96