### PR TITLE
feat: display status effects with icons

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -671,7 +671,15 @@ class Combat:
                 if key and src and dst:
                     self.animate_projectile(key, src, dst)
             elif t == "status":
-                self.add_status(self._find_unit_by_id(e.get("target")), e.get("status",""), e.get("duration",1))
+                unit = self._find_unit_by_id(e.get("target"))
+                if unit:
+                    self.add_status(
+                        unit,
+                        e.get("status", ""),
+                        e.get("duration", 1),
+                        e.get("modifiers"),
+                        e.get("icon"),
+                    )
             elif t == "heal":
                 u = self._find_unit_by_id(e.get("target"))
                 if u:

--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -201,7 +201,10 @@ class CombatHUD:
                 )
                 y += 18
                 x_stat = right.x + 20
-                for idx, eff in enumerate(effects):
+                idx = 0
+                for eff in effects:
+                    if eff.duration <= 0:
+                        continue
                     icon_id = eff.icon or f"status_{eff.name}"
                     rect = pygame.Rect(x_stat + idx * 22, y, 18, 18)
                     btn = IconButton(
@@ -212,7 +215,11 @@ class CombatHUD:
                         enabled=False,
                     )
                     btn.draw(screen)
+                    if eff.duration:
+                        txt = self.small.render(str(eff.duration), True, theme.PALETTE["text"])
+                        screen.blit(txt, (rect.x + rect.width - txt.get_width(), rect.y))
                     action_buttons[f"status_{idx}"] = btn
+                    idx += 1
                 y += 22
 
             # Turn order thumbnails

--- a/core/spell.py
+++ b/core/spell.py
@@ -120,6 +120,19 @@ def cast_ice_wall(spell: Spell, target_line: List[Tuple[int, int]]) -> List[Effe
 def cast_shield(spell: Spell, target_id: int) -> List[Effect]:
     """Apply a protective status to ``target_id``."""
     st = spell.data["status"]
-    return [{"type": "status", "target": target_id, "status": st.get("name", "shielded"),
-             "duration": int(st.get("duration", 2)), "reduction": float(st.get("reduction", 0.25))},
-            {"type": "fx", "asset": spell.data.get("fx_asset", "effects/shield_glow"), "target": target_id}]
+    icon = st.get("icon", "status_shield")
+    return [
+        {
+            "type": "status",
+            "target": target_id,
+            "status": st.get("name", "shielded"),
+            "duration": int(st.get("duration", 2)),
+            "reduction": float(st.get("reduction", 0.25)),
+            "icon": icon,
+        },
+        {
+            "type": "fx",
+            "asset": spell.data.get("fx_asset", "effects/shield_glow"),
+            "target": target_id,
+        },
+    ]


### PR DESCRIPTION
## Summary
- attach status effect icons when casting shield
- show status effect icons with remaining duration in combat HUD
- propagate status effect metadata when resolving spell effects

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae0785773c83219a08d45477e281bd