### PR TITLE
Overhaul quest system and add map generation utilities

### DIFF
--- a/assets/quests/quests.json
+++ b/assets/quests/quests.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "deliver_wood",
+    "type": "deliver_resource",
+    "difficulty": "Novice",
+    "params": {"resource": "wood", "amount": 10},
+    "reward": {"gold": 100}
+  },
+  {
+    "id": "slay_bandits",
+    "type": "defeat_enemy",
+    "difficulty": "Intermédiaire",
+    "params": {"enemy": "Bandit"},
+    "reward": {"artifact": "Bandit's Charm"}
+  },
+  {
+    "id": "explore_mysterious_tile",
+    "type": "explore_tile",
+    "difficulty": "Novice",
+    "params": {"x": 2, "y": 3, "radius": 0},
+    "reward": {"gold": 50}
+  },
+  {
+    "id": "recruit_swordsmen",
+    "type": "recruit_unit",
+    "difficulty": "Novice",
+    "params": {"unit": "Swordsman", "count": 2},
+    "reward": {"gold": 20}
+  }
+]

--- a/core/game.py
+++ b/core/game.py
@@ -3002,15 +3002,25 @@ class Game:
     # Journal & Hero screens
     # ------------------------------------------------------------------
 
-    def open_journal(self) -> None:
-        """Open the quest journal.
+    def open_journal(self, surface: "pygame.Surface" | None = None) -> None:
+        """Open the quest journal overlay.
 
