### PR TITLE
Use shared simple combat fixture for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,18 +118,22 @@ def rng():
 
 
 @pytest.fixture
-def simple_combat():
+def simple_combat(monkeypatch):
     """Return a factory that builds a minimal :class:`Combat` instance.
 
-    The factory accepts optional ``hero_units`` and ``enemy_units`` lists and
-    any additional keyword arguments forwarded to :class:`Combat`.  A dummy
-    ``pygame.Surface`` and empty assets are used by default and a basic water
-    battlefield grid is supplied so no ``WorldMap`` interaction is required.
+    The created combat uses a reduced 5×5 battlefield so tests can run quickly
+    without needing any :class:`WorldMap` generation.  The factory accepts
+    optional ``hero_units`` and ``enemy_units`` lists and forwards any extra
+    keyword arguments to :class:`Combat`.
     """
 
     def _factory(hero_units=None, enemy_units=None, *, screen=None, assets=None,
                  combat_map=None, **kwargs):
         import pygame
+
+        # Shrink the combat grid for the duration of the test
+        monkeypatch.setattr(constants, "COMBAT_GRID_WIDTH", 5)
+        monkeypatch.setattr(constants, "COMBAT_GRID_HEIGHT", 5)
 
         pygame.init()
         if screen is None:
@@ -144,7 +148,7 @@ def simple_combat():
         if assets is None:
             assets = {}
         if combat_map is None:
