### PR TITLE
Handle shooting obstacles

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -849,8 +849,19 @@ class Combat:
         dist = self.hex_distance((attacker.x, attacker.y), (defender.x, defender.y))
         flank = combat_rules.flanking_bonus(attacker, defender)
 
+        blocked: set[Tuple[int, int]] = set(self.obstacles) | set(self.ice_walls)
+        for u in self.units:
+            if not u.is_alive:
+                continue
+            if u is attacker or u is defender:
+                continue
+            blocked.add((u.x, u.y))
         result = combat_rules.compute_damage(
-            attacker, defender, attack_type=attack_type, distance=dist
+            attacker,
+            defender,
+            attack_type=attack_type,
+            distance=dist,
+            obstacles=blocked,
         )
         base = result["value"]
         luck_mul = result.get("luck", 1.0)

--- a/tests/test_ranged_obstacle_penalty.py
+++ b/tests/test_ranged_obstacle_penalty.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from core.combat_rules import UnitView, compute_damage, blocking_squares
+
+
+@dataclass
+class DummyStats:
+    attack_min: int = 10
+    attack_max: int = 10
+    defence_melee: int = 0
+    defence_ranged: int = 0
+    defence_magic: int = 0
+    luck: int = 0
+
+
+def test_blocking_squares_simple():
+    assert blocking_squares((0, 0), (2, 0)) == [(1, 0)]
+
+
+def test_ranged_shot_penalty_with_obstacle():
+    attacker = UnitView(side="hero", stats=DummyStats(), x=0, y=0)
+    defender = UnitView(side="enemy", stats=DummyStats(), x=2, y=0)
+    baseline = compute_damage(attacker, defender, attack_type="ranged", distance=2)
+    blocked = compute_damage(
+        attacker,
+        defender,
+        attack_type="ranged",
+        distance=2,
+        obstacles={(1, 0)},
+    )
+    assert blocked["value"] == int(baseline["value"] * 0.5)


### PR DESCRIPTION
## Summary
- Compute hexagonal blocking squares to check projectile paths
- Apply ranged damage penalty when an obstacle lies between shooter and target
- Add tests covering blocking square calculation and obstacle penalty

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae060c75d88321abe8e46aef10a61b