### PR TITLE
feat: auto recruit units for AI towns

### DIFF
--- a/state/game_state.py
+++ b/state/game_state.py
@@ -112,6 +112,11 @@ class GameState:
             return
         for town in getattr(self.world, "towns", []):
             town.next_week()
+            owner = getattr(town, "owner", None)
+            if owner and owner in self.economy.players and owner != 0:
+                econ_player = self.economy.players[owner]
+                if hasattr(town, "recruit"):
+                    town.recruit(econ_player)
 
     def next_day(self) -> None:
         """Advance the game by one day applying economic effects."""

--- a/tests/test_ai_recruitment.py
+++ b/tests/test_ai_recruitment.py
@@ -1,0 +1,33 @@
+import os
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+import pygame
+
+from core.buildings import Town
+from core.entities import Hero
+from core.world import WorldMap
+from state.game_state import GameState
+from core import economy
+
+
+def test_ai_weekly_recruitment_consumes_resources():
+    pygame.init()
+    world = WorldMap(map_data=["G"])
+    town = Town()
+    town.owner = 1
+    world.grid[0][0].building = town
+
+    hero = Hero(0, 0, [])
+    hero.resources['wood'] = 5
+    hero.resources['stone'] = 5
+    hero.gold = 100
+    assert town.build_structure('barracks', hero)
+
+    state = GameState(world=world)
+    state.economy.players[1] = economy.PlayerEconomy()
+    state.economy.players[1].resources['gold'] = 1000
+
+    state.next_week()
+
+    assert any(u.stats.name == 'Swordsman' and u.count == 10 for u in town.garrison)
+    assert state.economy.players[1].resources['gold'] == 500


### PR DESCRIPTION
## Summary
- add Town.recruit to buy units using PlayerEconomy
- trigger weekly auto-recruitment for AI towns
- test AI recruitment consumes resources

## Testing
- `SKIP=precommit-test pre-commit run --files core/buildings.py state/game_state.py tests/test_ai_recruitment.py`
- `pytest tests/test_ai_recruitment.py::test_ai_weekly_recruitment_consumes_resources -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae35cbd60483219969bb562313d7bc