### PR TITLE
Centralize UI formatting helpers

### DIFF
--- a/theme.py
+++ b/theme.py
@@ -46,6 +46,28 @@ def get_font(size: int = 16):
 
 
 # ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def format_number(value: int | float) -> str:
+    """Return a string representation for ``value``.
+
+    Centralising this logic in the theme allows widgets to stay consistent and
+    enables future customisation (e.g. thousands separators) without touching
+    individual widgets.
+    """
+
+    return f"{value}"
+
+
+def format_delta(value: int) -> str:
+    """Return a signed numeric string for deltas such as ``+5`` or ``-2``."""
+
+    return f"{value:+d}"
+
+
+# ---------------------------------------------------------------------------
 # Frame rendering
 # ---------------------------------------------------------------------------
 _FRAME_CACHE: dict[tuple[int, int, int], tuple["pygame.Surface", "pygame.Surface", "pygame.Surface"]] = {}

--- a/ui/widgets/desc_bar.py
+++ b/ui/widgets/desc_bar.py
@@ -13,7 +13,7 @@ from typing import Optional, Tuple
 
 import pygame
 
-from .. import constants
+from .. import constants, theme
 from ..state.event_bus import EVENT_BUS, ON_INFO_MESSAGE
 
 # Colours used for different probe types
@@ -30,13 +30,10 @@ class DescBar:
     """Display a one-line description with colour coding."""
 
     def __init__(self) -> None:
-        # Default font; size chosen to comfortably fit inside UI panels.  Some
-        # test environments provide a very small pygame stub without the font
-        # module; handle this gracefully by falling back to ``None``.
-        try:
-            self.font = pygame.font.Font(None, 24)
-        except Exception:  # pragma: no cover - missing font module
-            self.font = None
+        # Default font; size chosen to comfortably fit inside UI panels.
+        # ``theme.get_font`` gracefully handles environments where the font
+        # module is unavailable.
+        self.font = theme.get_font(24)
         self.text: str = ""
         self.colour: Tuple[int, int, int] = constants.WHITE
         self._message_timer = 0

--- a/ui/widgets/hero_army_panel.py
+++ b/ui/widgets/hero_army_panel.py
@@ -59,10 +59,7 @@ class HeroArmyPanel:
         self.portrait = self._make_portrait()
         if hero is not None:
             self.set_hero(hero)
-        try:  # pragma: no cover - font module may be missing
-            self.font = pygame.font.SysFont(None, 16)
-        except Exception:  # pragma: no cover - font module missing
-            self.font = None
+        self.font = theme.get_font(16)
         self.drag: Optional[_DragState] = None
         # Update displayed hero when selection changes
         EVENT_BUS.subscribe(ON_SELECT_HERO, self.set_hero)
@@ -225,7 +222,7 @@ class HeroArmyPanel:
         surface.blit(self.portrait, p_rect)
         if self.font and self.hero:
             name = getattr(self.hero, "name", "Hero")
-            name_s = self.font.render(name, True, (230,230,235))
+            name_s = self.font.render(name, True, theme.PALETTE["text"])
             name_pos = (
                 p_rect.x + (p_rect.width - name_s.get_width()) // 2,
                 p_rect.y + p_rect.height + 4,
@@ -254,8 +251,12 @@ class HeroArmyPanel:
             if icon: surface.blit(icon, cell.topleft)
             # count + barre HP
             if self.font:
-                count = self.font.render(str(getattr(unit, "count", 0)), True, (230,230,235))
-                surface.blit(count, (cell.x+2, cell.y+2))
+                count = self.font.render(
+                    theme.format_number(getattr(unit, "count", 0)),
+                    True,
+                    theme.PALETTE["text"],
+                )
+                surface.blit(count, (cell.x + 2, cell.y + 2))
             max_hp = getattr(getattr(unit, "stats", None), "max_hp", 0)
             cur_hp = getattr(unit, "current_hp", 0)
             if max_hp > 0:
@@ -276,7 +277,7 @@ class HeroArmyPanel:
                 pygame.draw.rect(surface, (74, 76, 86), brect, 1)
                 if self.selected_formation == key:
                     pygame.draw.rect(surface, (200, 200, 80), brect, 2)
-                text = self.font.render(label, True, (230, 230, 235))
+                text = self.font.render(label, True, theme.PALETTE["text"])
                 surface.blit(
                     text,
                     (

--- a/ui/widgets/hero_list.py
+++ b/ui/widgets/hero_list.py
@@ -169,7 +169,10 @@ class HeroList:
             return None
         hero = self._heroes[idx].actor
         name = getattr(hero, "name", "Hero")
-        return f"{name} – ({hero.x}, {hero.y})\nGo to"
+        return (
+            f"{name} – (" 
+            f"{theme.format_number(hero.x)}, {theme.format_number(hero.y)})\nGo to"
+        )
 
     def draw(self, surface: pygame.Surface, rect: pygame.Rect) -> None:
         """Draw the hero list to ``surface`` within ``rect``."""
@@ -187,5 +190,7 @@ class HeroList:
                 name_surf = self.font.render(name, True, theme.PALETTE["text"])
                 surface.blit(name_surf, (card.x + self.CARD_SIZE + 4, card.y + 4))
                 ap = getattr(info.actor, "ap", 0)
-                ap_surf = self.font.render(str(ap), True, theme.PALETTE["text"])
+                ap_surf = self.font.render(
+                    theme.format_number(ap), True, theme.PALETTE["text"]
+                )
                 surface.blit(ap_surf, (card.x + self.CARD_SIZE + 4, card.bottom - ap_surf.get_height() - 4))

--- a/ui/widgets/resources_bar.py
+++ b/ui/widgets/resources_bar.py
@@ -81,13 +81,17 @@ class ResourcesBar:
             pos = (x, y_center - icon.get_height() // 2)
             surface.blit(icon, pos)
             x += icon.get_width() + 4
-            txt_surface = self.font.render(str(value), True, theme.PALETTE["text"])
+            txt_surface = self.font.render(
+                theme.format_number(value), True, theme.PALETTE["text"]
+            )
             surface.blit(txt_surface, (x, y_center - txt_surface.get_height() // 2))
             # Draw delta animations above the value
             if self.show_delta:
                 for anim in self._deltas.get(name, []):
                     colour = constants.GREEN if anim.amount > 0 else constants.RED
-                    delta_surf = self.font.render(f"{anim.amount:+d}", True, colour)
+                    delta_surf = self.font.render(
+                        theme.format_delta(anim.amount), True, colour
+                    )
                     dy = y_center - txt_surface.get_height() // 2 + anim.offset
                     surface.blit(delta_surf, (x, dy))
             x += txt_surface.get_width() + 20


### PR DESCRIPTION
## Summary
- centralize number and delta formatting in `ui.theme`
- use theme helpers for fonts and text color across widgets
- update resource, hero list and army widgets to render using shared formatters

## Testing
- `pre-commit run --files theme.py ui/widgets/desc_bar.py ui/widgets/hero_army_panel.py ui/widgets/hero_list.py ui/widgets/resources_bar.py` *(interrupted: KeyboardInterrupt)*
- `pytest -q` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68adf78290b083219315c7b9d6eabe83