-            combat_map = water_battlefield_template()
+            combat_map = [["ocean"] * constants.COMBAT_GRID_WIDTH for _ in range(constants.COMBAT_GRID_HEIGHT)]
         return Combat(
             screen,
             assets,

--- a/tests/test_auto_mode_hotkey.py
+++ b/tests/test_auto_mode_hotkey.py
@@ -5,24 +5,12 @@ import pygame
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
 from core.entities import Unit, SWORDSMAN_STATS
-from core.combat import Combat
-import constants
 
 pygame.init()
 
 
-def _make_combat():
-    screen = pygame.Surface(
-        (
-            constants.COMBAT_GRID_WIDTH * constants.COMBAT_TILE_SIZE,
-            constants.COMBAT_GRID_HEIGHT * constants.COMBAT_TILE_SIZE,
-        )
-    )
-    return Combat(screen, {}, [Unit(SWORDSMAN_STATS, 1, 'hero')], [Unit(SWORDSMAN_STATS, 1, 'enemy')])
-
-
-def test_hotkey_disables_auto_mode(monkeypatch):
-    combat = _make_combat()
+def test_hotkey_disables_auto_mode(monkeypatch, simple_combat):
+    combat = simple_combat([Unit(SWORDSMAN_STATS, 1, 'hero')], [Unit(SWORDSMAN_STATS, 1, 'enemy')])
     combat.auto_mode = True
     # provide minimal constants used by run()
     monkeypatch.setattr(pygame, 'QUIT', 0, raising=False)

--- a/tests/test_combat_ai.py
+++ b/tests/test_combat_ai.py
@@ -41,7 +41,7 @@ def test_ai_mage_casts_fireball_when_out_of_range(simple_combat):
     combat = simple_combat([hero], [mage])
     hero_unit = combat.hero_units[0]
     mage_unit = combat.enemy_units[0]
-    combat.move_unit(hero_unit, 5, 0)
+    combat.move_unit(hero_unit, 4, 4)
     combat.move_unit(mage_unit, 0, 0)
     ai_take_turn(combat, mage_unit, [hero_unit])
     assert hero_unit.current_hp < hero_unit.stats.max_hp
@@ -69,7 +69,7 @@ def test_hex_neighbors_within_bounds(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
     combat = simple_combat([hero], [enemy])
-    center_neighbors = combat.hex_neighbors(5, 5)
+    center_neighbors = combat.hex_neighbors(2, 2)
     assert len(center_neighbors) == 6
     edge_neighbors = combat.hex_neighbors(0, 0)
     assert len(edge_neighbors) < 6

--- a/tests/test_factions.py
+++ b/tests/test_factions.py
@@ -5,7 +5,6 @@ import pygame
 from loaders.core import Context
 from loaders.faction_loader import load_factions
 from core.entities import Unit, SWORDSMAN_STATS
-from core.combat import Combat
 
 
 def _ctx():
@@ -15,23 +14,23 @@ def _ctx():
     return Context(repo_root=repo, search_paths=search, asset_loader=None)
 
 
-def test_doctrine_bonus():
+def test_doctrine_bonus(simple_combat):
     factions = load_factions(_ctx())
     rk = factions["red_knights"]
     unit = Unit(SWORDSMAN_STATS, 5, "hero")
-    combat = Combat(pygame.Surface((1, 1)), {}, [unit], [], hero_faction=rk)
+    combat = simple_combat([unit], [], screen=pygame.Surface((1, 1)), hero_faction=rk)
     assert combat.hero_units[0].stats.morale == 1
 
 
-def test_army_synergy():
+def test_army_synergy(simple_combat):
     factions = load_factions(_ctx())
     rk = factions["red_knights"]
     units = [Unit(SWORDSMAN_STATS, 5, "hero") for _ in range(3)]
-    combat = Combat(pygame.Surface((1, 1)), {}, units, [], hero_faction=rk)
+    combat = simple_combat(units, [], screen=pygame.Surface((1, 1)), hero_faction=rk)
     assert all(u.stats.morale == 2 for u in combat.hero_units)
 
     undead = Unit(SWORDSMAN_STATS, 5, "hero")
     undead.tags.append("undead")
-    combat = Combat(pygame.Surface((1, 1)), {}, units + [undead], [], hero_faction=rk)
+    combat = simple_combat(units + [undead], [], screen=pygame.Surface((1, 1)), hero_faction=rk)
     assert all(u.stats.morale == 1 for u in combat.hero_units)
 

--- a/tests/test_overlay_rendering.py
+++ b/tests/test_overlay_rendering.py
@@ -2,7 +2,6 @@ import pygame
 from types import SimpleNamespace
 import constants
 from core.world import WorldMap, BIOME_IMAGES
-from core.combat import Combat
 from core import combat_render
 from core.entities import UnitStats, Unit
 from core.game import Game
@@ -105,7 +104,7 @@ def test_world_overlay_uses_additive_blending(monkeypatch):
     assert pygame.BLEND_RGBA_ADD in calls
 
 
-def test_combat_overlay_uses_additive_blending(monkeypatch):
+def test_combat_overlay_uses_additive_blending(monkeypatch, simple_combat):
     _ensure_stub_functions(monkeypatch)
     highlight = pygame.Surface((constants.COMBAT_TILE_SIZE, constants.COMBAT_TILE_SIZE), pygame.SRCALPHA)
     highlight.fill((255, 0, 0, 255))
@@ -128,7 +127,7 @@ def test_combat_overlay_uses_additive_blending(monkeypatch):
     )
     hero = Unit(stats, 1, "hero")
     enemy = Unit(stats, 1, "enemy")
-    combat = Combat(screen, assets, [hero], [enemy])
+    combat = simple_combat([hero], [enemy], screen=screen, assets=assets)
     combat.selected_unit = combat.hero_units[0]
     combat.selected_action = "move"
 
@@ -146,7 +145,7 @@ def test_combat_overlay_uses_additive_blending(monkeypatch):
     assert pygame.BLEND_RGBA_ADD in calls
 
 
-def test_combat_active_unit_overlay_uses_additive_blending(monkeypatch):
+def test_combat_active_unit_overlay_uses_additive_blending(monkeypatch, simple_combat):
     _ensure_stub_functions(monkeypatch)
     active = pygame.Surface(
         (constants.COMBAT_TILE_SIZE, constants.COMBAT_TILE_SIZE), pygame.SRCALPHA
@@ -171,7 +170,7 @@ def test_combat_active_unit_overlay_uses_additive_blending(monkeypatch):
     )
     hero = Unit(stats, 1, "hero")
     enemy = Unit(stats, 1, "enemy")
-    combat = Combat(screen, assets, [hero], [enemy])
+    combat = simple_combat([hero], [enemy], screen=screen, assets=assets)
     combat.turn_order = [combat.hero_units[0]]
     combat.current_index = 0
 

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -78,8 +78,8 @@ def test_teleport_spell_moves_unit(simple_combat):
     combat = simple_combat([hero], [enemy], hero_mana=10)
     caster = combat.hero_units[0]
     spell = combat.get_spell('Teleport')
-    combat.cast_spell(spell, caster, (caster, (5, 5)))
-    assert caster.x == 5 and caster.y == 5
+    combat.cast_spell(spell, caster, (caster, (4, 4)))
+    assert caster.x == 4 and caster.y == 4
     assert combat.hero_mana == 9
 
 
@@ -103,11 +103,11 @@ def test_chain_lightning_hits_multiple_targets(simple_combat):
     hero = Unit(MAGE_STATS, 1, 'hero')
     combat = simple_combat([hero], enemies, hero_mana=10)
     caster = combat.hero_units[0]
-    positions = [(3, 3), (4, 3), (5, 3)]
+    positions = [(1, 1), (2, 1), (3, 1)]
     for unit, (x, y) in zip(combat.enemy_units, positions):
         combat.move_unit(unit, x, y)
     spell = combat.get_spell('Chain Lightning')
-    combat.cast_spell(spell, caster, (4, 3))
+    combat.cast_spell(spell, caster, (2, 1))
     assert all(u.current_hp < u.stats.max_hp for u in combat.enemy_units)
 
 


### PR DESCRIPTION
## Summary
- add `simple_combat` fixture that builds a 5×5 combat without a world map
- replace ad-hoc combat creation in tests with the shared fixture
- adjust unit placement in tests to match the small grid

## Testing
- `pytest -o addopts="" tests/test_auto_mode_hotkey.py tests/test_factions.py tests/test_overlay_rendering.py tests/test_combat_ai.py tests/test_spells.py tests/test_units_abilities.py tests/test_morale.py tests/test_luck_log.py tests/test_combat_cleanup.py tests/test_combat_unit_sort.py tests/test_min_range_and_retaliation.py tests/test_combat_show_stats_screen.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae179109388321bf879b1abf7fae6b