### PR TITLE
Load factions dynamically for scenario config

### DIFF
--- a/tests/test_new_game_menu.py
+++ b/tests/test_new_game_menu.py
@@ -7,6 +7,7 @@ import pygame
 
 from ui import menu
 import constants
+from core.faction import FactionDef
 
 
 def _init_screen(monkeypatch):
@@ -118,6 +119,14 @@ def test_scenario_config_confirm(monkeypatch):
         return events.pop(0) if events else []
 
     monkeypatch.setattr(pygame.event, "get", fake_get)
+
+    def fake_load_factions(_ctx):
+        return {
+            "red_knights": FactionDef(id="red_knights", name="Red Knights"),
+            "blue_knaves": FactionDef(id="blue_knaves", name="Blue Knaves"),
+        }
+
+    monkeypatch.setattr(menu, "load_factions", fake_load_factions)
     config, _ = menu._scenario_config(screen, "foo.json")
     assert config["scenario"] == "foo.json"
     assert config["map_size"] == list(constants.MAP_SIZE_PRESETS.keys())[0]

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -19,6 +19,8 @@ import constants, audio, settings
 from core.game import Game, SAVE_SLOT_FILES
 from ui.options_menu import options_menu
 from ui.menu_utils import simple_menu
+from loaders.faction_loader import load_factions
+from loaders.core import Context
 
 # Backwards compatibility: expose helper under old name
 _menu = simple_menu
@@ -179,13 +181,18 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
     map_type_labels = [MENU_TEXTS[opt] for opt in map_type_opts]
     colour_labels = [MENU_TEXTS["blue"], MENU_TEXTS["red"]]
     colour_values = [constants.BLUE, constants.RED]
-    faction_opts = ["red_knights", None]
-    faction_labels = ["Red Knights" if f else MENU_TEXTS["random"] for f in faction_opts]
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    ctx = Context(repo_root=repo_root, search_paths=[os.path.join(repo_root, "assets")])
+    factions = load_factions(ctx)
+    faction_items = sorted(factions.items())
+    faction_opts = [fid for fid, _ in faction_items] + [None]
+    faction_labels = [f.name for _, f in faction_items] + [MENU_TEXTS["random"]]
     total_players_opts = [2, 3, 4]
     human_players_opts = [1, 2, 3, 4]
 
     # Current selection indices for each option group.
-    idx_size = idx_map = idx_diff = idx_total = idx_human = idx_colour = idx_faction = 0
+    idx_size = idx_map = idx_diff = idx_total = idx_human = idx_colour = 0
+    idx_faction = faction_opts.index("red_knights") if "red_knights" in faction_opts else 0
     player_name = MENU_TEXTS["default_player_name"]
 
     rows = [


### PR DESCRIPTION
## Summary
- derive faction options dynamically via `load_factions` in `_scenario_config`
- preserve `red_knights` as default faction and add a "random" option
- update menu test to mock faction loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1b9cf11c8321a4a3d6f02a96c47e