### PR TITLE
feat: French-first i18n for combat UI

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1,5 +1,16 @@
 {
   "Novice": "Novice",
   "Intermédiaire": "Intermediate",
-  "Avancé": "Advanced"
+  "Avancé": "Advanced",
+  "Spells": "Spells",
+  "Status": "Status",
+  "Next": "Next",
+  "Auto resolve": "Auto resolve",
+  "Auto combat": "Auto combat",
+  "Spellbook": "Spellbook",
+  "Back": "Back",
+  "Level": "Level",
+  "Mana": "Mana",
+  "Cooldown": "Cooldown",
+  "Range": "Range"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -1,5 +1,16 @@
 {
   "Novice": "Novice",
   "Intermédiaire": "Intermédiaire",
-  "Avancé": "Avancé"
+  "Avancé": "Avancé",
+  "Spells": "Sorts",
+  "Status": "Statuts",
+  "Next": "Suivant",
+  "Auto resolve": "Résolution auto",
+  "Auto combat": "Combat auto",
+  "Spellbook": "Grimoire",
+  "Back": "Retour",
+  "Level": "Niveau",
+  "Mana": "Mana",
+  "Cooldown": "Temps de recharge",
+  "Range": "Portée"
 }

--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -9,6 +9,7 @@ import theme
 import settings
 from ui.widgets.icon_button import IconButton
 from loaders import icon_loader as IconLoader
+from loaders.i18n import load_locale
 
 BUTTON_H = 28
 # Slightly wider and taller panel to fit spells/statuses
@@ -26,6 +27,7 @@ class CombatHUD:
         self.small = pygame.font.SysFont(None, 16)
         self.title = pygame.font.SysFont(None, 22)
         self.action_labels = self._load_action_labels(settings.LANGUAGE)
+        self.texts = load_locale(settings.LANGUAGE)
 
         # Preload commonly used action and stat icons
         self.action_icon_keys = {
@@ -73,7 +75,7 @@ class CombatHUD:
 
     def _load_action_labels(self, language: str) -> Dict[str, str]:
         """Load translated action labels from ``assets/i18n/action_labels.json``."""
-        default = "en"
+        default = "fr"
         path = (
             Path(__file__).resolve().parents[1]
             / "assets"
@@ -182,7 +184,11 @@ class CombatHUD:
                     spells.append((name, cost))
             if spells:
                 screen.blit(
-                    self.small.render("Spells:", True, theme.PALETTE["text"]),
+                    self.small.render(
+                        f"{self.texts.get('Spells', 'Spells')}:",
+                        True,
+                        theme.PALETTE["text"],
+                    ),
                     (right.x + 10, y),
                 )
                 y += 18
@@ -196,7 +202,11 @@ class CombatHUD:
             if effects:
                 y += 6
                 screen.blit(
-                    self.small.render("Status:", True, theme.PALETTE["text"]),
+                    self.small.render(
+                        f"{self.texts.get('Status', 'Status')}:",
+                        True,
+                        theme.PALETTE["text"],
+                    ),
                     (right.x + 10, y),
                 )
                 y += 18
@@ -225,7 +235,11 @@ class CombatHUD:
             # Turn order thumbnails
             y0 = y + 10
             screen.blit(
-                self.small.render("Next:", True, theme.PALETTE["text"]),
+                self.small.render(
+                    f"{self.texts.get('Next', 'Next')}:",
+                    True,
+                    theme.PALETTE["text"],
+                ),
                 (right.x + 10, y0),
             )
             y = y0 + 18
@@ -252,7 +266,7 @@ class CombatHUD:
                 "action_auto_resolve",
                 combat.auto_resolve,
                 hotkey=self.hotkeys.get("action_auto_resolve"),
-                tooltip="Auto resolve",
+                tooltip=self.texts.get("Auto resolve", "Auto resolve"),
             )
             auto_resolve_btn.draw(screen)
             action_buttons["auto_resolve"] = auto_resolve_btn
@@ -264,7 +278,7 @@ class CombatHUD:
                 "action_auto_combat",
                 combat.auto_combat,
                 hotkey=self.hotkeys.get("action_auto_combat"),
-                tooltip="Auto combat",
+                tooltip=self.texts.get("Auto combat", "Auto combat"),
             )
             auto_button.draw(screen)
             y = auto_combat_rect.bottom + 6
@@ -275,7 +289,7 @@ class CombatHUD:
                 "action_cast",
                 lambda: combat.hero_spells and combat.show_spellbook(),
                 hotkey=getattr(pygame, "K_s", ord("s")),
-                tooltip="Spellbook",
+                tooltip=self.texts.get("Spellbook", "Spellbook"),
                 enabled=bool(combat.hero_spells),
             )
             spell_btn.draw(screen)
@@ -368,10 +382,14 @@ class CombatHUD:
                 rect,
                 "action_move",
                 lambda: setattr(combat, "selected_action", None),
-                tooltip="Back",
+                tooltip=self.texts.get("Back", "Back"),
             )
             back_btn.draw(screen)
-            txt = self.small.render("Back", True, theme.PALETTE["text"])
+            txt = self.small.render(
+                self.texts.get("Back", "Back"),
+                True,
+                theme.PALETTE["text"],
+            )
             screen.blit(txt, txt.get_rect(center=rect.center))
             action_buttons["back"] = back_btn
 

