### PR TITLE
Add precommit test target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,13 @@ make lf
 ```
 
 Cela déclenche `pytest --lf`.
+
+Avant de valider vos modifications, exécutez également :
+
+```
+make precommit-test
+```
+
+Cette commande lance une suite de tests rapide
+(`pytest --maxfail=1 -q -m "not slow and not worldgen and not combat and not serial"`)
+utilisée par le hook pre-commit pour détecter les régressions.

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ lf:
 all-fast:
 	pytest -q -n auto --dist=loadgroup -m "not slow and not worldgen and not combat and not serial"
 
-precommit-test: all-fast
+precommit-test:
+	pytest --maxfail=1 -q -m "not slow and not worldgen and not combat and not serial"
 
 serial:
 	pytest -q -n 1 -m serial


### PR DESCRIPTION
## Summary
- add a precommit-test Makefile target for running non-slow tests with maxfail
- document running precommit tests before committing

## Testing
- `make precommit-test` *(fails: KeyboardInterrupt)*
- `pre-commit run --files Makefile CONTRIBUTING.md` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68aebd9c4a348321bb882460e1a29188