### PR TITLE
Support faction-specific skill manifests

### DIFF
--- a/assets/skills/skills_solaceheim.json
+++ b/assets/skills/skills_solaceheim.json
@@ -1,28 +1,28 @@
 {
-  "solaceheim_tree": {
-    "solar_doctrine": {
-      "N": {"id":"sun_blessing_n","name":"Aurore Bienveillante","effect":"Bless 1 stack (1t) au début du combat."},
-      "A": {"id":"hymn_of_light_a","name":"Hymne Lumineux","type":"order","cd":3,"effect":"Cône court: alliés ATK +1~+1 (1t), ennemis defence_magic -1 (1t)."},
-      "E": {"id":"lumen_matrix_e","name":"Lumen Matrix","effect":"Lumière/Ordre +15% puissance; coût -1 mana (min 1)."},
-      "M": {"id":"solar_zenith_m","name":"Zénith du Soleil","effect":"Aura 2 hex: initiative +1, morale +1; 1x/comb. Sunburst gratuit."}
-    },
-    "desert_way": {
-      "N": {"id":"dune_march_n","name":"Marche des Dunes","effect":"PM +5% sur carte."},
-      "A": {"id":"sand_step_a","name":"Pas de Sable","effect":"PM +10%; ignore malus de sable/dunes."},
-      "E": {"id":"sirocco_e","name":"Brise du Sirocco","effect":"En désert: alliés +1 initiative au 1er round."},
-      "M": {"id":"sun_paths_m","name":"Chemins Solaires","effect":"PM +15%; vision +1 désert; immunité sandstorm."}
-    },
-    "resonant_tactics": {
-      "N": {"id":"ritual_beats_n","name":"Battements Rituels","effect":"+1 initiative aux T1–T3."},
-      "A": {"id":"maneuver_chorale_a","name":"Chorale de Manœuvre","type":"order","cd":3,"effect":"Repositionne 1 stack de 1 hex et lui donne morale +1 (1t)."},
-      "E": {"id":"harmony_formation_e","name":"Formation Harmonie","effect":"1er round: projectiles reçus -1 pour lignes adjacentes."},
-      "M": {"id":"ascetic_cadence_m","name":"Cadence Ascétique","effect":"Repositionne 2 stacks; flanking allié +10% dégâts ce round."}
-    },
-    "sutra_guard": {
-      "N": {"id":"mantra_ward_n","name":"Mantra de Protection","effect":"Alliés defence_magic +1."},
-      "A": {"id":"sutra_aegis_a","name":"Aegis des Sutras","type":"order","cd":2,"effect":"Cible: defence_melee +2, defence_magic +2, dissipe 1 malus (1t)."},
-      "E": {"id":"guardian_intercession_e","name":"Intercession du Gardien","effect":"1x/tour: si allié ≤30% HP dans 2 hex est frappé, -20% dégâts."},
-      "M": {"id":"solar_bulwark_m","name":"Rempart Solaire","type":"order","cd":3,"effect":"Cible: insensible aux sorts et -30% AoE (1t)."}
-    }
+  "sheet": "solaceheim_skills.png",
+  "solar_doctrine": {
+    "N": {"id": "sun_blessing_n", "name": "Aurore Bienveillante", "desc": "Bless 1 stack (1t) au début du combat."},
+    "A": {"id": "hymn_of_light_a", "name": "Hymne Lumineux", "type": "order", "cd": 3, "desc": "Cône court: alliés ATK +1~+1 (1t), ennemis defence_magic -1 (1t)."},
+    "E": {"id": "lumen_matrix_e", "name": "Lumen Matrix", "desc": "Lumière/Ordre +15% puissance; coût -1 mana (min 1)."},
+    "M": {"id": "solar_zenith_m", "name": "Zénith du Soleil", "desc": "Aura 2 hex: initiative +1, morale +1; 1x/comb. Sunburst gratuit."}
+  },
+  "desert_way": {
+    "N": {"id": "dune_march_n", "name": "Marche des Dunes", "desc": "PM +5% sur carte."},
+    "A": {"id": "sand_step_a", "name": "Pas de Sable", "desc": "PM +10%; ignore malus de sable/dunes."},
+    "E": {"id": "sirocco_e", "name": "Brise du Sirocco", "desc": "En désert: alliés +1 initiative au 1er round."},
+    "M": {"id": "sun_paths_m", "name": "Chemins Solaires", "desc": "PM +15%; vision +1 désert; immunité sandstorm."}
+  },
+  "resonant_tactics": {
+    "N": {"id": "ritual_beats_n", "name": "Battements Rituels", "desc": "+1 initiative aux T1–T3."},
+    "A": {"id": "maneuver_chorale_a", "name": "Chorale de Manœuvre", "type": "order", "cd": 3, "desc": "Repositionne 1 stack de 1 hex et lui donne morale +1 (1t)."},
+    "E": {"id": "harmony_formation_e", "name": "Formation Harmonie", "desc": "1er round: projectiles reçus -1 pour lignes adjacentes."},
+    "M": {"id": "ascetic_cadence_m", "name": "Cadence Ascétique", "desc": "Repositionne 2 stacks; flanking allié +10% dégâts ce round."}
+  },
+  "sutra_guard": {
+    "N": {"id": "mantra_ward_n", "name": "Mantra de Protection", "desc": "Alliés defence_magic +1."},
+    "A": {"id": "sutra_aegis_a", "name": "Aegis des Sutras", "type": "order", "cd": 2, "desc": "Cible: defence_melee +2, defence_magic +2, dissipe 1 malus (1t)."},
+    "E": {"id": "guardian_intercession_e", "name": "Intercession du Gardien", "desc": "1x/tour: si allié ≤30% HP dans 2 hex est frappé, -20% dégâts."},
+    "M": {"id": "solar_bulwark_m", "name": "Rempart Solaire", "type": "order", "cd": 3, "desc": "Cible: insensible aux sorts et -30% AoE (1t)."}
   }
 }
+

--- a/assets/skills/skills_sylvan.json
+++ b/assets/skills/skills_sylvan.json
@@ -1,28 +1,28 @@
 {
-  "solaceheim_tree": {
-    "Verdant_Grace": {
-      "N": {"id":"dew_mend_n","name":"Dew Mend","effect":"Cleanse (retire Poison/Brûlure/Lenteur)"},
-      "A": {"id":"ripple_shield_a","name":"Ripple Shield","type":"order","cd":3,"effect":"(+armure magique mono, courte durée)."},
-      "E": {"id":"rebirth_chance_e","name":"Rebirth Chance","effect":"(+10 % chance de relever 1 unité T1–T3 à la fin du combat"},
-      "M": {"id":"sanctuary_m","name":"Sanctuary","effect":"zone sacrée : alliés reçoivent +defense & regen légère dans l’aire"}
-    },
-    "Mists_Streams": {
-      "N": {"id":"mist_veil_n","name":"Mist Veil","effect":"nuage de brume, −LoS & −def_ranged ennemie dans l’aire"},
-      "A": {"id":"Slick_Ground_a","name":"Slick Ground","effect":"terrain glissant, −init & malus de déplacement sur quelques cases"},
-      "E": {"id":"Whirlpool_Pull_e","name":"Whirlpool Pull","effect":"attire légèrement les cibles au centre, petite zone"},
-      "M": {"id":"Mist_Portal_m","name":"Mist Portal","effect":"téléport court mono-cible alliée, ligne de vue non requise mais portée limitée"}
-    },
-    "Song_Wind": {
-      "N": {"id":"Zephyr_Step_n","name":"Zephyr Step","effect":"+AP ou +1 case de déplacement au tour en cours"},
-      "A": {"id":"Gust_a","name":"Gust","type":"order","cd":3,"effect":"cône, repousse de 1 case, −1 initiative"},
-      "E": {"id":"Lullaby_e","name":"Lullaby","effect":"sommeil 1 tour sur cible unique, test de résistance"},
-      "M": {"id":"Wind Chorus_m","name":"Wind Chorus","effect":"Mass Haste : +init/+speed de l’armée 1 tour"}
-    },
-    "Sylvan_Heart": {
-      "N": {"id":"Entangling_Vines_n","name":"Entangling Vines","effect":"Entravé 1 tour, −init"},
-      "A": {"id":"Bramble_Field_a","name":"Bramble Field","type":"order","cd":2,"effect":"pièges d’épines, dégâts & lenteur à l’entrée"},
-      "E": {"id":"Summon_Sprite_e","name":"Summon Sprite","effect":"petite unité faë éphémère T1"},
-      "M": {"id":"Forest_Heart_m","name":"Forest Heart","type":"order","cd":3,"effect":"totem/semis : petite zone qui soigne alliés et inflige épines aux ennemis"}
-    }
+  "sheet": "sylvan_skills.png",
+  "Verdant_Grace": {
+    "N": {"id": "dew_mend_n", "name": "Dew Mend", "desc": "Cleanse (retire Poison/Brûlure/Lenteur)"},
+    "A": {"id": "ripple_shield_a", "name": "Ripple Shield", "type": "order", "cd": 3, "desc": "(+armure magique mono, courte durée)."},
+    "E": {"id": "rebirth_chance_e", "name": "Rebirth Chance", "desc": "+10 % chance de relever 1 unité T1–T3 à la fin du combat"},
+    "M": {"id": "sanctuary_m", "name": "Sanctuary", "desc": "zone sacrée : alliés reçoivent +defense & regen légère dans l’aire"}
+  },
+  "Mists_Streams": {
+    "N": {"id": "mist_veil_n", "name": "Mist Veil", "desc": "nuage de brume, −LoS & −def_ranged ennemie dans l’aire"},
+    "A": {"id": "Slick_Ground_a", "name": "Slick Ground", "desc": "terrain glissant, −init & malus de déplacement sur quelques cases"},
+    "E": {"id": "Whirlpool_Pull_e", "name": "Whirlpool Pull", "desc": "attire légèrement les cibles au centre, petite zone"},
+    "M": {"id": "Mist_Portal_m", "name": "Mist Portal", "desc": "téléport court mono-cible alliée, ligne de vue non requise mais portée limitée"}
+  },
+  "Song_Wind": {
+    "N": {"id": "Zephyr_Step_n", "name": "Zephyr Step", "desc": "+AP ou +1 case de déplacement au tour en cours"},
+    "A": {"id": "Gust_a", "name": "Gust", "type": "order", "cd": 3, "desc": "cône, repousse de 1 case, −1 initiative"},
+    "E": {"id": "Lullaby_e", "name": "Lullaby", "desc": "sommeil 1 tour sur cible unique, test de résistance"},
+    "M": {"id": "Wind_Chorus_m", "name": "Wind Chorus", "desc": "Mass Haste : +init/+speed de l’armée 1 tour"}
+  },
+  "Sylvan_Heart": {
+    "N": {"id": "Entangling_Vines_n", "name": "Entangling Vines", "desc": "Entravé 1 tour, −init"},
+    "A": {"id": "Bramble_Field_a", "name": "Bramble Field", "type": "order", "cd": 2, "desc": "pièges d’épines, dégâts & lenteur à l’entrée"},
+    "E": {"id": "Summon_Sprite_e", "name": "Summon Sprite", "desc": "petite unité faë éphémère T1"},
+    "M": {"id": "Forest_Heart_m", "name": "Forest Heart", "type": "order", "cd": 3, "desc": "totem/semis : petite zone qui soigne alliés et inflige épines aux ennemis"}
   }
 }
+

--- a/tests/test_faction_skill_catalog.py
+++ b/tests/test_faction_skill_catalog.py
@@ -1,0 +1,74 @@
+import pygame
+
+import core.entities as entities
+from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.faction import FactionDef
+from ui.inventory_screen import InventoryScreen
+
+
+class DummySurface:
+    def __init__(self, size=(800, 600)):
+        self._size = size
+
+    def fill(self, *args, **kwargs):
+        pass
+
+    def get_size(self):
+        return self._size
+
+    def blit(self, *args, **kwargs):
+        pass
+
+
+class Rect:
+    def __init__(self, x, y, w, h):
+        self.x, self.y, self.width, self.height = x, y, w, h
+
+    @property
+    def size(self):
+        return (self.width, self.height)
+
+    @property
+    def centerx(self):
+        return self.x + self.width // 2
+
+    @property
+    def centery(self):
+        return self.y + self.height // 2
+
+    @property
+    def right(self):
+        return self.x + self.width
+
+    @property
+    def bottom(self):
+        return self.y + self.height
+
+    @property
+    def topleft(self):
+        return (self.x, self.y)
+
+    def collidepoint(self, pos):
+        px, py = pos
+        return self.x <= px < self.x + self.width and self.y <= py < self.y + self.height
+
+
+def test_skill_catalog_changes_with_faction():
+    entities.build_skill_catalog("red_knights")
+    red = set(entities.SKILL_CATALOG.keys())
+    entities.build_skill_catalog("sylvan")
+    syl = set(entities.SKILL_CATALOG.keys())
+    assert "logistics_N" in red and "logistics_N" not in syl
+
+
+def test_inventory_skill_tabs_vary_by_faction(monkeypatch):
+    monkeypatch.setattr(pygame, "Rect", Rect)
+    screen = DummySurface()
+    hero_red = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")],
+                    faction=FactionDef(id="red_knights", name="Red"))
+    inv_red = InventoryScreen(screen, {}, hero_red)
+    hero_syl = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")],
+                    faction=FactionDef(id="sylvan", name="Sylvan"))
+    inv_syl = InventoryScreen(screen, {}, hero_syl)
+    assert inv_red.SKILL_TABS != inv_syl.SKILL_TABS
+

