### PR TITLE
Support building requirements for recruitment

### DIFF
--- a/assets/buildings/banner_hall.json
+++ b/assets/buildings/banner_hall.json
@@ -7,6 +7,7 @@
     "occludes": true,
     "path": "buildings/banner_hall/banner_hall_0.png",
     "variants": 1,
+    "requires": [],
     "provides": {"resource": "gold", "per_day": 1}
   }
 ]

--- a/assets/buildings/buildings.json
+++ b/assets/buildings/buildings.json
@@ -8,6 +8,7 @@
     "occludes": true,
     "path": "buildings/mine/mine_0.png",
     "variants": 1,
+    "requires": [],
     "provides": {"resource": "stone", "per_day": 2}
   },
   {
@@ -18,6 +19,7 @@
     "occludes": true,
     "path": "buildings/sawmill/sawmill_0.png",
     "variants": 1,
+    "requires": [],
     "provides": {"resource": "wood", "per_day": 2}
   },
   {
@@ -28,6 +30,7 @@
     "occludes": true,
     "path": "buildings/crystal_mine/crystal_mine_0.png",
     "variants": 1,
+    "requires": [],
     "provides": {"resource": "crystal", "per_day": 1}
   },
   {
@@ -38,6 +41,7 @@
     "occludes": true,
     "path": "buildings/swordsman_camp/swordsman_camp_0.png",
     "variants": 1,
+    "requires": ["barracks"],
     "growth_per_week": {"Swordsman": 5}
   },
   {
@@ -48,6 +52,7 @@
     "occludes": true,
     "path": "buildings/archer_camp/archer_camp_0.png",
     "variants": 1,
+    "requires": ["archery_range"],
     "growth_per_week": {"Archer": 5}
   },
   {
@@ -58,6 +63,7 @@
     "occludes": true,
     "path": "buildings/shipyard.png",
     "variants": 1,
+    "requires": [],
     "upgrade_cost": {"wood": 5}
   },
   {
@@ -68,6 +74,7 @@
     "occludes": true,
     "path": "buildings/town/town_0.png",
     "variants": 1,
+    "requires": [],
     "provides": {"resource": "gold", "per_day": 0}
   },
   {
@@ -77,7 +84,8 @@
     "passable": true,
     "occludes": true,
     "path": "buildings/sea_sanctuary/sea_sanctuary_0.png",
-    "variants": 1
+    "variants": 1,
+    "requires": []
   },
   {
     "id": "lighthouse",
@@ -86,7 +94,8 @@
     "passable": true,
     "occludes": true,
     "path": "buildings/lighthouse/lighthouse_0.png",
-    "variants": 1
+    "variants": 1,
+    "requires": []
   }
 ]
 

--- a/loaders/building_loader.py
+++ b/loaders/building_loader.py
@@ -36,6 +36,7 @@ class BuildingAsset:
     scale: float = 1.0
     upgrade_cost: Dict[str, int] = field(default_factory=dict)
     production_per_level: Dict[str, int] = field(default_factory=dict)
+    requires: List[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         if self.footprint is None:
@@ -121,6 +122,7 @@ def load_buildings(
             files=files,
             upgrade_cost=dict(entry.get("upgrade_cost", {})),
             production_per_level=dict(entry.get("production_per_level", {})),
+            requires=list(entry.get("requires", [])),
         )
         defs[a.id] = a
     return defs

--- a/tests/test_recruit_requires.py
+++ b/tests/test_recruit_requires.py
@@ -1,0 +1,16 @@
+import os
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+import pygame
+
+from core.buildings import Town
+
+
+def test_recruit_requires_prereqs():
+    pygame.init()
+    town = Town()
+    town.built_structures.add('archer_camp')
+    assert 'Archer' not in town.recruitable_units('archer_camp')
+    town.built_structures.add('archery_range')
+    units = town.recruitable_units('archer_camp')
+    assert 'Archer' in units


### PR DESCRIPTION
## Summary
- add optional `requires` field to building manifests
- ensure `Town.recruitable_units` honors building prerequisites
- test recruitment prerequisite logic

## Testing
- `pytest tests/test_recruit_requires.py -q`
- `pytest -q` *(fails: hung after majority of tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2a5379fc8321aa01a86327156088