### PR TITLE
Handle day controls and robust save/load

### DIFF
--- a/tests/test_ai_recruitment.py
+++ b/tests/test_ai_recruitment.py
@@ -13,7 +13,7 @@ from core import economy
 def test_ai_weekly_recruitment_consumes_resources():
     pygame.init()
     world = WorldMap(map_data=["G"])
-    town = Town()
+    town = Town(faction_id="red_knights")
     town.owner = 1
     world.grid[0][0].building = town
 

--- a/tests/test_dwelling_growth.py
+++ b/tests/test_dwelling_growth.py
@@ -35,7 +35,7 @@ def test_weekly_transfer_to_garrison():
 
 def test_town_available_units():
     pygame.init()
-    town = Town()
+    town = Town(faction_id="red_knights")
     hero = Hero(0, 0, [])
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5

--- a/tests/test_game_controls.py
+++ b/tests/test_game_controls.py
@@ -1,0 +1,84 @@
+import os
+import pygame
+
+from ui.main_screen import MainScreen, EVENT_BUS as UI_BUS, ON_INFO_MESSAGE as UI_INFO
+
+
+def test_save_game_missing_path(pygame_stub):
+    pygame_stub()
+    from core.game import Game
+    screen = pygame.Surface((640, 480))
+    game = Game(screen)
+    game.default_save_path = None
+    msg = game.save_game(None)
+    assert msg and "No save path specified" in msg
+
+
+def test_load_game_missing_file(pygame_stub, tmp_path):
+    pygame_stub()
+    from core.game import Game
+    screen = pygame.Surface((640, 480))
+    game = Game(screen)
+    path = tmp_path / "missing.json"
+    msg = game.load_game(str(path))
+    assert msg and "not found" in msg
+
+
+def test_main_screen_load_game_checks_file(pygame_stub, tmp_path):
+    pygame_stub()
+    from core.game import Game
+    screen = pygame.Surface((640, 480))
+    game = Game(screen)
+    game.default_save_path = str(tmp_path / "missing.json")
+    game.default_profile_path = str(tmp_path / "missing_profile.json")
+
+    called = False
+
+    def fake_load(path, profile):
+        nonlocal called
+        called = True
+
+    game.load_game = fake_load
+    messages = []
+    UI_BUS.subscribe(UI_INFO, lambda msg: messages.append(msg))
+
+    main = MainScreen(game)
+    main.load_game()
+    assert not called
+    assert messages and "not found" in messages[0]
+
+
+def test_toggle_pause(pygame_stub):
+    pygame_stub()
+    from core.game import Game
+    screen = pygame.Surface((640, 480))
+    game = Game(screen)
+    assert not getattr(game, "paused", False)
+    game.toggle_pause()
+    assert game.paused
+    game.toggle_pause()
+    assert not game.paused
+
+
+def test_end_day_advances_turn_and_resets_ap(pygame_stub):
+    pygame_stub()
+    from core.game import Game
+    screen = pygame.Surface((640, 480))
+    game = Game(screen)
+    game.hero.ap = 0
+    turn_before = game.turn
+    game.end_day()
+    assert game.hero.ap == game.hero.max_ap
+    assert game.turn == turn_before + 1
+
+
+def test_next_town_centers_camera(pygame_stub):
+    pygame_stub()
+    from core.game import Game
+    screen = pygame.Surface((640, 480))
+    game = Game(screen)
+    tx, ty = game.world.hero_town
+    called = []
+    game.world_renderer.center_on = lambda pos: called.append(pos)
+    game.next_town()
+    assert called and called[0] == (tx, ty)

--- a/tests/test_game_state_weekly_town_growth.py
+++ b/tests/test_game_state_weekly_town_growth.py
@@ -13,7 +13,7 @@ from state.game_state import GameState
 def test_weekly_growth_via_next_day():
     pygame.init()
     world = WorldMap(map_data=["G"])
