### PR TITLE
Add animation speed and tooltip read mode settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ Pytest provides several options to iterate quickly during development:
 Runtime options are read from environment variables and the `settings.json`
 file in the project root. Setting `FG_DEBUG_BUILDINGS=1` (or adding
 `"debug_buildings": true` to `settings.json`) draws debug markers for building
-positions in the world renderer.
+positions in the world renderer. Additional entries such as
+`animation_speed`, `tooltip_read_mode` and `keymap` allow tuning animation
+speed, enabling a reader-friendly tooltip mode and remapping controls.
 
 ## Roadmap and Ideas
 

--- a/settings.json
+++ b/settings.json
@@ -7,6 +7,8 @@
   "language": "en",
   "volume": 1.0,
   "scroll_speed": 20,
+  "animation_speed": 1.0,
+  "tooltip_read_mode": false,
   "keymap": {
     "pan_left": ["K_LEFT", "K_a"],
     "pan_right": ["K_RIGHT", "K_d"],

--- a/settings.py
+++ b/settings.py
@@ -82,6 +82,16 @@ VOLUME: float = _get_float("FG_VOLUME", "volume", 1.0)
 # Map scroll speed in pixels per key press
 SCROLL_SPEED: int = _get_int("FG_SCROLL_SPEED", "scroll_speed", 20)
 
+# Animation speed multiplier for game visuals
+ANIMATION_SPEED: float = _get_float(
+    "FG_ANIMATION_SPEED", "animation_speed", 1.0
+)
+
+# Enable a reading-friendly mode for tooltips
+TOOLTIP_READ_MODE: bool = _get_bool(
+    "FG_TOOLTIP_READ_MODE", "tooltip_read_mode", False
+)
+
 _DEFAULT_KEYMAP: Dict[str, List[str]] = {
     "pan_left": ["K_LEFT", "K_a"],
     "pan_right": ["K_RIGHT", "K_d"],
@@ -108,11 +118,21 @@ def save_settings(**kwargs: Any) -> None:
         json.dump(data, f)
 
 
+def remap_key(action: str, keys: List[str]) -> None:
+    """Assign new ``keys`` to ``action`` and persist the mapping."""
+
+    KEYMAP[action] = keys
+    save_settings(keymap=KEYMAP)
+
+
 __all__ = [
     "DEBUG_BUILDINGS",
     "LANGUAGE",
     "VOLUME",
     "SCROLL_SPEED",
+    "ANIMATION_SPEED",
+    "TOOLTIP_READ_MODE",
     "KEYMAP",
     "save_settings",
+    "remap_key",
 ]

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -100,10 +100,10 @@ def test_options_menu_shows_translated_difficulties(monkeypatch):
     def fake_menu(_screen, options, title=''):
         calls.append(options)
         if len(calls) == 1:  # Open difficulty selection
-            return 5, _screen
+            return 7, _screen
         if len(calls) == 2:  # Difficulty options displayed
             return None, _screen
-        return 9, _screen  # Exit options menu
+        return 11, _screen  # Exit options menu
 
     monkeypatch.setattr(options_menu, 'simple_menu', fake_menu)
 

--- a/tests/test_settings_features.py
+++ b/tests/test_settings_features.py
@@ -1,0 +1,21 @@
+import json
+import settings
+
+
+def test_save_settings_persists_new_options(tmp_path, monkeypatch):
+    cfg = tmp_path / "settings.json"
+    monkeypatch.setattr(settings, "SETTINGS_FILE", cfg)
+    settings.save_settings(animation_speed=2.0, tooltip_read_mode=True)
+    data = json.loads(cfg.read_text(encoding="utf-8"))
+    assert data["animation_speed"] == 2.0
+    assert data["tooltip_read_mode"] is True
+
+
+def test_remap_key_persists(tmp_path, monkeypatch):
+    cfg = tmp_path / "settings.json"
+    monkeypatch.setattr(settings, "SETTINGS_FILE", cfg)
+    settings.KEYMAP = {}
+    settings.remap_key("pan_left", ["K_f"])
+    data = json.loads(cfg.read_text(encoding="utf-8"))
+    assert data["keymap"]["pan_left"] == ["K_f"]
+    assert settings.KEYMAP["pan_left"] == ["K_f"]


### PR DESCRIPTION
## Summary
- allow tweaking animation speed and enabling a tooltip reading mode via `settings.py`
- persist key remaps with a new helper and expose options in the menu
- document and test the new settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aed1bc621c8321ba12f209f49b4270