### PR TITLE
Load hero definitions from manifest

### DIFF
--- a/assets/units/heroes.json
+++ b/assets/units/heroes.json
@@ -6,15 +6,23 @@
     "faction": "red_knights",
     "level": 5,
     "overworld": { "movement": 12, "vision": 3 },
-    "combat": {
-      "mana": 30, "spellpower": 3, "knowledge": 2,
-      "morale": 1, "luck": 0
-    },
-    "starting_skills": [
-      {"branch":"logistics","rank":"N","id":"logistics_N"},
-      {"branch":"logistics","rank":"A","id":"logistics_A"},
-      {"branch":"tactics","rank":"N","id":"tactics_N"},
-      {"branch":"logistics","rank":"E","id":"logistics_E"}
+      "combat": {
+        "mana": 30, "spellpower": 3, "knowledge": 2,
+        "morale": 1, "luck": 0
+      },
+      "starting_army": [
+        {"unit": "Swordsman", "count": 22},
+        {"unit": "Archer", "count": 30},
+        {"unit": "Mage", "count": 15},
+        {"unit": "Cavalry", "count": 16},
+        {"unit": "Dragon", "count": 5},
+        {"unit": "Priest", "count": 15}
+      ],
+      "starting_skills": [
+        {"branch":"logistics","rank":"N","id":"logistics_N"},
+        {"branch":"logistics","rank":"A","id":"logistics_A"},
+        {"branch":"tactics","rank":"N","id":"tactics_N"},
+        {"branch":"logistics","rank":"E","id":"logistics_E"}
     ],
     "known_spells": ["Crimson Surge","Valiant Charge","Guard Order","Rally on the Road"],
     "PortraitSprite": "hero/red_knights/lady_aurianne.png",
@@ -34,12 +42,12 @@
       "mana": 30, "spellpower": 4, "knowledge": 1,
       "morale": 0, "luck": 1
     },
-    "starting_skills": [
-      {"branch":"marksmanship","rank":"N","id":"marksmanship_N"},
-      {"branch":"marksmanship","rank":"A","id":"marksmanship_A},
-      {"branch":"weaponsmithing","rank":"N","id":"weaponsmithing_N"},
-      {"branch":"weaponsmithing","rank":"A","id":"weaponsmithing_A"}
-    ],
+      "starting_skills": [
+        {"branch":"marksmanship","rank":"N","id":"marksmanship_N"},
+        {"branch":"marksmanship","rank":"A","id":"marksmanship_A"},
+        {"branch":"weaponsmithing","rank":"N","id":"weaponsmithing_N"},
+        {"branch":"weaponsmithing","rank":"A","id":"weaponsmithing_A"}
+      ],
     "known_spells": ["sand_screen"],
     "PortraitSprite": "hero/red_knights/lady_aurianne.png",
     "OverWorldSprite": "hero/red_knights/lady_aurianne.png",

--- a/loaders/hero_loader.py
+++ b/loaders/hero_loader.py
@@ -1,0 +1,75 @@
+"""Loader for hero definitions."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, Any
+
+from .core import Context, read_json, require_keys
+
+
+@dataclass(slots=True)
+class HeroDef:
+    id: str
+    name: str
+    faction: str
+    overworld: Dict[str, Any] = field(default_factory=dict)
+    combat: Dict[str, Any] = field(default_factory=dict)
+    starting_army: List[Tuple[str, int]] = field(default_factory=list)
+    starting_skills: List[Dict[str, Any]] = field(default_factory=list)
+    known_spells: List[str] = field(default_factory=list)
+    portrait: str | None = None
+    overworld_sprite: str | None = None
+    battlefield_sprite: str | None = None
+
+
+def _parse_army(items: List[Any]) -> List[Tuple[str, int]]:
+    army: List[Tuple[str, int]] = []
+    for entry in items:
+        if isinstance(entry, dict):
+            unit = entry.get("unit") or entry.get("id")
+            if not unit:
+                continue
+            count = int(entry.get("count", 1))
+            army.append((unit, count))
+        elif isinstance(entry, str):
+            army.append((entry, 1))
+    return army
+
+
+def load_heroes(ctx: Context, manifest: str = "units/heroes.json") -> Dict[str, HeroDef]:
+    """Load hero definitions from ``manifest``.
+
+    The manifest should be a JSON array describing heroes. Each hero entry may
+    specify ``starting_army`` as a list of unit identifiers or objects with
+    ``unit``/``id`` and ``count`` fields.
+    """
+
+    try:
+        data = read_json(ctx, manifest)
+    except Exception:
+        return {}
+
+    heroes: Dict[str, HeroDef] = {}
+    for entry in data:
+        try:
+            require_keys(entry, ["id", "faction"])
+        except Exception:
+            continue
+        hero = HeroDef(
+            id=entry["id"],
+            name=entry.get("name", entry["id"]),
+            faction=entry.get("faction", ""),
+            overworld=dict(entry.get("overworld", {})),
+            combat=dict(entry.get("combat", {})),
+            starting_army=_parse_army(entry.get("starting_army", [])),
+            starting_skills=[dict(s) for s in entry.get("starting_skills", [])],
+            known_spells=list(entry.get("known_spells", [])),
+            portrait=entry.get("PortraitSprite"),
+            overworld_sprite=entry.get("OverWorldSprite"),
+            battlefield_sprite=entry.get("BattlefieldSprite"),
+        )
+        heroes[hero.id] = hero
+    return heroes
+
+
+__all__ = ["HeroDef", "load_heroes"]

--- a/tests/test_hero_loader.py
+++ b/tests/test_hero_loader.py
@@ -1,0 +1,13 @@
+import os
+from loaders.core import Context
+from loaders.hero_loader import load_heroes
+
+
+def test_hero_loader_parses_manifest():
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    ctx = Context(repo_root=repo_root, search_paths=[os.path.join(repo_root, "assets")])
+    heroes = load_heroes(ctx, "units/heroes.json")
+    assert "scarletia_aurianne" in heroes
+    aurianne = heroes["scarletia_aurianne"]
+    assert aurianne.faction == "red_knights"
+    assert any(u == "Swordsman" for u, _ in aurianne.starting_army)


### PR DESCRIPTION
## Summary
- add `HeroDef` dataclass and loader for `assets/units/heroes.json`
- use hero definitions in `Game` to build starting army, skills, and spells
- document hero starting army in heroes manifest and add loader test

## Testing
- `pytest tests/test_hero_loader.py tests/test_coast_assets.py::test_coast_assets_loaded -q`
- `pre-commit run --files loaders/hero_loader.py core/game.py assets/units/heroes.json tests/test_hero_loader.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1e4506b083219cbbd42bcc8085b8