-    town = Town()
+    town = Town(faction_id="red_knights")
     world.grid[0][0].building = town
     hero = Hero(0, 0, [])
     state = GameState(world=world, heroes=[hero])

--- a/tests/test_town_build_limit.py
+++ b/tests/test_town_build_limit.py
@@ -10,7 +10,7 @@ from core import economy
 
 def test_one_structure_per_day():
     pygame.init()
-    town = Town()
+    town = Town(faction_id="red_knights")
     hero = Hero(0, 0, [])
     hero.resources["wood"] = 10
     hero.resources["stone"] = 10

--- a/tests/test_town_recruitment.py
+++ b/tests/test_town_recruitment.py
@@ -17,7 +17,7 @@ def _create_game_with_town():
     Game = game_module.Game
     world = WorldMap(map_data=["G"])
     tile = world.grid[0][0]
-    tile.building = Town()
+    tile.building = Town(faction_id="red_knights")
     hero = Hero(0, 0, [])
     game = Game.__new__(Game)
     game.world = world
@@ -46,7 +46,7 @@ def test_town_build_and_recruit():
 
 def test_town_recruitment_limited_by_stock():
     pygame.init()
-    town = Town()
+    town = Town(faction_id="red_knights")
     hero = Hero(0, 0, [])
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
@@ -62,7 +62,7 @@ def test_town_recruitment_limited_by_stock():
 
 def test_recruit_into_garrison():
     pygame.init()
-    town = Town()
+    town = Town(faction_id="red_knights")
     hero = Hero(0, 0, [])
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
@@ -76,7 +76,7 @@ def test_recruit_into_garrison():
 
 def test_recruit_into_visiting_army():
     pygame.init()
-    town = Town()
+    town = Town(faction_id="red_knights")
     hero = Hero(0, 0, [])
     visiting = Hero(1, 0, [])
     hero.resources['wood'] = 5
@@ -106,7 +106,7 @@ def test_townscreen_recruit_with_hero_goes_to_garrison(monkeypatch, pygame_stub)
     monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
     from ui.town_screen import TownScreen
 
-    town = Town()
+    town = Town(faction_id="red_knights")
     hero = Hero(0, 0, [])
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
@@ -153,7 +153,7 @@ def test_townscreen_recruit_visiting_army(monkeypatch, pygame_stub):
     from ui.town_screen import TownScreen
     from core.entities import Army
 
-    town = Town()
+    town = Town(faction_id="red_knights")
     hero = Hero(1, 0, [])
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5

--- a/tests/test_townscreen_click_without_resources.py
+++ b/tests/test_townscreen_click_without_resources.py
@@ -15,7 +15,7 @@ def test_townscreen_click_without_resources(monkeypatch, pygame_stub):
 
     pygame = pg
     pygame.init()
-    town = Town()
+    town = Town(faction_id="red_knights")
     hero = Hero(0, 0, [])
     hero.gold = 0
     hero.resources["wood"] = 0

--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -11,6 +11,7 @@ this stub with a more feature complete interface.
 
 from typing import Dict, Optional, List
 
+import os
 import pygame
 from . import theme, constants
 
@@ -135,7 +136,10 @@ class MainScreen:
         path = getattr(self.game, "default_save_path", None)
         profile = getattr(self.game, "default_profile_path", None)
         if cb and path:
-            cb(path, profile)
+            if os.path.exists(path):
+                cb(path, profile)
+            else:
+                EVENT_BUS.publish(ON_INFO_MESSAGE, f"Save file not found: {path}")
 
     def prev_hero(self) -> None:
         cb = getattr(self.game, "prev_hero", None)


### PR DESCRIPTION
## Summary
- add Game methods for ending the day, pausing, and cycling through player towns
- return info messages when save/load paths are invalid
- ensure load button only loads existing files
- remove faction-specific barracks from generic town building list
- update barracks-related tests to use red_knights faction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af58f1dec88321b87558dd0fc0948c