### PR TITLE
Add minimap POI filtering and refresh on biome reload

### DIFF
--- a/loaders/biomes.py
+++ b/loaders/biomes.py
@@ -74,6 +74,13 @@ class BiomeCatalog:
         cls._biomes = biomes
         # Refresh derived mappings in constants
         constants.BIOME_BASE_IMAGES = constants.build_biome_base_images()
+        from core import world as core_world
+        core_world.init_biome_images()
+        try:
+            from ui.widgets.minimap import Minimap
+            Minimap.invalidate_all()
+        except Exception:
+            pass
 
     @classmethod
     def get(cls, biome_id: str) -> Optional[Biome]:


### PR DESCRIPTION
## Summary
- Clip minimap POI icons to widget bounds
- Add internal POI filter menu with checkbox states
- Regenerate minimap after biome manifest reload

## Testing
- `pytest tests/test_minimap.py tests/test_vision_bonus.py tests/test_multi_terrain_movement.py tests/test_encounter_priority.py tests/test_movement_cost.py tests/test_army_actions.py -q`
- `pytest tests/test_biome_transition_blending.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af57158af08321a5f167147c6d1fb1