### PR TITLE
Add faction-specific town buildings loader

### DIFF
--- a/core/buildings.py
+++ b/core/buildings.py
@@ -8,6 +8,7 @@ import constants
 from loaders import building_loader
 from loaders.building_loader import BuildingAsset
 from loaders.core import Context
+from loaders.town_building_loader import load_faction_town_buildings
 
 if TYPE_CHECKING:  # pragma: no cover
     from core.entities import Hero, Unit
@@ -181,7 +182,7 @@ class Town(Building):
     image = "town"
     _counter = 0
 
-    def __init__(self, name: Optional[str] = None) -> None:
+    def __init__(self, name: Optional[str] = None, faction_id: Optional[str] = None) -> None:
         super().__init__()
         if name is None:
             Town._counter += 1
@@ -212,6 +213,18 @@ class Town(Building):
                 "dwelling": entry.get("dwelling", {}),
             }
         self.ui_order = order
+
+        if faction_id:
+            repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+            ctx = Context(
+                repo_root=repo_root,
+                search_paths=[os.path.join(repo_root, "assets")],
+                asset_loader=None,
+            )
+            extras = load_faction_town_buildings(ctx, faction_id)
+            for sid, info in extras.items():
+                self.structures[sid] = info
+                self.ui_order.append(sid)
 
         # Tavern is present by default in every town
         self.built_structures: Set[str] = {"tavern"}

--- a/loaders/town_building_loader.py
+++ b/loaders/town_building_loader.py
@@ -1,0 +1,59 @@
+"""Loader for faction-specific town building manifests."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .core import Context, read_json
+
+# Mapping of faction identifiers to their town building manifest paths
+FACTION_TOWN_BUILDING_MANIFESTS: Dict[str, str] = {
+    "sylvan": "buildings/buildings_sylvan.json",
+    "solaceheim": "buildings/buildings_solaceheim.json",
+}
+
+
+def load_town_buildings(ctx: Context, manifest: str) -> Dict[str, Dict[str, object]]:
+    """Load town structure definitions from ``manifest``.
+
+    The manifest is expected to contain a list of objects each describing a
+    building. Only a handful of common fields are normalised so that the
+    :class:`core.buildings.Town` class can consume the resulting mapping.
+    Unknown keys are preserved as-is which allows experimental attributes to be
+    carried through without explicit support in the loader.
+    """
+
+    try:
+        entries: List[Dict[str, object]] = read_json(ctx, manifest)
+    except Exception:
+        return {}
+
+    defs: Dict[str, Dict[str, object]] = {}
+    for entry in entries:
+        bid = entry.get("id")
+        if not bid:
+            continue
+        data = dict(entry)
+        # Normalise expected fields with sensible defaults
+        data.setdefault("cost", {})
+        data.setdefault("desc", "")
+        data.setdefault("dwelling", {})
+        data.setdefault("prereq", data.pop("requires", []))
+        data.setdefault("image", data.get("image", ""))
+        defs[bid] = data
+    return defs
+
+
+def load_faction_town_buildings(ctx: Context, faction_id: str) -> Dict[str, Dict[str, object]]:
+    """Return town buildings defined for ``faction_id``."""
+
+    manifest = FACTION_TOWN_BUILDING_MANIFESTS.get(faction_id)
+    if not manifest:
+        return {}
+    return load_town_buildings(ctx, manifest)
+
+
+__all__ = [
+    "FACTION_TOWN_BUILDING_MANIFESTS",
+    "load_town_buildings",
+    "load_faction_town_buildings",
+]

--- a/tests/test_faction_town_buildings.py
+++ b/tests/test_faction_town_buildings.py
@@ -1,0 +1,24 @@
+import os
+
+from core.buildings import Town
+from loaders.core import Context
+from loaders.town_building_loader import (
+    FACTION_TOWN_BUILDING_MANIFESTS,
+    load_faction_town_buildings,
+)
+
+
+def _ctx():
+    repo = os.path.join(os.path.dirname(__file__), "..")
+    repo = os.path.abspath(repo)
+    search = [os.path.join(repo, "assets")]
+    return Context(repo_root=repo, search_paths=search, asset_loader=None)
+
+
+def test_faction_town_buildings_available():
+    ctx = _ctx()
+    for faction_id in FACTION_TOWN_BUILDING_MANIFESTS:
+        town = Town(faction_id=faction_id)
+        expected = load_faction_town_buildings(ctx, faction_id)
+        for bid in expected:
+            assert bid in town.structures


### PR DESCRIPTION
## Summary
- add town building loader to parse faction manifests
- allow Town to merge faction-specific structures via `faction_id`
- add tests ensuring faction towns expose their unique buildings

## Testing
- `pytest tests/test_faction_town_buildings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af18d895748321947749cf8fbdeb90