### PR TITLE
Add min-range and retaliation tracking in combat

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -846,7 +846,7 @@ class Combat:
             0 if dy == 0 else (1 if dy > 0 else -1),
         )
         attacker.facing = direction
-        dist = abs(dx) + abs(dy)
+        dist = self.hex_distance((attacker.x, attacker.y), (defender.x, defender.y))
         flank = combat_rules.flanking_bonus(attacker, defender)
 
         result = combat_rules.compute_damage(

--- a/core/entities.py
+++ b/core/entities.py
@@ -89,6 +89,10 @@ class UnitStats:
 
     The graphical representation of a unit is defined by a sprite sheet
     identifier and separate frame ranges for the hero and enemy sides.
+
+    ``min_range`` defines the minimum distance allowed for ranged
+    attacks, and ``retaliations_per_round`` sets how many counterattacks
+    a unit may perform in a single round.
     """
 
     name: str


### PR DESCRIPTION
## Summary
- Document min_range and retaliations_per_round in UnitStats
- Use proper hex distance when applying attack penalties and retaliation limits

## Testing
- `pytest -q` *(fails: tests/test_world_ai.py::test_enemy_target_weighted_by_difficulty)*

------
https://chatgpt.com/codex/tasks/task_e_68ae01c80dac83219ee38a610a8cfbc5