--- a/ui/inventory_screen.py
+++ b/ui/inventory_screen.py
@@ -23,8 +23,8 @@ from core.entities import (
     Unit,
     SKILL_CATALOG,
     REPO_ROOT,
+    build_skill_catalog,
 )
-from tools.skill_manifest import load_skill_manifest
 from .inventory_interface import InventoryInterface
 
 # --------------------------------------------------------------------------- #
@@ -144,7 +144,8 @@ class InventoryScreen:
     # ------------------------------------------------------------------ Skills
     def _build_skill_trees(self) -> None:
         """Populate skill trees and positions from the JSON manifest."""
-        manifest = load_skill_manifest(REPO_ROOT)
+        faction_id = self.hero.faction.id if self.hero.faction else None
+        manifest = build_skill_catalog(faction_id)
         rank_order = ["N", "A", "E", "M"]
         order: List[str] = []
         for entry in manifest:


### PR DESCRIPTION
## Summary
- Load skills per faction by optionally specifying `faction_id`
- Convert Sylvan and Solaceheim skill manifests to branch/rank schema
- Rebuild global skill catalog per selected faction and update inventory screen accordingly
- Add tests for faction-dependent skill catalogs and UI

## Testing
- `pre-commit run --files tools/skill_manifest.py assets/skills/skills_solaceheim.json assets/skills/skills_sylvan.json core/entities.py ui/inventory_screen.py tests/test_faction_skill_catalog.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af34857cd083219c71d764cd95add6