### PR TITLE
Document testmon and last-failure test runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,18 @@
 # Guide de contribution
 
-Pour exécuter uniquement les tests affectés par vos modifications, utilisez le script :
+Pour exécuter uniquement les tests affectés par vos modifications, utilisez :
 
 ```
-make fast-test
+make fast
 ```
 
-Ce script lance `pytest --testmon -m "not slow"` afin d’exécuter uniquement les tests touchés
+Ce script lance `pytest --testmon` afin d’exécuter uniquement les tests touchés
 tout en évitant ceux marqués comme lents.
+
+Pour relancer seulement les tests ayant échoué lors de la précédente exécution :
+
+```
+make lf
+```
+
+Cela déclenche `pytest --lf`.

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-.PHONY: fast all-fast serial long fast-test precommit-test
+.PHONY: fast lf all-fast serial long fast-test precommit-test
 
 fast:
-pytest -q -n auto
+	pytest --testmon -q -n auto
 
 fast-test: fast
+
+lf:
+	pytest --lf -q -n auto
 
 all-fast:
 	pytest -q -n auto --dist=loadgroup -m "not slow and not worldgen and not combat and not serial"

--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ write test logs to a file when needed.
 Pytest provides several options to iterate quickly during development:
 
 * `pytest --testmon` runs only the tests impacted by your recent changes.
-* `pytest --lf` re-executes only the tests that failed in the previous run.
+  Use `make fast` as a shortcut for this mode.
+* `pytest --lf` re-executes only the tests that failed in the previous run;
+  `make lf` exposes this behaviour.
 * `pytest --randomly-seed=0` (requires the `pytest-randomly` plugin) fixes the
   random seed to help detect order-dependent failures.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-xdist",
-    "pytest-testmon",
+    "pytest-testmon",  # run only impacted tests
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- note pytest-testmon in dev extras
- add Makefile helpers `fast` and `lf`
- document running only impacted tests or last failures

## Testing
- `make fast` *(fails: hangs around 52%)*
- `pytest --lf -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68aebb23000c8321b2d5b061a1d96505