### PR TITLE
Handle faction-specific towns during generation and loading

### DIFF
--- a/core/buildings.py
+++ b/core/buildings.py
@@ -184,6 +184,7 @@ class Town(Building):
 
     def __init__(self, name: Optional[str] = None, faction_id: Optional[str] = None) -> None:
         super().__init__()
+        self.faction_id = faction_id
         if name is None:
             Town._counter += 1
             self.name = f"Town {Town._counter}"

--- a/core/world.py
+++ b/core/world.py
@@ -394,8 +394,12 @@ class WorldMap:
         map_data: Optional[List[str]] = None,
         size_range: Tuple[int, int] = constants.WORLD_SIZE_RANGE,
         biome_weights: Optional[Dict[str, float]] = None,
+        player_faction: Optional[str] = None,
+        enemy_faction: Optional[str] = None,
     ) -> None:
         _reset_town_counter()
+        self.player_faction = player_faction
+        self.enemy_faction = enemy_faction
         self.hero_start: Optional[Tuple[int, int]] = None
         self.enemy_start: Optional[Tuple[int, int]] = None
         # Track town locations separately from hero spawn positions
@@ -1186,7 +1190,8 @@ class WorldMap:
             ]
             coords = area_coords.copy()
             random.shuffle(coords)
-            town = Town()
+            fid = self.player_faction if owner == 0 else self.enemy_faction
+            town = Town(faction_id=fid)
             placed = False
             while coords:
                 tx, ty = coords.pop()
@@ -1530,7 +1535,12 @@ class WorldMap:
                 # '.' or any other char leaves the tile empty
 
     @classmethod
-    def from_file(cls, path: str) -> 'WorldMap':
+    def from_file(
+        cls,
+        path: str,
+        player_faction: Optional[str] = None,
+        enemy_faction: Optional[str] = None,
+    ) -> 'WorldMap':
         """Create a world map from a text file.
 
         Each tile is represented by a biome character (``G`` grass, ``F``
@@ -1543,7 +1553,13 @@ class WorldMap:
         _reset_town_counter()
         with open(path, 'r', encoding='utf-8') as f:
             lines = [line.rstrip('\n') for line in f]
-        return cls(width=0, height=0, map_data=lines)
+        return cls(
+            width=0,
+            height=0,
+            map_data=lines,
+            player_faction=player_faction,
+            enemy_faction=enemy_faction,
+        )
 
     def draw(
         self,

--- a/tests/test_faction_town_buildings.py
+++ b/tests/test_faction_town_buildings.py
@@ -22,3 +22,14 @@ def test_faction_town_buildings_available():
         expected = load_faction_town_buildings(ctx, faction_id)
         for bid in expected:
             assert bid in town.structures
+
+
+def test_faction_recruitment_buildings_present():
+    ctx = _ctx()
+    for faction_id in FACTION_TOWN_BUILDING_MANIFESTS:
+        town = Town(faction_id=faction_id)
+        expected = load_faction_town_buildings(ctx, faction_id)
+        for bid, info in expected.items():
+            if info.get("dwelling"):
+                assert bid in town.structures
+                assert town.structures[bid].get("dwelling") == info.get("dwelling")


### PR DESCRIPTION
## Summary
- Track player and enemy faction IDs on the world map
- Preserve town faction IDs through save/load and use them when instantiating towns
- Test that each faction's towns include their recruitment buildings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af2f98e0c883219f256c34de466554