### PR TITLE
Add faction town building manifests and tests

### DIFF
--- a/assets/buildings/buildings_red_knights.json
+++ b/assets/buildings/buildings_red_knights.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "crimson_watch",
+    "cost": {"wood": 5, "stone": 5},
+    "prereq": [],
+    "dwelling": {"red_squire": 5},
+    "desc": "Train the order's squires.",
+    "image": "buildings/crimson_watch.png"
+  },
+  {
+    "id": "scarlet_fletchery",
+    "cost": {"wood": 3, "stone": 2},
+    "prereq": ["crimson_watch"],
+    "dwelling": {"scarlet_archer": 5},
+    "desc": "Recruit archers loyal to the Flame.",
+    "image": "buildings/scarlet_fletchery.png"
+  },
+  {
+    "id": "sun_spire",
+    "cost": {"wood": 10, "stone": 10, "crystal": 5},
+    "prereq": ["scarlet_fletchery"],
+    "dwelling": {"sun_priest": 3},
+    "desc": "Sanctum for the Sun Priests.",
+    "image": "buildings/sun_spire.png"
+  }
+]

--- a/assets/buildings/buildings_solaceheim.json
+++ b/assets/buildings/buildings_solaceheim.json
@@ -1,14 +1,105 @@
 [
-  {"id":"sanctuary_of_the_sun","unlocks":["disciple_initie"],"visit_bonus":{"mana_per_day":1}},
-  {"id":"cloister_of_resonance","unlocks":["ascete_cloche"],"grants_scroll":"sonic_bell_once","requires":["sanctuary_of_the_sun"]},
-  {"id":"celestial_aeries","unlocks":["aigle_choeur"],"city_bonus":{"vision_radius":1},"requires":["cloister_of_resonance"]},
-  {"id":"sutra_guardhouse","unlocks":["gardien_sutras"],"city_bonus":{"defence_magic_city":1},"requires":["celestial_aeries"]},
-  {"id":"hall_of_ascetics","unlocks":["guerrier_ascete"],"hero_depart_bonus":{"desert_move_pct":10},"requires":["sutra_guardhouse"]},
-  {"id":"sanctum_of_the_veil","unlocks":["chimere_ascese"],"city_bonus":{"ambush_detection":1},"requires":["hall_of_ascetics"]},
-  {"id":"choir_of_singing_dunes","unlocks":["serpent_cantique"],"map_bonus":{"desert_move_cost_bonus":1},"requires":["sanctum_of_the_veil","cloister_of_resonance"]},
-  {"id":"spire_of_solar_apotheosis","unlocks":["avatar_soleil"],"requires":["sutra_guardhouse","choir_of_singing_dunes"]},
-
-  {"id":"terrace_of_discipline","growth_bonus":{"tiers":["T1","T2","T3"],"pct":10}},
-  {"id":"voice_of_the_dunes","visit_bonus":{"mana_per_day":1},"map_bonus":{"desert_hazard_res_pct":15}},
-  {"id":"colossus_of_sutras","city_bonus":{"global_defence_magic":1}}
+  {
+    "id": "sanctuary_of_the_sun",
+    "dwelling": {"disciple_initie": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/sanctuary_of_the_sun.png",
+    "unlocks": ["disciple_initie"],
+    "visit_bonus": {"mana_per_day": 1}
+  },
+  {
+    "id": "cloister_of_resonance",
+    "dwelling": {"ascete_cloche": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/cloister_of_resonance.png",
+    "unlocks": ["ascete_cloche"],
+    "grants_scroll": "sonic_bell_once",
+    "requires": ["sanctuary_of_the_sun"]
+  },
+  {
+    "id": "celestial_aeries",
+    "dwelling": {"aigle_choeur": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/celestial_aeries.png",
+    "unlocks": ["aigle_choeur"],
+    "city_bonus": {"vision_radius": 1},
+    "requires": ["cloister_of_resonance"]
+  },
+  {
+    "id": "sutra_guardhouse",
+    "dwelling": {"gardien_sutras": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/sutra_guardhouse.png",
+    "unlocks": ["gardien_sutras"],
+    "city_bonus": {"defence_magic_city": 1},
+    "requires": ["celestial_aeries"]
+  },
+  {
+    "id": "hall_of_ascetics",
+    "dwelling": {"guerrier_ascete": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/hall_of_ascetics.png",
+    "unlocks": ["guerrier_ascete"],
+    "hero_depart_bonus": {"desert_move_pct": 10},
+    "requires": ["sutra_guardhouse"]
+  },
+  {
+    "id": "sanctum_of_the_veil",
+    "dwelling": {"chimere_ascese": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/sanctum_of_the_veil.png",
+    "unlocks": ["chimere_ascese"],
+    "city_bonus": {"ambush_detection": 1},
+    "requires": ["hall_of_ascetics"]
+  },
+  {
+    "id": "choir_of_singing_dunes",
+    "dwelling": {"serpent_cantique": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/choir_of_singing_dunes.png",
+    "unlocks": ["serpent_cantique"],
+    "map_bonus": {"desert_move_cost_bonus": 1},
+    "requires": ["sanctum_of_the_veil", "cloister_of_resonance"]
+  },
+  {
+    "id": "spire_of_solar_apotheosis",
+    "dwelling": {"avatar_soleil": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/spire_of_solar_apotheosis.png",
+    "unlocks": ["avatar_soleil"],
+    "requires": ["sutra_guardhouse", "choir_of_singing_dunes"]
+  },
+  {
+    "id": "terrace_of_discipline",
+    "dwelling": {},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/terrace_of_discipline.png",
+    "growth_bonus": {"tiers": ["T1", "T2", "T3"], "pct": 10}
+  },
+  {
+    "id": "voice_of_the_dunes",
+    "dwelling": {},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/voice_of_the_dunes.png",
+    "visit_bonus": {"mana_per_day": 1},
+    "map_bonus": {"desert_hazard_res_pct": 15}
+  },
+  {
+    "id": "colossus_of_sutras",
+    "dwelling": {},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/colossus_of_sutras.png",
+    "city_bonus": {"global_defence_magic": 1}
+  }
 ]

--- a/assets/buildings/buildings_sylvan.json
+++ b/assets/buildings/buildings_sylvan.json
@@ -1,9 +1,65 @@
 [
-  {"id":"grove_of_lirael","unlocks":["moss_sprite","mist_nymph"],"visit_bonus":{"mana_per_day":1}},
-  {"id":"hanging_aeries","unlocks":["dew_phoenix"],"city_bonus":{"vision_radius":1}},
-  {"id":"liana_pens","unlocks":["liana_panther"],"hero_depart_bonus":{"forest_road_move_pct":10}},
-  {"id":"cascade_terraces","unlocks":["cascade_serpent"],"map_bonus":{"ford_move_cost_bonus":1}},
-  {"id":"warden_hall","unlocks":["garden_warden"],"growth_bonus":{"tiers":["T1","T2","T3"],"pct":10}},
-  {"id":"spire_of_mists","unlocks":["mist_dragon"],"requires":["warden_hall","hanging_aeries"]},
-  {"id":"amphitheater_of_winds","unlocks":["harmonia"],"grants_scroll":"song_inspire_once"}
+  {
+    "id": "grove_of_lirael",
+    "dwelling": {"moss_sprite": 1, "mist_nymph": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/grove_of_lirael.png",
+    "unlocks": ["moss_sprite", "mist_nymph"],
+    "visit_bonus": {"mana_per_day": 1}
+  },
+  {
+    "id": "hanging_aeries",
+    "dwelling": {"dew_phoenix": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/hanging_aeries.png",
+    "unlocks": ["dew_phoenix"],
+    "city_bonus": {"vision_radius": 1}
+  },
+  {
+    "id": "liana_pens",
+    "dwelling": {"liana_panther": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/liana_pens.png",
+    "unlocks": ["liana_panther"],
+    "hero_depart_bonus": {"forest_road_move_pct": 10}
+  },
+  {
+    "id": "cascade_terraces",
+    "dwelling": {"cascade_serpent": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/cascade_terraces.png",
+    "unlocks": ["cascade_serpent"],
+    "map_bonus": {"ford_move_cost_bonus": 1}
+  },
+  {
+    "id": "warden_hall",
+    "dwelling": {"garden_warden": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/warden_hall.png",
+    "unlocks": ["garden_warden"],
+    "growth_bonus": {"tiers": ["T1", "T2", "T3"], "pct": 10}
+  },
+  {
+    "id": "spire_of_mists",
+    "dwelling": {"mist_dragon": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/spire_of_mists.png",
+    "unlocks": ["mist_dragon"],
+    "requires": ["warden_hall", "hanging_aeries"]
+  },
+  {
+    "id": "amphitheater_of_winds",
+    "dwelling": {"harmonia": 1},
+    "cost": {},
+    "desc": "",
+    "image": "buildings/amphitheater_of_winds.png",
+    "unlocks": ["harmonia"],
+    "grants_scroll": "song_inspire_once"
+  }
 ]

--- a/loaders/town_building_loader.py
+++ b/loaders/town_building_loader.py
@@ -7,10 +7,10 @@ from .core import Context, read_json
 
 # Mapping of faction identifiers to their town building manifest paths
 FACTION_TOWN_BUILDING_MANIFESTS: Dict[str, str] = {
+    "red_knights": "buildings/buildings_red_knights.json",
     "sylvan": "buildings/buildings_sylvan.json",
     "solaceheim": "buildings/buildings_solaceheim.json",
 }
-
 
 def load_town_buildings(ctx: Context, manifest: str) -> Dict[str, Dict[str, object]]:
     """Load town structure definitions from ``manifest``.

--- a/tests/test_faction_town_buildings.py
+++ b/tests/test_faction_town_buildings.py
@@ -33,3 +33,15 @@ def test_faction_recruitment_buildings_present():
             if info.get("dwelling"):
                 assert bid in town.structures
                 assert town.structures[bid].get("dwelling") == info.get("dwelling")
+
+
+def test_loader_returns_expected_dwellings():
+    ctx = _ctx()
+    rk = load_faction_town_buildings(ctx, "red_knights")
+    assert rk["crimson_watch"]["dwelling"] == {"red_squire": 5}
+
+    syl = load_faction_town_buildings(ctx, "sylvan")
+    assert syl["grove_of_lirael"]["dwelling"] == {"moss_sprite": 1, "mist_nymph": 1}
+
+    sol = load_faction_town_buildings(ctx, "solaceheim")
+    assert sol["sanctuary_of_the_sun"]["dwelling"] == {"disciple_initie": 1}


### PR DESCRIPTION
## Summary
- add Red Knights town building manifest
- expand Sylvan and Solaceheim manifests with dwelling metadata
- load faction-specific manifests and test expected dwellings

## Testing
- `pre-commit run --files assets/buildings/buildings_solaceheim.json assets/buildings/buildings_sylvan.json assets/buildings/buildings_red_knights.json loaders/town_building_loader.py tests/test_faction_town_buildings.py`
- `python3 -m pytest tests/test_faction_town_buildings.py`


------
https://chatgpt.com/codex/tasks/task_e_68af314ef04483218349d1c056a08c13