### PR TITLE
Align world and minimap top margins

### DIFF
--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -24,12 +24,13 @@ def test_layout_16_9_and_16_10():
     ms = MainScreen(game)
     assert len(ms.widgets) == 8
     side_w = max(260, int(0.23 * 1280))
-    bar_h = 24
+    bar_h = int(24 * 1.5)
     margin = 8
     expected_w = 1280 - side_w - 2 * margin
-    expected_h = 720 - 3 * bar_h - 3 * margin
+    expected_h = 720 - 2 * bar_h - 3 * margin
     assert ms.widgets["1"].width == expected_w
     assert ms.widgets["1"].height == expected_h
+    assert ms.widgets["1"].y == ms.widgets["4"].y == margin
     # hero list and buttons are the same height and directly adjacent
     hero_rect = ms.widgets["5"]
     buttons_rect = ms.widgets["6"]
@@ -38,7 +39,7 @@ def test_layout_16_9_and_16_10():
     assert hero_rect.y == buttons_rect.y
     # Recompute for 16:10
     ms.compute_layout(1280, 800)
-    expected_h = 800 - 3 * bar_h - 3 * margin
+    expected_h = 800 - 2 * bar_h - 3 * margin
     assert ms.widgets["1"].height == expected_h
 
 

--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -174,12 +174,13 @@ class MainScreen:
 
         M = 8
         side_w = max(260, int(0.23 * width))
-        bar_h = 24
+        base_bar_h = 24
+        bar_h = int(base_bar_h * 1.5)
 
         root = Layout(pygame.Rect(0, 0, width, height))
         root.dock_left(M)
         root.dock_right(M)
-        root.dock_top(bar_h + M)
+        root.dock_top(M)
 
         # Colonne droite (minimap + liste héros + boutons + armée)
         sidebar_full = root.dock_right(side_w - M, margin=M)
@@ -207,9 +208,9 @@ class MainScreen:
         # puis l'armée dessous qui prend tout le reste.
         sidebar_top = pygame.Rect(
             sidebar_full.x,
-            M,
+            world_rect.y,
             sidebar_full.width,
-            world_rect.y + world_rect.height - M,
+            world_rect.height,
         )
         side_layout = Layout(sidebar_top)
 


### PR DESCRIPTION
## Summary
- Align world and minimap rectangles to share the same top offset
- Redistribute top bar height into bottom bars to keep overall spacing
- Update resolution tests for new layout and verify alignment

## Testing
- `pytest -q`
- `pytest tests/test_resolutions.py -m serial`


------
https://chatgpt.com/codex/tasks/task_e_68af5e2b2cd483218ac835e4db06cbbe