--- a/loaders/i18n.py
+++ b/loaders/i18n.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 The project keeps locale files in :mod:`assets/i18n` using a simple
 ``key -> value`` mapping per language.  This module exposes a small helper
-that merges the default (English) strings with the requested language so
-missing keys gracefully fall back to the English text.
+that merges the default (French) strings with the requested language so
+missing keys gracefully fall back to the French text.
 """
 
 from typing import Dict
@@ -14,7 +14,7 @@ import os
 from .core import Context, read_json
 
 
-def load_locale(language: str, default: str = "en") -> Dict[str, str]:
+def load_locale(language: str, default: str = "fr") -> Dict[str, str]:
     """Return a dictionary of translation strings for ``language``.
 
     ``default`` specifies the base language to fall back to when a key is not

--- a/settings.py
+++ b/settings.py
@@ -74,7 +74,7 @@ def _get_float(env_var: str, key: str, default: float) -> float:
 DEBUG_BUILDINGS: bool = _get_bool("FG_DEBUG_BUILDINGS", "debug_buildings", False)
 
 # Language used for UI text
-LANGUAGE: str = _get_str("FG_LANGUAGE", "language", "en")
+LANGUAGE: str = _get_str("FG_LANGUAGE", "language", "fr")
 
 # Master audio volume (0.0 - 1.0)
 VOLUME: float = _get_float("FG_VOLUME", "volume", 1.0)

--- a/tests/test_spellbook_overlay.py
+++ b/tests/test_spellbook_overlay.py
@@ -2,6 +2,8 @@ import pygame
 from types import SimpleNamespace
 
 from core.spell import Spell
+from loaders.i18n import load_locale
+import settings
 
 
 class DummyCombat:
@@ -36,6 +38,7 @@ def test_pagination_and_tooltip(pygame_stub):
     overlay.handle_event(_make_event(pygame.MOUSEBUTTONDOWN, button=4))
     assert overlay.page == 0
 
+    strings = load_locale(settings.LANGUAGE)
     lines = overlay._spell_tooltip("spell1")
-    assert any("Mana" in ln for ln in lines)
-    assert any("Cooldown" in ln for ln in lines)
+    assert any(strings.get("Mana", "Mana") in ln for ln in lines)
+    assert any(strings.get("Cooldown", "Cooldown") in ln for ln in lines)

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -26,7 +26,7 @@ _menu = simple_menu
 
 def _load_menu_texts(language: str) -> dict[str, str]:
     """Load translated menu strings from ``assets/i18n/menu.json``."""
-    default = "en"
+    default = "fr"
     path = Path(__file__).resolve().parents[1] / "assets" / "i18n" / "menu.json"
     try:
         with path.open("r", encoding="utf-8") as f:

--- a/ui/spellbook_overlay.py
+++ b/ui/spellbook_overlay.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pygame
 import theme
+import settings
+from loaders.i18n import load_locale
 
 
 class SpellbookOverlay:
@@ -15,6 +17,7 @@ class SpellbookOverlay:
         self.screen = screen
         self.combat = combat
         self.font = theme.get_font(20) or pygame.font.SysFont(None, 20)
+        self.texts = load_locale(settings.LANGUAGE)
         # Pagination state
         self.page: int = 0
         self.spell_names = sorted(self.combat.hero_spells.keys())
@@ -34,13 +37,13 @@ class SpellbookOverlay:
         lines = [name.replace("_", " ").title()]
         lvl = self.combat.hero_spells.get(name)
         if lvl:
-            lines.append(f"Level: {lvl}")
+            lines.append(f"{self.texts.get('Level', 'Level')}: {lvl}")
         spec = getattr(self.combat, "spell_defs", {}).get(name)
         if spec:
-            lines.append(f"Mana: {spec.cost_mana}")
+            lines.append(f"{self.texts.get('Mana', 'Mana')}: {spec.cost_mana}")
             if spec.cooldown:
-                lines.append(f"Cooldown: {spec.cooldown}")
-            lines.append(f"Range: {spec.range}")
+                lines.append(f"{self.texts.get('Cooldown', 'Cooldown')}: {spec.cooldown}")
+            lines.append(f"{self.texts.get('Range', 'Range')}: {spec.range}")
         return lines
 
     def _draw_tooltip(self, surface: pygame.Surface, pos: tuple[int, int], lines: list[str]) -> None:
@@ -94,7 +97,7 @@ class SpellbookOverlay:
         overlay.fill((*self.BG, 230))
         theme.draw_frame(overlay, overlay.get_rect())
 
-        title = self.font.render("Spellbook", True, self.TEXT)
+        title = self.font.render(self.texts.get("Spellbook", "Spellbook"), True, self.TEXT)
         overlay.blit(title, ((w - title.get_width()) // 2, 10))
 
         self._label_rects.clear()


### PR DESCRIPTION
## Summary
- default to French locales and load menu/action texts from assets/i18n
- replace hard coded combat HUD and spellbook strings with translation keys
- localize tests for spell tooltips

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aee9d40b4c8321b3e85ff3f07e5f1d