### PR TITLE
Flash turn bar on week change

### DIFF
--- a/tests/test_calendar_turn_bar.py
+++ b/tests/test_calendar_turn_bar.py
@@ -41,3 +41,21 @@ def test_turn_bar_animation_and_click():
     event = SimpleNamespace(type=MOUSEBUTTONDOWN, pos=(10, 10), button=1)
     assert bar.handle_event(event, rect)
     assert clicked and clicked[0] == cal.label()
+
+
+def test_turn_bar_flashes_on_week_change():
+    cal = GameCalendar()
+    bar = TurnBar(cal)
+
+    # Day progresses within the same week -> no flash
+    bar._on_turn_end(1)
+    assert bar._flash_time == 0
+
+    # Crossing into a new week should trigger the flash animation
+    bar._on_turn_end(7)
+    assert bar._flash_time == 0.5
+
+    # Finish the animation and ensure regular days don't retrigger it
+    bar.update(1.0)
+    bar._on_turn_end(8)
+    assert bar._flash_time == 0

--- a/ui/widgets/turn_bar.py
+++ b/ui/widgets/turn_bar.py
@@ -70,8 +70,12 @@ class TurnBar:
     def _on_turn_end(self, turn_index: int) -> None:
         """Update calendar and start animation from event bus."""
 
+        # Remember the previous week so we can detect when a new one begins
+        prev_week = self.calendar.week
         self.set_turn(turn_index)
-        self.on_turn_end()
+        # Only trigger the flash animation when the week actually changes
+        if self.calendar.week != prev_week:
+            self.on_turn_end()
 
     # ------------------------------------------------------------------
     def draw(self, surface: pygame.Surface, rect: pygame.Rect) -> None:


### PR DESCRIPTION
## Summary
- flash the turn bar when a new week starts
- cover week change animation with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aed7a453488321b6d6021acc9fb619