### PR TITLE
Configure pytest markers and document heavy test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,23 +178,23 @@ generation, combat rules and save/load behaviour. Most tests can be run in
 parallel; a few that rely on global state are marked with ``serial`` and must
 run one at a time.
 
-Run the main test suite (excluding slow, worldgen and combat cases) with:
+Run the main test suite (excluding slow, worldgen, combat and serial cases) with:
 
 ```bash
-pytest -q -n auto -m "not slow and not worldgen and not combat"
+pytest
 ```
 
 Tests marked ``serial`` must be executed separately:
 
 ```bash
-pytest -q -n 1 -m serial
+pytest -m serial
 ```
 
 Slow and specialised tests covering world generation and extended combat are
 skipped by default. Run them explicitly with:
 
 ```bash
-pytest -q -n auto -m "slow or worldgen or combat"
+pytest -m "slow or worldgen or combat"
 ```
 
 In continuous integration environments, add `--log-file=pytest.log` to

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ markers =
     worldgen: tests involving large-scale map generation
     combat: tests with long AI loops
     serial: tests that cannot run in parallel
-addopts = -q -n auto --dist=loadgroup -m "not slow and not worldgen and not combat and not serial" --durations=20 --maxfail=1
+addopts = -q -m "not slow and not worldgen and not combat and not serial"
 log_file =
 log_file_level = WARNING
 log_auto_indent = False

--- a/tests/test_army_treasure_combat.py
+++ b/tests/test_army_treasure_combat.py
@@ -1,10 +1,13 @@
 import types
 import sys
 import pygame
+import pytest
 
 from tests.test_army_actions import setup_game
 from ui.widgets.hero_list import HeroList
 
+
+pytestmark = pytest.mark.combat
 
 def test_army_without_hero_treasure_and_combat(monkeypatch, pygame_stub):
     game, constants, Army, Unit, S_STATS = setup_game(monkeypatch, pygame_stub)

--- a/tests/test_combat_ai.py
+++ b/tests/test_combat_ai.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import replace
+import pytest
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
@@ -13,6 +14,8 @@ from core.entities import (
 from core.combat_ai import ai_take_turn, allied_ai_turn, select_spell, _a_star
 import constants
 
+
+pytestmark = pytest.mark.combat
 
 def test_ai_attacks_nearest_enemy(simple_combat):
     hero = Unit(SWORDSMAN_STATS, 1, 'hero')

--- a/tests/test_combat_cleanup.py
+++ b/tests/test_combat_cleanup.py
@@ -1,8 +1,10 @@
 import pygame
+import pytest
 
 from core.entities import Unit, SWORDSMAN_STATS
 import audio
 import core.combat_render as combat_render
+pytestmark = pytest.mark.combat
 
 
 def test_combat_clears_dead_stacks(monkeypatch, simple_combat):

--- a/tests/test_combat_map_shoreline.py
+++ b/tests/test_combat_map_shoreline.py
@@ -1,4 +1,6 @@
 from core.world import WorldMap, generate_combat_map
+import pytest
+pytestmark = pytest.mark.combat
 
 
 def test_shoreline_combat_map_has_no_ocean():

--- a/tests/test_combat_show_stats_screen.py
+++ b/tests/test_combat_show_stats_screen.py
@@ -2,9 +2,13 @@ from types import SimpleNamespace
 
 import pygame
 import theme
+import pytest
 
 from core.entities import Unit, SWORDSMAN_STATS
 from ui import combat_summary
+
+
+pytestmark = pytest.mark.combat
 
 
 class DummyScreen:

--- a/tests/test_combat_spellbook_button.py
+++ b/tests/test_combat_spellbook_button.py
@@ -1,4 +1,8 @@
 from core.combat_render import handle_button_click
+import pytest
+
+
+pytestmark = pytest.mark.combat
 
 
 class DummyCombat:

--- a/tests/test_combat_stats.py
+++ b/tests/test_combat_stats.py
@@ -4,6 +4,9 @@ import pytest
 from core.entities import UnitStats, Unit, apply_defence
 
 
+pytestmark = pytest.mark.combat
+
+
 def _create_unit(**kwargs) -> Unit:
     data = dict(
         name="Test",

--- a/tests/test_combat_unit_sort.py
+++ b/tests/test_combat_unit_sort.py
@@ -1,8 +1,11 @@
 import pygame
-import pygame
+import pytest
 from core.entities import UnitStats, Unit
 from core import combat_render
 from tests.test_overlay_rendering import _ensure_stub_functions
+
+
+pytestmark = pytest.mark.combat
 
 
 def _make_unit(name: str, side: str = "hero") -> Unit:

--- a/tests/test_naval_combat_map.py
+++ b/tests/test_naval_combat_map.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 
 from core.game import Game
+import pytest
+pytestmark = pytest.mark.combat
 
 
 def test_naval_combat_map_is_all_water(monkeypatch):


### PR DESCRIPTION
## Summary
- Simplify pytest configuration to skip slow, worldgen, combat and serial tests by default
- Mark all combat-heavy tests with a `combat` marker
- Document how to run heavy or serial tests explicitly in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1b1069b0832189bc25ca93395aef