### PR TITLE
refactor: use module fixtures for map reuse

### DIFF
--- a/tests/test_marine_ocean_features.py
+++ b/tests/test_marine_ocean_features.py
@@ -8,12 +8,19 @@ from core.world import WorldMap
 from core.buildings import create_building
 
 
-def _load_world() -> WorldMap:
+@pytest.fixture(scope="module")
+def _marine_world_base() -> WorldMap:
     path = Path(__file__).parent / "fixtures" / "mini_marine_map.txt"
     world = WorldMap.from_file(str(path))
     # Reload original data to undo starting area modifications
     rows = [line.rstrip("\n") for line in open(path, "r", encoding="utf-8")]
     world._load_from_parsed_data([world._parse_row(r) for r in rows])
+    return world
+
+
+@pytest.fixture
+def marine_world(_marine_world_base: WorldMap) -> WorldMap:
+    world = _marine_world_base.clone()
     # Place buildings and features on the water
     world.grid[1][1].building = create_building("sea_sanctuary")
     world.grid[3][3].building = create_building("lighthouse")
@@ -22,8 +29,8 @@ def _load_world() -> WorldMap:
     return world
 
 
-def test_marine_world_scattered_ocean_features():
-    world = _load_world()
+def test_marine_world_scattered_ocean_features(marine_world: WorldMap):
+    world = marine_world
 
     buildings = {"sea_sanctuary": 0, "lighthouse": 0}
     water_resources = 0

--- a/tests/test_shipyard_placement.py
+++ b/tests/test_shipyard_placement.py
@@ -7,9 +7,15 @@ from core.world import WorldMap
 from core.buildings import Town, create_building
 
 
-def _load_world() -> WorldMap:
+@pytest.fixture(scope="module")
+def _world_base() -> WorldMap:
     path = Path(__file__).parent / "fixtures" / "mini_continent_map.txt"
-    world = WorldMap.from_file(str(path))
+    return WorldMap.from_file(str(path))
+
+
+@pytest.fixture
+def world(_world_base: WorldMap) -> WorldMap:
+    world = _world_base.clone()
     # Place the hero's town on the first continent
     world.grid[2][4].building = Town()
     world.hero_town = (4, 2)
@@ -29,15 +35,13 @@ def _shipyard_positions(world: WorldMap):
     ]
 
 
-def test_starting_area_has_shipyard_when_near_water():
-    world = _load_world()
+def test_starting_area_has_shipyard_when_near_water(world: WorldMap):
     htx, hty = world.hero_town
     shipyards = _shipyard_positions(world)
     assert any(abs(x - htx) + abs(y - hty) <= 5 for x, y in shipyards)
 
 
-def test_each_continent_has_shipyard():
-    world = _load_world()
+def test_each_continent_has_shipyard(world: WorldMap):
     shipyards = set(_shipyard_positions(world))
     for continent in world._find_continents():
         assert any((x, y) in shipyards for x, y in continent)


### PR DESCRIPTION
## Summary
- build base world maps once per module and clone per test in shipyard and marine feature tests
- avoid shared mutation of world maps across tests

## Testing
- `pytest tests/test_shipyard_placement.py tests/test_marine_ocean_features.py -m worldgen`


------
https://chatgpt.com/codex/tasks/task_e_68ae19f772208321af68172a53383431