### PR TITLE
feat: add unit stat templates and palettes

### DIFF
--- a/assets/units/creatures.json
+++ b/assets/units/creatures.json
@@ -1,53 +1,81 @@
-[
-  {
-    "id": "fumet_lizard",
-    "image": "units/scarletia/fumet_lizard_0.png",
-    "anchor_px": [384, 580],
-    "shadow_baked": false,
-    "biomes": ["scarletia_volcanic"],
-    "behavior": "roamer",
-    "guard_range": 3,
-    "battlefield_scale": 1.0
+{
+  "templates": {
+    "lizard": {
+      "stats": {"attack": 4, "defense": 3, "hp": 18, "speed": 5},
+      "palette": ["#556B2F", "#8FBC8F", "#2E8B57"]
+    },
+    "wolf": {
+      "stats": {"attack": 5, "defense": 3, "hp": 20, "speed": 6},
+      "palette": ["#696969", "#A9A9A9", "#000000"]
+    },
+    "boar": {
+      "stats": {"attack": 6, "defense": 4, "hp": 28, "speed": 5},
+      "palette": ["#8B4513", "#A0522D", "#3E2723"]
+    },
+    "hurlombe": {
+      "stats": {"attack": 7, "defense": 6, "hp": 35, "speed": 4},
+      "palette": ["#2F4F4F", "#708090", "#000000"]
+    },
+    "serpent": {
+      "stats": {"attack": 9, "defense": 8, "hp": 50, "speed": 7},
+      "palette": ["#1E90FF", "#00CED1", "#F0FFFF"]
+    }
   },
-  {
-    "id": "shadowleaf_wolf",
-    "image": "units/scarletia/shadowleaf_wolf_0.png",
-    "anchor_px": [384, 590],
-    "shadow_baked": false,
-    "biomes": ["scarletia_crimson_forest"],
-    "behavior": "roamer",
-    "guard_range": 3,
-    "battlefield_scale": 1.0
-  },
-  {
-    "id": "boar_raven",
-    "image": "units/scarletia/boar_raven_0.png",
-    "anchor_px": [384, 610],
-    "shadow_baked": false,
-    "biomes": ["scarletia_echo_plain", "mountain"],
-    "behavior": "roamer",
-    "guard_range": 2,
-    "battlefield_scale": 1.0
-  },
-  {
-    "id": "hurlombe",
-    "image": "units/scarletia/hurlombe_0.png",
-    "anchor_px": [384, 600],
-    "shadow_baked": false,
-    "biomes": ["scarletia_crimson_forest", "mountain"],
-    "behavior": "guardian",
-    "guard_range": 2,
-    "battlefield_scale": 1.0
-  },
-  {
-    "id": "reef_serpent",
-    "image": "units/scarletia/reef_serpent_0.png",
-    "anchor_px": [384, 600],
-    "shadow_baked": false,
-    "biomes": ["ocean"],
-    "behavior": "roamer",
-    "guard_range": 3,
-    "battlefield_scale": 1.75
-  }
-]
-
+  "creatures": [
+    {
+      "id": "fumet_lizard",
+      "template": "lizard",
+      "image": "units/scarletia/fumet_lizard_0.png",
+      "anchor_px": [384, 580],
+      "shadow_baked": false,
+      "biomes": ["scarletia_volcanic"],
+      "behavior": "roamer",
+      "guard_range": 3,
+      "battlefield_scale": 1.0
+    },
+    {
+      "id": "shadowleaf_wolf",
+      "template": "wolf",
+      "image": "units/scarletia/shadowleaf_wolf_0.png",
+      "anchor_px": [384, 590],
+      "shadow_baked": false,
+      "biomes": ["scarletia_crimson_forest"],
+      "behavior": "roamer",
+      "guard_range": 3,
+      "battlefield_scale": 1.0
+    },
+    {
+      "id": "boar_raven",
+      "template": "boar",
+      "image": "units/scarletia/boar_raven_0.png",
+      "anchor_px": [384, 610],
+      "shadow_baked": false,
+      "biomes": ["scarletia_echo_plain", "mountain"],
+      "behavior": "roamer",
+      "guard_range": 2,
+      "battlefield_scale": 1.0
+    },
+    {
+      "id": "hurlombe",
+      "template": "hurlombe",
+      "image": "units/scarletia/hurlombe_0.png",
+      "anchor_px": [384, 600],
+      "shadow_baked": false,
+      "biomes": ["scarletia_crimson_forest", "mountain"],
+      "behavior": "guardian",
+      "guard_range": 2,
+      "battlefield_scale": 1.0
+    },
+    {
+      "id": "reef_serpent",
+      "template": "serpent",
+      "image": "units/scarletia/reef_serpent_0.png",
+      "anchor_px": [384, 600],
+      "shadow_baked": false,
+      "biomes": ["ocean"],
+      "behavior": "roamer",
+      "guard_range": 3,
+      "battlefield_scale": 1.75
+    }
+  ]
+}

--- a/assets/units/heroes.json
+++ b/assets/units/heroes.json
@@ -1,15 +1,55 @@
-[
-  {
-    "id": "scarletia_aurianne",
-    "name": "Lady Aurianne",
-    "class": "Banner Marshal",
-    "faction": "red_knights",
-    "level": 5,
-    "overworld": { "movement": 12, "vision": 3 },
-      "combat": {
-        "mana": 30, "spellpower": 3, "knowledge": 2,
-        "morale": 1, "luck": 0
+{
+  "templates": {
+    "red_marshal": {
+      "stats": {
+        "overworld": {"movement": 12, "vision": 3},
+        "combat": {"mana": 30, "spellpower": 3, "knowledge": 2, "morale": 1, "luck": 0}
       },
+      "palette": ["#B22222", "#FFD700"]
+    },
+    "red_cinderblade": {
+      "stats": {
+        "overworld": {"movement": 12, "vision": 3},
+        "combat": {"mana": 30, "spellpower": 4, "knowledge": 1, "morale": 0, "luck": 1}
+      },
+      "palette": ["#B22222", "#8B0000"]
+    },
+    "sylvan_warden": {
+      "stats": {
+        "overworld": {"movement": 12, "vision": 4},
+        "combat": {"mana": 40, "spellpower": 2, "knowledge": 3, "morale": 1, "luck": 0}
+      },
+      "palette": ["#006400", "#8FBC8F"]
+    },
+    "sylvan_druid": {
+      "stats": {
+        "overworld": {"movement": 12, "vision": 4},
+        "combat": {"mana": 35, "spellpower": 3, "knowledge": 2, "morale": 0, "luck": 1}
+      },
+      "palette": ["#228B22", "#2E8B57"]
+    },
+    "sol_sage": {
+      "stats": {
+        "overworld": {"movement": 12, "vision": 4},
+        "combat": {"mana": 120, "spellpower": 2, "knowledge": 3, "morale": 1, "luck": 0}
+      },
+      "palette": ["#FFD700", "#FFFACD"]
+    },
+    "sol_scorpion": {
+      "stats": {
+        "overworld": {"movement": 12, "vision": 4},
+        "combat": {"mana": 35, "spellpower": 3, "knowledge": 2, "morale": 0, "luck": 1}
+      },
+      "palette": ["#DAA520", "#8B4513"]
+    }
+  },
+  "heroes": [
+    {
+      "id": "scarletia_aurianne",
+      "template": "red_marshal",
+      "name": "Lady Aurianne",
+      "class": "Banner Marshal",
+      "faction": "red_knights",
       "starting_army": [
         {"unit": "Swordsman", "count": 22},
         {"unit": "Archer", "count": 30},
@@ -19,137 +59,113 @@
         {"unit": "Priest", "count": 15}
       ],
       "starting_skills": [
-        {"branch":"logistics","rank":"N","id":"logistics_N"},
-        {"branch":"logistics","rank":"A","id":"logistics_A"},
-        {"branch":"tactics","rank":"N","id":"tactics_N"},
-        {"branch":"logistics","rank":"E","id":"logistics_E"}
-    ],
-    "known_spells": ["Crimson Surge","Valiant Charge","Guard Order","Rally on the Road"],
-    "PortraitSprite": "hero/red_knights/lady_aurianne.png",
-    "OverWorldSprite": "hero/red_knights/lady_aurianne.png",
-    "BattlefieldSprite": "hero/bf_default.png",
-    "battlefield_scale": 1.0,
-    "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
-  },
-  {
-    "id": "scarletia_draxen",
-    "name": "Draxen the Cinderblade",
-    "class": "Cinderblade",
-    "faction": "red_knights",
-    "level": 5,
-    "overworld": { "movement": 12, "vision": 3 },
-    "combat": {
-      "mana": 30, "spellpower": 4, "knowledge": 1,
-      "morale": 0, "luck": 1
-    },
-      "starting_skills": [
-        {"branch":"marksmanship","rank":"N","id":"marksmanship_N"},
-        {"branch":"marksmanship","rank":"A","id":"marksmanship_A"},
-        {"branch":"weaponsmithing","rank":"N","id":"weaponsmithing_N"},
-        {"branch":"weaponsmithing","rank":"A","id":"weaponsmithing_A"}
+        {"branch": "logistics", "rank": "N", "id": "logistics_N"},
+        {"branch": "logistics", "rank": "A", "id": "logistics_A"},
+        {"branch": "tactics", "rank": "N", "id": "tactics_N"},
+        {"branch": "logistics", "rank": "E", "id": "logistics_E"}
       ],
-    "known_spells": ["sand_screen"],
-    "PortraitSprite": "hero/red_knights/draxen.png",
-    "OverWorldSprite": "hero/red_knights/draxen.png",
-    "BattlefieldSprite": "hero/bf_default.png",
-    "battlefield_scale": 1.0,
-    "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
-  },
-  {
-    "id": "sylvan_lirael",
-    "name": "Lirael",
-    "class": "Mist Grove Warden",
-    "faction": "sylvan",
-    "level": 5,
-    "overworld": { "movement": 12, "vision": 4 },
-    "combat": {
-      "mana": 40, "spellpower": 2, "knowledge": 3,
-      "morale": 1, "luck": 0
+      "known_spells": ["Crimson Surge", "Valiant Charge", "Guard Order", "Rally on the Road"],
+      "PortraitSprite": "hero/red_knights/lady_aurianne.png",
+      "OverWorldSprite": "hero/red_knights/lady_aurianne.png",
+      "BattlefieldSprite": "hero/bf_default.png",
+      "battlefield_scale": 1.0,
+      "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
     },
-    "starting_skills": [
-      {"branch":"Mists & Streams","rank":"N","id":"Mist Veil"},
-      {"branch":"Sylvan Heart","rank":"N","id":"Entangling Vines"},
-      {"branch":"Verdant Grace","rank":"N","id":"Dew Mend"},
-      {"branch":"Song of the Wind","rank":"N","id":"Zephyr Step"}
-    ],
-    "known_spells": ["sand_screen"],
-    "PortraitSprite": "hero/sylvan_haven/lirael.png",
-    "OverWorldSprite": "hero/sylvan_haven/lirael.png",
-    "BattlefieldSprite": "hero/bf_default.png",
-    "battlefield_scale": 1.0,
-    "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
-  },
-  {
-    "id": "sylvan_thorne",
-    "name": "Thorne of the Umbra Grove",
-    "class": "Umbra Druid",
-    "faction": "sylvan",
-    "level": 5,
-    "overworld": { "movement": 12, "vision": 4 },
-    "combat": {
-      "mana": 35, "spellpower": 3, "knowledge": 2,
-      "morale": 0, "luck": 1
+    {
+      "id": "scarletia_draxen",
+      "template": "red_cinderblade",
+      "name": "Draxen the Cinderblade",
+      "class": "Cinderblade",
+      "faction": "red_knights",
+      "starting_skills": [
+        {"branch": "marksmanship", "rank": "N", "id": "marksmanship_N"},
+        {"branch": "marksmanship", "rank": "A", "id": "marksmanship_A"},
+        {"branch": "weaponsmithing", "rank": "N", "id": "weaponsmithing_N"},
+        {"branch": "weaponsmithing", "rank": "A", "id": "weaponsmithing_A"}
+      ],
+      "known_spells": ["sand_screen"],
+      "PortraitSprite": "hero/red_knights/draxen.png",
+      "OverWorldSprite": "hero/red_knights/draxen.png",
+      "BattlefieldSprite": "hero/bf_default.png",
+      "battlefield_scale": 1.0,
+      "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
     },
-    "starting_skills": [
-      {"branch":"Sylvan Heart","rank":"N","id":"Entangling Vines"},
-      {"branch":"Sylvan Heart","rank":"A","id":"Bramble Field"},
-      {"branch":"Sylvan Heart","rank":"E","id":"Summon Sprite"},
-      {"branch":"Verdant Grace","rank":"N","id":"Dew Mend"}
-    ],
-    "known_spells": ["sand_screen"],
-    "PortraitSprite": "hero/sylvan_haven/thorne.png",
-    "OverWorldSprite": "hero/sylvan_haven/thorne.png",
-    "BattlefieldSprite": "hero/bf_default.png",
-    "battlefield_scale": 1.0,
-    "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
-  },
-  {
-    "id": "sol_aurelion",
-    "name": "Hiérophante Aurelion",
-    "class": "Sage solaire",
-    "faction": "solaceheim",
-    "level": 5,
-    "overworld": { "movement": 12, "vision": 4 },
-    "combat": {
-      "mana": 120, "spellpower": 2, "knowledge": 3,
-      "morale": 1, "luck": 0
+    {
+      "id": "sylvan_lirael",
+      "template": "sylvan_warden",
+      "name": "Lirael",
+      "class": "Mist Grove Warden",
+      "faction": "sylvan",
+      "starting_skills": [
+        {"branch": "Mists & Streams", "rank": "N", "id": "Mist Veil"},
+        {"branch": "Sylvan Heart", "rank": "N", "id": "Entangling Vines"},
+        {"branch": "Verdant Grace", "rank": "N", "id": "Dew Mend"},
+        {"branch": "Song of the Wind", "rank": "N", "id": "Zephyr Step"}
+      ],
+      "known_spells": ["sand_screen"],
+      "PortraitSprite": "hero/sylvan_haven/lirael.png",
+      "OverWorldSprite": "hero/sylvan_haven/lirael.png",
+      "BattlefieldSprite": "hero/bf_default.png",
+      "battlefield_scale": 1.0,
+      "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
     },
-    "starting_skills": [
-      {"branch":"solar_doctrine","rank":"A","id":"hymn_light"},
-      {"branch":"solar_doctrine","rank":"N","id":"sun_bless"},
-      {"branch":"sutra_guard","rank":"N","id":"mantra_ward"},
-      {"branch":"desert_way","rank":"N","id":"dune_march"}
-    ],
-    "known_spells": ["bless", "minor_heal", "cleanse", "sunburst"],
-    "PortraitSprite": "hero/solaceheim/Aurelion.png",
-    "OverWorldSprite": "hero/solaceheim/Aurelion.png",
-    "BattlefieldSprite": "hero/bf_default.png",
-    "battlefield_scale": 1.0,
-    "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
-  },
-  
-{    
-    "id": "Serkath",
-    "name": "Ser’kath, le Parangon Scorpion",
-    "class": "Stratège ascétique (scorpiokin)",
-    "faction": "solaceheim",
-    "level": 5,
-    "overworld": { "movement": 12, "vision": 4 },
-    "combat": {
-      "mana": 35, "spellpower": 3, "knowledge": 2,
-      "morale": 0, "luck": 1
+    {
+      "id": "sylvan_thorne",
+      "template": "sylvan_druid",
+      "name": "Thorne of the Umbra Grove",
+      "class": "Umbra Druid",
+      "faction": "sylvan",
+      "starting_skills": [
+        {"branch": "Sylvan Heart", "rank": "N", "id": "Entangling Vines"},
+        {"branch": "Sylvan Heart", "rank": "A", "id": "Bramble Field"},
+        {"branch": "Sylvan Heart", "rank": "E", "id": "Summon Sprite"},
+        {"branch": "Verdant Grace", "rank": "N", "id": "Dew Mend"}
+      ],
+      "known_spells": ["sand_screen"],
+      "PortraitSprite": "hero/sylvan_haven/thorne.png",
+      "OverWorldSprite": "hero/sylvan_haven/thorne.png",
+      "BattlefieldSprite": "hero/bf_default.png",
+      "battlefield_scale": 1.0,
+      "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
     },
-    "starting_skills": [
-      {"branch":"resonant_tactics","rank":"N","id":"ritual_beats"},
-      {"branch":"resonant_tactics","rank":"A","id":"maneuver_chorale"},
-      {"branch":"desert_way","rank":"A","id":"sand_step"},
-      {"branch":"sutra_guard","rank":"N","id":"mantra_ward"}
-    ],
-    "known_spells": ["sand_screen"],
-    "PortraitSprite": "hero/solaceheim/Serk'Ath.png",
-    "OverWorldSprite": "hero/solaceheim/Serk'Ath.png",
-    "BattlefieldSprite": "hero/bf_default.png",
-    "battlefield_scale": 1.0,
-    "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
-  }
-]
+    {
+      "id": "sol_aurelion",
+      "template": "sol_sage",
+      "name": "Hiérophante Aurelion",
+      "class": "Sage solaire",
+      "faction": "solaceheim",
+      "starting_skills": [
+        {"branch": "solar_doctrine", "rank": "A", "id": "hymn_light"},
+        {"branch": "solar_doctrine", "rank": "N", "id": "sun_bless"},
+        {"branch": "sutra_guard", "rank": "N", "id": "mantra_ward"},
+        {"branch": "desert_way", "rank": "N", "id": "dune_march"}
+      ],
+      "known_spells": ["bless", "minor_heal", "cleanse", "sunburst"],
+      "PortraitSprite": "hero/solaceheim/Aurelion.png",
+      "OverWorldSprite": "hero/solaceheim/Aurelion.png",
+      "BattlefieldSprite": "hero/bf_default.png",
+      "battlefield_scale": 1.0,
+      "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
+    },
+    {
+      "id": "Serkath",
+      "template": "sol_scorpion",
+      "name": "Ser'kath, le Parangon Scorpion",
+      "class": "Stratège ascétique (scorpiokin)",
+      "faction": "solaceheim",
+      "starting_skills": [
+        {"branch": "resonant_tactics", "rank": "N", "id": "ritual_beats"},
+        {"branch": "resonant_tactics", "rank": "A", "id": "maneuver_chorale"},
+        {"branch": "desert_way", "rank": "A", "id": "sand_step"},
+        {"branch": "sutra_guard", "rank": "N", "id": "mantra_ward"}
+      ],
+      "known_spells": ["sand_screen"],
+      "PortraitSprite": "hero/solaceheim/Serk'Ath.png",
+      "OverWorldSprite": "hero/solaceheim/Serk'Ath.png",
+      "BattlefieldSprite": "hero/bf_default.png",
+      "battlefield_scale": 1.0,
+      "icon": {"image": "units/hero.png", "anchor": [0, 0], "scale": 64}
+    }
+  ]
+}
+

--- a/assets/units/units.json
+++ b/assets/units/units.json
@@ -1,9 +1,78 @@
-[
-  {"id": "swordsman", "image": "units/swordsman.png", "anchor_px": [32, 64], "shadow_baked": true, "battlefield_scale": 1.0},
-  {"id": "archer", "image": "units/archer.png", "anchor_px": [32, 64], "shadow_baked": true, "battlefield_scale": 1.0},
-  {"id": "mage", "image": "units/mage.png", "anchor_px": [32, 64], "shadow_baked": true, "battlefield_scale": 1.0},
-  {"id": "dragon", "image": "units/dragon.png", "anchor_px": [32, 64], "shadow_baked": true, "battlefield_scale": 1.75},
-  {"id": "priest", "image": "units/priest.png", "anchor_px": [32, 64], "shadow_baked": true, "battlefield_scale": 1.0},
-  {"id": "cavalry", "image": "units/cavalry.png", "anchor_px": [32, 64], "shadow_baked": true, "battlefield_scale": 1.3}
-]
-
+{
+  "templates": {
+    "infantry": {
+      "stats": {"attack": 7, "defense": 5, "hp": 30, "speed": 5},
+      "palette": ["#C0C0C0", "#5A5A5A", "#FFFFFF"]
+    },
+    "ranged": {
+      "stats": {"attack": 6, "defense": 3, "hp": 20, "speed": 6},
+      "palette": ["#708090", "#228B22", "#FFFFFF"]
+    },
+    "mage": {
+      "stats": {"attack": 8, "defense": 2, "hp": 18, "speed": 5},
+      "palette": ["#4B0082", "#FFFFFF", "#FFD700"]
+    },
+    "dragon": {
+      "stats": {"attack": 20, "defense": 20, "hp": 200, "speed": 10},
+      "palette": ["#8B0000", "#FFA500", "#FFD700"]
+    },
+    "priest": {
+      "stats": {"attack": 5, "defense": 4, "hp": 25, "speed": 5},
+      "palette": ["#FFFFE0", "#FFD700", "#FFFFFF"]
+    },
+    "cavalry": {
+      "stats": {"attack": 9, "defense": 7, "hp": 40, "speed": 8},
+      "palette": ["#8B4513", "#C0C0C0", "#FFFFFF"]
+    }
+  },
+  "units": [
+    {
+      "id": "swordsman",
+      "template": "infantry",
+      "image": "units/swordsman.png",
+      "anchor_px": [32, 64],
+      "shadow_baked": true,
+      "battlefield_scale": 1.0
+    },
+    {
+      "id": "archer",
+      "template": "ranged",
+      "image": "units/archer.png",
+      "anchor_px": [32, 64],
+      "shadow_baked": true,
+      "battlefield_scale": 1.0
+    },
+    {
+      "id": "mage",
+      "template": "mage",
+      "image": "units/mage.png",
+      "anchor_px": [32, 64],
+      "shadow_baked": true,
+      "battlefield_scale": 1.0
+    },
+    {
+      "id": "dragon",
+      "template": "dragon",
+      "image": "units/dragon.png",
+      "anchor_px": [32, 64],
+      "shadow_baked": true,
+      "battlefield_scale": 1.75
+    },
+    {
+      "id": "priest",
+      "template": "priest",
+      "image": "units/priest.png",
+      "anchor_px": [32, 64],
+      "shadow_baked": true,
+      "battlefield_scale": 1.0
+    },
+    {
+      "id": "cavalry",
+      "template": "cavalry",
+      "image": "units/cavalry.png",
+      "anchor_px": [32, 64],
+      "shadow_baked": true,
+      "battlefield_scale": 1.3
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- organize unit, creature, and hero manifests with reusable stat templates and color palettes
- update game and loader logic to apply templates when loading assets
- verify sprite sheet generation and ensure tests pass

## Testing
- `python - <<'PY'
import pygame
from graphics.spritesheet import load_sprite_sheet
pygame.init()
pygame.display.set_mode((1,1))
sheet = pygame.Surface((64,32), pygame.SRCALPHA)
sheet.fill((255,0,0), pygame.Rect(0,0,32,32))
sheet.fill((0,255,0), pygame.Rect(32,0,32,32))
path='/tmp/test_sheet.png'
pygame.image.save(sheet, path)
frames = load_sprite_sheet(path,32,32)
print('generated', len(frames), 'frames')
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af25f6d108832192c0f7aec830e65d