### PR TITLE
Restrict enemy AI to visible tiles

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -2806,6 +2806,8 @@ class Game:
                             continue
                         hero.army.append(Unit(stats, amount, "enemy"))
                         b.garrison[unit_id] = 0
+        if getattr(self, "ai_player", None):
+            self.ai_player.update_visibility(self.world)
 
     def move_enemy_heroes(self) -> None:
         """Move each enemy hero one step toward the hero or nearest resource."""
@@ -2881,6 +2883,8 @@ class Game:
                 self._update_caches_for_tile(enemy.x, enemy.y)
             if enemy.x == self.hero.x and enemy.y == self.hero.y:
                 self.combat_with_enemy_hero(enemy, initiated_by="enemy")
+        if getattr(self, "ai_player", None):
+            self.ai_player.update_visibility(self.world)
 
     def combat_with_enemy_hero(self, enemy: EnemyHero, initiated_by: str) -> bool:
         """Handle combat between the player and an enemy hero.

--- a/tests/test_ai_fow.py
+++ b/tests/test_ai_fow.py
@@ -1,0 +1,48 @@
+import pytest
+
+from core.world import WorldMap
+from core.ai.faction_ai import FactionAI
+from core.entities import EnemyHero, Unit, SWORDSMAN_STATS, Hero
+from core.buildings import Town, Building
+
+
+def _basic_world():
+    world = WorldMap(width=5, height=1)
+    for x, tile in enumerate(world.grid[0]):
+        tile.biome = "scarletia_echo_plain"
+        tile.obstacle = False
+        if x == 2:
+            tile.obstacle = True
+    return world
+
+
+def test_ai_mine_search_respects_fog():
+    world = _basic_world()
+    town = Town()
+    town.owner = 1
+    world.grid[0][4].building = town
+    world.enemy_town = (4, 0)
+    hero = EnemyHero(3, 0, [Unit(SWORDSMAN_STATS, 1, "enemy")])
+    ai = FactionAI(town, heroes=[hero])
+    ai.update_visibility(world)
+    mine = Building()
+    mine.income = {"gold": 100}
+    mine.owner = 0
+    world.grid[0][0].building = mine
+    assert ai._find_nearest_mine(world, hero) is None
+    world.reveal(1, 0, 0, radius=0)
+    assert ai._find_nearest_mine(world, hero) == (0, 0)
+
+
+def test_ai_town_threat_respects_fog():
+    world = _basic_world()
+    town = Town()
+    town.owner = 1
+    world.grid[0][4].building = town
+    world.enemy_town = (4, 0)
+    ai = FactionAI(town, heroes=[])
+    ai.update_visibility(world)
+    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])
+    assert not ai._town_threatened(world, [hero], radius=5)
+    world.reveal(1, 0, 0, radius=0)
+    assert ai._town_threatened(world, [hero], radius=5)


### PR DESCRIPTION
## Summary
- limit FactionAI mine searching and threat detection to fog-visible tiles
- compute and refresh enemy fog of war around heroes and towns
- add regression tests for AI behaviour under fog of war

## Testing
- `pytest tests/test_ai_fow.py -q`
- `pytest -q` *(fails: KeyboardInterrupt after long run)*

------
https://chatgpt.com/codex/tasks/task_e_68aebb2b56888321ae41d1c59741a7ef