### PR TITLE
Ensure display surface fully clears between scenes

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -1384,10 +1384,11 @@ class Game:
             # Advance queued movement then draw world
             self.update_movement()
             self.screen.fill(theme.PALETTE["background"])
-            dirty = [self.draw_world(self.anim_frame)]
-            # Overlay generic UI panels and collect their dirty rects
-            dirty.extend(self.main_screen.draw(self.screen))
-            pygame.display.update(dirty)
+            # Draw world and UI; update entire display to avoid residual
+            # artefacts from previous scenes (no dirty rect optimisation).
+            self.draw_world(self.anim_frame)
+            self.main_screen.draw(self.screen)
+            pygame.display.flip()
             dt = self.clock.tick(constants.FPS) / 1000.0
             self.main_screen.turn_bar.update(dt)
             self.anim_frame = (self.anim_frame + 1) % 60
@@ -3088,8 +3089,12 @@ class Game:
 
         overlay = TownOverlay(self.screen, self, towns)
         running = True
+        fast_tests = os.environ.get("FG_FAST_TESTS") == "1"
         while running:
-            for event in pygame.event.get():
+            events = pygame.event.get()
+            if not events and fast_tests:
+                break
+            for event in events:
                 result = overlay.handle_event(event)
                 if result is True:
                     running = False

--- a/tests/test_main_screen_draw_background.py
+++ b/tests/test_main_screen_draw_background.py
@@ -90,7 +90,7 @@ def test_run_fills_background_before_world(monkeypatch):
 
     monkeypatch.setattr(pygame, "QUIT", 0, raising=False)
     monkeypatch.setattr(pygame.event, "get", lambda: [SimpleNamespace(type=0)])
-    monkeypatch.setattr(pygame.display, "update", lambda rects: None, raising=False)
+    monkeypatch.setattr(pygame.display, "flip", lambda: None, raising=False)
     monkeypatch.setattr(pygame, "quit", lambda: None, raising=False)
 
     game.run()


### PR DESCRIPTION
## Summary
- Refresh the entire screen each frame to prevent ghosted backgrounds
- Break out of town overlay loop when no events during fast tests
- Update test to stub pygame.display.flip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeca84beb88321b6192563829074ca