### PR TITLE
Track slow tests with pytest durations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,7 @@ make precommit-test
 Cette commande lance une suite de tests rapide
 (`pytest --maxfail=1 -q -m "not slow and not worldgen and not combat and not serial"`)
 utilisée par le hook pre-commit pour détecter les régressions.
+
+La configuration `pytest` inclut également `--durations=20` afin d'afficher les vingt tests les plus lents.
+Consultez cette liste après vos exécutions et tenez à jour le fichier
+[docs/test_durations.md](docs/test_durations.md) pour orienter l'optimisation des tests.

--- a/docs/test_durations.md
+++ b/docs/test_durations.md
@@ -1,0 +1,21 @@
+# Test durations
+
+La configuration de `pytest` inclut l'option `--durations=20` pour lister les
+vingt tests les plus lents. Cette section doit être mise à jour régulièrement
+pour aider les contributeurs à identifier les tests à optimiser.
+
+Exemple de sortie lors d'une exécution partielle :
+
+```
+$ pytest tests/test_coast_assets.py tests/test_caravan.py -q
+.....
+===================================================== slowest 20 durations =====================================================
+0.16s call     tests/test_coast_assets.py::test_coast_assets_loaded
+0.01s call     tests/test_caravan.py::test_townscreen_launches_caravan
+
+(13 durations < 0.005s hidden.  Use -vv to show these durations.)
+```
+
+Les contributeurs sont encouragés à re-générer cette liste après des changements
+importants et à examiner régulièrement les tests les plus lents afin de les
+réduire ou les refactorer.

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ markers =
     worldgen: tests involving large-scale map generation
     combat: tests with long AI loops
     serial: tests that cannot run in parallel
-addopts = -q -m "not slow and not worldgen and not combat and not serial"
+addopts = -q --durations=20 -m "not slow and not worldgen and not combat and not serial"
 log_file =
 log_file_level = WARNING
 log_auto_indent = False


### PR DESCRIPTION
## Summary
- report 20 slowest tests via `--durations=20`
- document reviewing slow test list in CONTRIBUTING
- add `docs/test_durations.md` with sample output for contributors

## Testing
- `pytest tests/test_coast_assets.py tests/test_caravan.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aec17f7c948321bcd42eef00b5f651