### PR TITLE
feat: expose more UI settings

### DIFF
--- a/render/world_renderer.py
+++ b/render/world_renderer.py
@@ -42,7 +42,7 @@ class WorldRenderer:
     def __init__(
         self,
         assets: object,
-        pan_speed: int = 20,
+        pan_speed: int = settings.SCROLL_SPEED,
         player_colour: Tuple[int, int, int] = constants.BLUE,
         game: Optional[object] = None,
     ) -> None:

--- a/settings.json
+++ b/settings.json
@@ -5,6 +5,8 @@
   "debug_buildings": false,
   "ai_difficulty": "Intermédiaire",
   "language": "en",
+  "volume": 1.0,
+  "scroll_speed": 20,
   "keymap": {
     "pan_left": ["K_LEFT", "K_a"],
     "pan_right": ["K_RIGHT", "K_d"],

--- a/settings.py
+++ b/settings.py
@@ -39,6 +39,34 @@ def _get_str(env_var: str, key: str, default: str) -> str:
     return str(_FILE_SETTINGS.get(key, default))
 
 
+def _get_int(env_var: str, key: str, default: int) -> int:
+    """Return an integer setting from environment or JSON."""
+    value = os.environ.get(env_var)
+    if value is not None:
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    try:
+        return int(_FILE_SETTINGS.get(key, default))
+    except Exception:
+        return default
+
+
+def _get_float(env_var: str, key: str, default: float) -> float:
+    """Return a float setting from environment or JSON."""
+    value = os.environ.get(env_var)
+    if value is not None:
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    try:
+        return float(_FILE_SETTINGS.get(key, default))
+    except Exception:
+        return default
+
+
 # ---------------------------------------------------------------------------
 # Public settings
 # ---------------------------------------------------------------------------
@@ -47,6 +75,12 @@ DEBUG_BUILDINGS: bool = _get_bool("FG_DEBUG_BUILDINGS", "debug_buildings", False
 
 # Language used for UI text
 LANGUAGE: str = _get_str("FG_LANGUAGE", "language", "en")
+
+# Master audio volume (0.0 - 1.0)
+VOLUME: float = _get_float("FG_VOLUME", "volume", 1.0)
+
+# Map scroll speed in pixels per key press
+SCROLL_SPEED: int = _get_int("FG_SCROLL_SPEED", "scroll_speed", 20)
 
 _DEFAULT_KEYMAP: Dict[str, List[str]] = {
     "pan_left": ["K_LEFT", "K_a"],
@@ -60,4 +94,25 @@ _DEFAULT_KEYMAP: Dict[str, List[str]] = {
 _FILE_KEYMAP = _FILE_SETTINGS.get("keymap", {}) if isinstance(_FILE_SETTINGS, dict) else {}
 KEYMAP: Dict[str, List[str]] = {**_DEFAULT_KEYMAP, **_FILE_KEYMAP}
 
-__all__ = ["DEBUG_BUILDINGS", "LANGUAGE", "KEYMAP"]
+def save_settings(**kwargs: Any) -> None:
+    """Persist ``kwargs`` to :data:`SETTINGS_FILE`."""
+    data: Dict[str, Any] = {}
+    if SETTINGS_FILE.exists():
+        try:
+            with SETTINGS_FILE.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            data = {}
+    data.update(kwargs)
+    with SETTINGS_FILE.open("w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+__all__ = [
+    "DEBUG_BUILDINGS",
+    "LANGUAGE",
+    "VOLUME",
+    "SCROLL_SPEED",
+    "KEYMAP",
+    "save_settings",
+]

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -100,10 +100,10 @@ def test_options_menu_shows_translated_difficulties(monkeypatch):
     def fake_menu(_screen, options, title=''):
         calls.append(options)
         if len(calls) == 1:  # Open difficulty selection
-            return 3, _screen
+            return 5, _screen
         if len(calls) == 2:  # Difficulty options displayed
             return None, _screen
-        return 6, _screen  # Exit options menu
+        return 9, _screen  # Exit options menu
 
     monkeypatch.setattr(options_menu, 'simple_menu', fake_menu)
 

--- a/ui/options_menu.py
+++ b/ui/options_menu.py
@@ -97,6 +97,7 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
 
     music = audio.get_music_volume()
     sfx = audio.get_sfx_volume()
+    volume = settings.VOLUME
     fullscreen = _load_fullscreen()
     difficulties = list(constants.AI_DIFFICULTIES)
     labels = [constants.DIFFICULTY_LABELS[d] for d in difficulties]
@@ -104,61 +105,145 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
     tracks = audio.get_music_tracks()
     current_track = audio.get_current_music() or audio.get_default_music()
     track_idx = tracks.index(current_track) if current_track in tracks else -1
+    scroll_speed = settings.SCROLL_SPEED
+    languages = {"en": "English", "fr": "Français"}
+    lang_codes = list(languages.keys())
+    lang_idx = lang_codes.index(settings.LANGUAGE) if settings.LANGUAGE in lang_codes else 0
 
-    def _update_texts() -> Tuple[str, str, str, str, str, str]:
+    def _update_texts() -> Tuple[str, ...]:
         track_name = tracks[track_idx] if track_idx >= 0 else "Aucun"
         return (
+            f"Volume : {int(volume * 100)}%",
             f"Musique : {int(music * 100)}%",
             f"Sons : {int(sfx * 100)}%",
+            f"Vitesse scroll : {scroll_speed}",
             f"Plein écran : {'Oui' if fullscreen else 'Non'}",
             f"Difficulté IA : {labels[difficulty_idx]}",
             f"Musique de fond : {track_name}",
             "Touches",
+            f"Langue : {languages[lang_codes[lang_idx]]}",
         )
 
     while True:
-        opt_music, opt_sfx, opt_full, opt_ai, opt_track, opt_keys = _update_texts()
-        options = [opt_music, opt_sfx, opt_full, opt_ai, opt_track, opt_keys, "Retour"]
+        (
+            opt_vol,
+            opt_music,
+            opt_sfx,
+            opt_scroll,
+            opt_full,
+            opt_ai,
+            opt_track,
+            opt_keys,
+            opt_lang,
+        ) = _update_texts()
+        options = [
+            opt_vol,
+            opt_music,
+            opt_sfx,
+            opt_scroll,
+            opt_full,
+            opt_ai,
+            opt_track,
+            opt_keys,
+            opt_lang,
+            "Retour",
+        ]
 
         choice, screen = simple_menu(screen, options, title="Options")
 
-        if choice is None or choice == 6:
+        if choice is None or choice == 9:
             audio.save_settings(
                 fullscreen=fullscreen,
                 ai_difficulty=difficulties[difficulty_idx],
                 music_track=tracks[track_idx] if track_idx >= 0 else "",
+                scroll_speed=scroll_speed,
+                language=lang_codes[lang_idx],
+                volume=volume,
             )
             return screen
 
         if choice == 0:
             sel, screen = simple_menu(
+                screen, ["Augmenter", "Diminuer", "Retour"], title="Volume général"
+            )
+            if sel == 0:
+                volume = min(1.0, volume + 0.1)
+            elif sel == 1:
+                volume = max(0.0, volume - 0.1)
+            audio.set_music_volume(volume, save=False)
+            audio.set_sfx_volume(volume, save=False)
+            settings.VOLUME = volume
+            audio.save_settings(
+                fullscreen=fullscreen,
+                ai_difficulty=difficulties[difficulty_idx],
+                music_track=tracks[track_idx] if track_idx >= 0 else "",
+                scroll_speed=scroll_speed,
+                language=lang_codes[lang_idx],
+                volume=volume,
+            )
+        elif choice == 1:
+            sel, screen = simple_menu(
                 screen, ["Augmenter", "Diminuer", "Retour"], title="Volume Musique"
             )
             if sel == 0:
                 music = min(1.0, music + 0.1)
-                audio.set_music_volume(music)
             elif sel == 1:
                 music = max(0.0, music - 0.1)
-                audio.set_music_volume(music)
-        elif choice == 1:
+            audio.set_music_volume(music, save=False)
+            audio.save_settings(
+                fullscreen=fullscreen,
+                ai_difficulty=difficulties[difficulty_idx],
+                music_track=tracks[track_idx] if track_idx >= 0 else "",
+                scroll_speed=scroll_speed,
+                language=lang_codes[lang_idx],
+                volume=volume,
+            )
+        elif choice == 2:
             sel, screen = simple_menu(
                 screen, ["Augmenter", "Diminuer", "Retour"], title="Volume Sons"
             )
             if sel == 0:
                 sfx = min(1.0, sfx + 0.1)
-                audio.set_sfx_volume(sfx)
             elif sel == 1:
                 sfx = max(0.0, sfx - 0.1)
-                audio.set_sfx_volume(sfx)
-        elif choice == 2:
+            audio.set_sfx_volume(sfx, save=False)
+            audio.save_settings(
+                fullscreen=fullscreen,
+                ai_difficulty=difficulties[difficulty_idx],
+                music_track=tracks[track_idx] if track_idx >= 0 else "",
+                scroll_speed=scroll_speed,
+                language=lang_codes[lang_idx],
+                volume=volume,
+            )
+        elif choice == 3:
+            sel, screen = simple_menu(
+                screen, ["Augmenter", "Diminuer", "Retour"], title="Vitesse scroll"
+            )
+            if sel == 0:
+                scroll_speed += 5
+            elif sel == 1:
+                scroll_speed = max(1, scroll_speed - 5)
+            settings.SCROLL_SPEED = scroll_speed
+            audio.save_settings(
+                fullscreen=fullscreen,
+                ai_difficulty=difficulties[difficulty_idx],
+                music_track=tracks[track_idx] if track_idx >= 0 else "",
+                scroll_speed=scroll_speed,
+                language=lang_codes[lang_idx],
+                volume=volume,
+            )
+        elif choice == 4:
             fullscreen = not fullscreen
             pygame.display.toggle_fullscreen()
             audio.save_settings(
                 fullscreen=fullscreen,
                 ai_difficulty=difficulties[difficulty_idx],
                 music_track=tracks[track_idx] if track_idx >= 0 else "",
+                scroll_speed=scroll_speed,
+                language=lang_codes[lang_idx],
+                volume=volume,
             )
-        elif choice == 3:
+        elif choice == 5:
             sel, screen = simple_menu(
                 screen,
                 [l.capitalize() for l in labels],
@@ -170,8 +255,11 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
                     ai_difficulty=difficulties[difficulty_idx],
                     fullscreen=fullscreen,
                     music_track=tracks[track_idx] if track_idx >= 0 else "",
+                    scroll_speed=scroll_speed,
+                    language=lang_codes[lang_idx],
+                    volume=volume,
                 )
-        elif choice == 4:
+        elif choice == 6:
             if tracks:
                 sel, screen = simple_menu(
                     screen,
@@ -185,5 +273,36 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
                     elif sel == len(tracks):
                         track_idx = -1
                         audio.stop_music()
-        elif choice == 5:
+                audio.save_settings(
+                    fullscreen=fullscreen,
+                    ai_difficulty=difficulties[difficulty_idx],
+                    music_track=tracks[track_idx] if track_idx >= 0 else "",
+                    scroll_speed=scroll_speed,
+                    language=lang_codes[lang_idx],
+                    volume=volume,
+                )
+        elif choice == 7:
             screen = _keymap_menu(screen)
+            audio.save_settings(
+                fullscreen=fullscreen,
+                ai_difficulty=difficulties[difficulty_idx],
+                music_track=tracks[track_idx] if track_idx >= 0 else "",
+                scroll_speed=scroll_speed,
+                language=lang_codes[lang_idx],
+                volume=volume,
+            )
+        elif choice == 8:
+            sel, screen = simple_menu(
+                screen, list(languages.values()), title="Langue"
+            )
+            if sel is not None:
+                lang_idx = sel
+                settings.LANGUAGE = lang_codes[lang_idx]
+                audio.save_settings(
+                    fullscreen=fullscreen,
+                    ai_difficulty=difficulties[difficulty_idx],
+                    music_track=tracks[track_idx] if track_idx >= 0 else "",
+                    scroll_speed=scroll_speed,
+                    language=lang_codes[lang_idx],
+                    volume=volume,
+                )


### PR DESCRIPTION
## Summary
- add master volume, scroll speed, and language controls to options menu
- persist new options through settings API and apply on startup
- default world renderer pan speed to configurable setting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adfcd235d48321a06ae69a769c0b4e