-        The project does not yet provide a dedicated journal interface, so
-        the method simply notifies the user.  A full implementation can hook
-        into :class:`state.quests.QuestManager` to display active quests.
+        Parameters
+        ----------
+        surface:
+            Optional surface to render to.  When ``None`` the game's main
+            screen surface is used.  This allows the town screen to reuse the
+            same overlay implementation.
         """
 
-        self._notify("Journal not implemented")
+        try:  # pragma: no cover - allow running without package context
+            from .ui.quest_overlay import QuestOverlay
+        except ImportError:  # pragma: no cover
+            from ui.quest_overlay import QuestOverlay
+
+        surf = surface or self.screen
+        overlay = QuestOverlay(surf, self.quest_manager)
+        overlay.run()
 
     def open_skill_tree(self, tab: str = "skills") -> bool:
         """Convenience wrapper opening the hero screen on the skills tab."""

--- a/events/events.json
+++ b/events/events.json
@@ -1,19 +1,5 @@
 [
   {
-    "id": "deliver_wood",
-    "type": "deliver_resource",
-    "difficulty": "Novice",
-    "params": {"resource": "wood", "amount": 10},
-    "reward": {"gold": 100}
-  },
-  {
-    "id": "slay_bandits",
-    "type": "defeat_enemy",
-    "difficulty": "Intermédiaire",
-    "params": {"enemy": "Bandit"},
-    "reward": {"artifact": "Bandit's Charm"}
-  },
-  {
     "id": "explore_mysterious_tile",
     "type": "explore_tile",
     "difficulty": "Novice",

--- a/mapgen/generate_continent_map.py
+++ b/mapgen/generate_continent_map.py
@@ -1,0 +1,75 @@
+"""Utility to generate continent maps with resources and cities."""
+
+from __future__ import annotations
+
+import argparse
+import random
+from typing import List, Tuple
+
+from .continents import generate_continent_map as _base_generate
+
+RESOURCE_CHAR = "r"  # feature symbol for resource deposits
+CITY_CHAR = "T"       # feature symbol for towns/cities
+
+
+def _place_features(rows: List[str], num_resources: int, num_cities: int) -> List[str]:
+    """Place simple resource deposits and cities on ``rows``.
+
+    ``rows`` is the list returned by :func:`mapgen.continents.generate_continent_map`
+    where even indices hold biome letters and odd indices contain feature
+    symbols.  Resources and cities are marked by replacing the feature
+    character with :data:`RESOURCE_CHAR` and :data:`CITY_CHAR` respectively.
+    """
+
+    if not rows:
+        return rows
+    height = len(rows)
+    width = len(rows[0]) // 2
+    grid = [list(r) for r in rows]
+    land_cells: List[Tuple[int, int]] = [
+        (x, y)
+        for y in range(height)
+        for x in range(width)
+        if grid[y][2 * x] not in {"W", "R"}
+    ]
+    random.shuffle(land_cells)
+    for _ in range(min(num_resources, len(land_cells))):
+        x, y = land_cells.pop()
+        grid[y][2 * x + 1] = RESOURCE_CHAR
+    for _ in range(min(num_cities, len(land_cells))):
+        x, y = land_cells.pop()
+        grid[y][2 * x + 1] = CITY_CHAR
+    return ["".join(r) for r in grid]
+
+
+def generate_continent_map(width: int, height: int, seed: int | None = None,
+                           num_resources: int = 5, num_cities: int = 2) -> List[str]:
+    """Generate a continent map and place resources and cities."""
+    rows = _base_generate(width, height, seed=seed)
+    return _place_features(rows, num_resources, num_cities)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("width", type=int)
+    parser.add_argument("height", type=int)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--resources", type=int, default=5,
+                        help="number of resource deposits to place")
+    parser.add_argument("--cities", type=int, default=2,
+                        help="number of cities to place")
+    args = parser.parse_args()
+
+    rows = generate_continent_map(
+        args.width,
+        args.height,
+        seed=args.seed,
+        num_resources=args.resources,
+        num_cities=args.cities,
+    )
+    for row in rows:
+        print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/scenarios/medium.json
+++ b/scenarios/medium.json
@@ -1,0 +1,10 @@
+{
+  "name": "medium battle",
+  "units": [
+    {"type": "Swordsman", "x": 1, "y": 1, "count": 10},
+    {"type": "Archer", "x": 3, "y": 3, "count": 8},
+    {"type": "Mage", "x": 4, "y": 4, "count": 2}
+  ],
+  "objectives": ["Defeat all enemies", "Secure the region"],
+  "scripts": []
+}

--- a/scenarios/small.json
+++ b/scenarios/small.json
@@ -1,0 +1,9 @@
+{
+  "name": "small skirmish",
+  "units": [
+    {"type": "Swordsman", "x": 1, "y": 1, "count": 5},
+    {"type": "Archer", "x": 2, "y": 2, "count": 3}
+  ],
+  "objectives": ["Capture the outpost"],
+  "scripts": []
+}

--- a/ui/quest_overlay.py
+++ b/ui/quest_overlay.py
@@ -1,0 +1,128 @@
+"""Simple overlay window to manage quests."""
+
+from __future__ import annotations
+
+import pygame
+from typing import List, Tuple
+
+COLOR_BG = (40, 42, 50)
+COLOR_PANEL = (60, 62, 72)
+COLOR_BORDER = (110, 110, 120)
+COLOR_TEXT = (230, 230, 230)
+COLOR_ACCENT = (200, 180, 40)
+
+
+class QuestOverlay:
+    """Display available, active and completed quests.
+
+    The overlay groups quests into categories which can be toggled via
+    checkboxes at the top.  Available quests can be accepted, active quests can
+    be abandoned.  Completed quests are listed for reference.
+    """
+
+    def __init__(self, screen: pygame.Surface, qm: "QuestManager") -> None:
+        self.screen = screen
+        self.qm = qm
+        self.font = pygame.font.Font(None, 24)
+        self.font_big = pygame.font.Font(None, 32)
+        W, H = screen.get_size()
+        self.rect = pygame.Rect(0, 0, 480, 320)
+        self.rect.center = (W // 2, H // 2)
+        self.running = False
+        self.show_available = True
+        self.show_active = True
+        self.show_completed = True
+        self.checkbox_rects: dict[str, pygame.Rect] = {}
+        self.cards: List[Tuple[str, str, pygame.Rect]] = []  # (status, id, rect)
+
+    def run(self) -> None:
+        clock = pygame.time.Clock()
+        self.running = True
+        while self.running:
+            for evt in pygame.event.get():
+                if evt.type == pygame.QUIT:
+                    self.running = False
+                elif evt.type == pygame.KEYDOWN and evt.key in (pygame.K_ESCAPE, pygame.K_j):
+                    self.running = False
+                elif evt.type == pygame.MOUSEBUTTONDOWN:
+                    self._click(evt.pos)
+            self.draw()
+            pygame.display.flip()
+            clock.tick(60)
+
+    # ------------------------------------------------------------------ drawing
+    def draw(self) -> None:
+        s = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
+        s.fill((0, 0, 0, 160))
+        self.screen.blit(s, (0, 0))
+        pygame.draw.rect(self.screen, COLOR_BG, self.rect, border_radius=8)
+        pygame.draw.rect(self.screen, COLOR_BORDER, self.rect, 2, border_radius=8)
+        self.screen.blit(
+            self.font_big.render("Quests", True, COLOR_TEXT),
+            (self.rect.x + 16, self.rect.y + 10),
+        )
+        self._draw_filters()
+        self._draw_lists()
+
+    def _draw_filters(self) -> None:
+        y = self.rect.y + 50
+        x = self.rect.x + 20
+        opts = [
+            ("available", "Available", self.show_available),
+            ("active", "Active", self.show_active),
+            ("completed", "Completed", self.show_completed),
+        ]
+        self.checkbox_rects.clear()
+        for key, label, checked in opts:
+            box = pygame.Rect(x, y, 16, 16)
+            pygame.draw.rect(self.screen, COLOR_PANEL, box)
+            pygame.draw.rect(self.screen, COLOR_BORDER, box, 2)
+            if checked:
+                pygame.draw.line(self.screen, COLOR_ACCENT, box.topleft, box.bottomright, 2)
+                pygame.draw.line(self.screen, COLOR_ACCENT, box.topright, box.bottomleft, 2)
+            self.screen.blit(self.font.render(label, True, COLOR_TEXT), (x + 24, y - 4))
+            self.checkbox_rects[key] = box
+            x += 140
+
+    def _draw_lists(self) -> None:
+        self.cards.clear()
+        y = self.rect.y + 90
+        if self.show_available:
+            y = self._draw_section("Available", self.qm.get_available(), "available", y)
+        if self.show_active:
+            y = self._draw_section("Active", self.qm.get_active(), "active", y)
+        if self.show_completed:
+            self._draw_section("Completed", self.qm.get_completed(), "completed", y)
+
+    def _draw_section(self, title: str, quests, status: str, y: int) -> int:
+        if not quests:
+            return y
+        self.screen.blit(self.font_big.render(title, True, COLOR_TEXT), (self.rect.x + 16, y))
+        y += 32
+        for q in quests:
+            btn = pygame.Rect(self.rect.x + 20, y, self.rect.width - 40, 32)
+            pygame.draw.rect(self.screen, COLOR_PANEL, btn, border_radius=4)
+            pygame.draw.rect(self.screen, COLOR_BORDER, btn, 1, border_radius=4)
+            reward = q.reward.get("gold") or q.reward.get("artifact", "")
+            txt = f"{q.id} → {reward}"
+            self.screen.blit(self.font.render(txt, True, COLOR_TEXT), (btn.x + 8, btn.y + 6))
+            self.cards.append((status, q.id, btn))
+            y += 38
+        return y
+
+    # ------------------------------------------------------------------ events
+    def _click(self, pos: Tuple[int, int]) -> None:
+        for key, rect in self.checkbox_rects.items():
+            if rect.collidepoint(pos):
+                cur = getattr(self, f"show_{key}")
+                setattr(self, f"show_{key}", not cur)
+                return
+        for status, qid, rect in self.cards:
+            if rect.collidepoint(pos):
+                if status == "available":
+                    self.qm.accept(qid)
+                elif status == "active":
+                    self.qm.abandon(qid)
+                return
+        if not self.rect.collidepoint(pos):
+            self.running = False

--- a/ui/town_screen.py
+++ b/ui/town_screen.py
@@ -161,10 +161,6 @@ class TownScreen:
                 "army": [Unit(ARCHER_STATS, 10, "hero")],
             },
         ]
-        self.bounty_open = False
-        self.bounty_rect = pygame.Rect(0, 0, 420, 260)
-        self.bounty_cards: List[Tuple[str, pygame.Rect]] = []
-
         # Sélection des unités à envoyer en caravane
         self.send_queue: List[Unit] = []
 
@@ -268,8 +264,6 @@ class TownScreen:
             self._draw_castle_overlay()
         if self.tavern_open:
             self._draw_tavern_overlay()
-        if self.bounty_open:
-            self._draw_bounty_overlay()
 
         # tooltip detection for buildings when no overlay open
         if not self._overlay_active():
@@ -766,9 +760,6 @@ class TownScreen:
         if self.tavern_open:
             self._tavern_click(pos)
             return
-        if self.bounty_open:
-            self._bounty_click(pos)
-            return
 
     def _on_overlay_mouseup(self, pos: Tuple[int,int], button: int) -> None:
         pass
@@ -819,7 +810,6 @@ class TownScreen:
             or self.market_open
             or self.castle_open
             or self.tavern_open
-            or self.bounty_open
         )
 
     def _close_all_overlays(self) -> None:
@@ -827,7 +817,6 @@ class TownScreen:
         self.market_open = False
         self.castle_open = False
         self.tavern_open = False
-        self.bounty_open = False
 
     # ------------------------------------------------------------ Market overlay
     def _open_market_overlay(self) -> None:
@@ -956,37 +945,8 @@ class TownScreen:
 
     # ----------------------------------------------------------- Bounty overlay
     def _open_bounty_overlay(self) -> None:
-        self.bounty_open = True
-        W, H = self.screen.get_size()
-        self.bounty_rect.center = (W // 2, H // 2)
-
-    def _draw_bounty_overlay(self) -> None:
-        s = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
-        s.fill((0, 0, 0, 160))
-        self.screen.blit(s, (0, 0))
-        r = self.bounty_rect
-        pygame.draw.rect(self.screen, (40, 42, 50), r, border_radius=8)
-        pygame.draw.rect(self.screen, (110, 110, 120), r, 2, border_radius=8)
-        self.screen.blit(self.font_big.render("Quests", True, COLOR_TEXT), (r.x + 16, r.y + 12))
-        self.bounty_cards = []
-        y = r.y + 60
-        for q in self.game.quest_manager.get_available():
-            btn = pygame.Rect(r.x + 20, y, r.width - 40, 40)
-            pygame.draw.rect(self.screen, (60, 62, 72), btn, border_radius=4)
-            reward = q.reward.get("gold") or q.reward.get("artifact", "")
-            txt = f"{q.id} → {reward}"
-            self.screen.blit(self.font.render(txt, True, COLOR_TEXT), (btn.x + 8, btn.y + 8))
-            self.bounty_cards.append((q.id, btn))
-            y += 48
-
-    def _bounty_click(self, pos: Tuple[int,int]) -> None:
-        for qid, btn in self.bounty_cards:
-            if btn.collidepoint(pos):
-                self.game.quest_manager.accept(qid)
-                self.bounty_open = False
-                return
-        if not self.bounty_rect.collidepoint(pos):
-            self.bounty_open = False
+        # Reuse the game's quest overlay
+        self.game.open_journal(self.screen)
 
     # ----------------------------------------------------------- Castle overlay
     def _open_castle_overlay(self) -> None:


### PR DESCRIPTION
## Summary
- add small and medium scenarios
- generate continent maps with resource and city placement
- unify quest definitions and provide quest journal overlay

## Testing
- `FG_FAST_TESTS=1 pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68aec6971f388321a31712f32472834f