### PR TITLE
Add PyInstaller spec and build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ formatting and test utilities:
 pip install -e .[dev]
 ```
 
+## Building with PyInstaller
+
+The repository includes a `fantaisie.spec` file that bundles the entire
+`assets/` directory. Install **PyInstaller** and run the spec to create a
+standalone build:
+
+```bash
+pip install pyinstaller
+pyinstaller fantaisie.spec
+```
+
+The resulting executable and bundled assets are placed in `dist/fantaisie/`.
+
 ## Getting Started
 
 1. Make sure the `assets` folder contains the expected manifest files and

--- a/fantaisie.spec
+++ b/fantaisie.spec
@@ -1,0 +1,42 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[('assets', 'assets')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='fantaisie',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='fantaisie',
+)


### PR DESCRIPTION
## Summary
- include PyInstaller spec that bundles the assets directory
- document how to build a standalone executable with PyInstaller

## Testing
- `python -m pre_commit run --files README.md fantaisie.spec`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aed307dd54832183b094ac06b802ce