### PR TITLE
feat: add caravan unit selection and world progression

### DIFF
--- a/core/world.py
+++ b/core/world.py
@@ -1448,6 +1448,18 @@ class WorldMap:
         return towns
 
 
+    def advance_day(self) -> None:
+        """Advance daily progression for all towns on the map.
+
+        This currently forwards to each town's ``advance_day`` method so that
+        caravan orders continue their journey across the world.
+        """
+
+        for town in self.towns:
+            if hasattr(town, "advance_day"):
+                town.advance_day()
+
+
     def find_building_pos(self, building: Building) -> Optional[Tuple[int, int]]:
         """Search ``self.grid`` for ``building`` and return its coordinates.
 

--- a/state/game_state.py
+++ b/state/game_state.py
@@ -118,9 +118,12 @@ class GameState:
 
         economy.advance_day(self.economy)
         if self.world is not None:
-            for town in self.world.towns:
-                if hasattr(town, "advance_day"):
-                    town.advance_day()
+            if hasattr(self.world, "advance_day"):
+                self.world.advance_day()
+            else:
+                for town in self.world.towns:
+                    if hasattr(town, "advance_day"):
+                        town.advance_day()
         self.turn.turn_index += 1
         if self.economy.calendar.day == 1:
             self._advance_towns_week()

--- a/tests/test_caravan.py
+++ b/tests/test_caravan.py
@@ -61,3 +61,62 @@ def test_townscreen_launches_caravan(monkeypatch, pygame_stub):
     assert unit not in t1.garrison
     t1.advance_day()
     assert t2.garrison and t2.garrison[0] is unit
+
+
+def test_townscreen_selects_and_sends_queue(monkeypatch, pygame_stub):
+    pg = pygame_stub(
+        KEYDOWN=2,
+        MOUSEBUTTONDOWN=1,
+        K_u=117,
+        K_ESCAPE=27,
+        transform=types.SimpleNamespace(smoothscale=lambda img, size: img),
+    )
+    monkeypatch.setattr(pg.Rect, "collidepoint", lambda self, pos: True)
+    monkeypatch.setattr(
+        pg.Surface, "get_size", lambda self: (self.get_width(), self.get_height())
+    )
+    monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
+    monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
+
+    from core.world import WorldMap
+    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.buildings import Town
+    from ui.town_screen import TownScreen
+
+    game = types.SimpleNamespace()
+    world = WorldMap(width=2, height=1, biome_weights={"scarletia_echo_plain": 1.0}, num_obstacles=0, num_treasures=0, num_enemies=0)
+    t1, t2 = Town("A"), Town("B")
+    world.grid[0][0].building = t1
+    world.grid[0][1].building = t2
+    game.world = world
+    game.hero = Hero(0, 0, [])
+
+    screen = pg.display.set_mode((1, 1))
+    ts = TownScreen(screen, game, t1, None, None, (0, 0))
+    u1 = Unit(SWORDSMAN_STATS, 1, "hero")
+    u2 = Unit(SWORDSMAN_STATS, 2, "hero")
+    t1.garrison.extend([u1, u2])
+
+    ts.select_unit(0)
+    ts.select_unit(1)
+    assert ts.send_queued_caravan(t2)
+    assert u1 not in t1.garrison and u2 not in t1.garrison
+    world.advance_day()
+    assert u1 in t2.garrison and u2 in t2.garrison
+
+
+def test_world_map_advances_caravans():
+    from core.world import WorldMap
+    from core.buildings import Town
+    from core.entities import Unit, SWORDSMAN_STATS
+
+    world = WorldMap(width=3, height=1, biome_weights={"scarletia_echo_plain": 1.0}, num_obstacles=0, num_treasures=0, num_enemies=0)
+    t1, t2 = Town("A"), Town("B")
+    world.grid[0][0].building = t1
+    world.grid[0][2].building = t2
+    unit = Unit(SWORDSMAN_STATS, 1, "hero")
+    t1.garrison.append(unit)
+    assert t1.send_caravan(t2, [unit], world)
+    world.advance_day()
+    world.advance_day()
+    assert unit in t2.garrison


### PR DESCRIPTION
## Summary
- allow selecting garrison units in the town screen and queue them for caravans
- centralize daily world updates with `WorldMap.advance_day`
- cover caravan selection and world progression with new tests

## Testing
- `pytest tests/test_caravan.py tests/test_world_ai.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2dc10d348321beec69c98f7cb16d