### PR TITLE
feat: show all skill branches

### DIFF
--- a/tests/test_inventory_skill_layout.py
+++ b/tests/test_inventory_skill_layout.py
@@ -59,7 +59,7 @@ def make_screen_and_hero():
     return screen, hero
 
 
-def test_switch_skill_tabs(monkeypatch):
+def test_all_branches_drawn(monkeypatch):
     monkeypatch.setattr(pygame, "Rect", Rect)
     screen, hero = make_screen_and_hero()
     inv = InventoryScreen(screen, {}, hero)
@@ -69,16 +69,15 @@ def test_switch_skill_tabs(monkeypatch):
         "draw",
         types.SimpleNamespace(rect=lambda *a, **k: None, line=lambda *a, **k: None),
     )
-    rect = inv.skill_tab_buttons["tactics"]
-    assert inv.active_skill_tab == inv.SKILL_TABS[0]
-    assert inv._check_skill_tab_click((rect.x + 1, rect.y + 1))
-    assert inv.active_skill_tab == "tactics"
+    inv._draw_skills_content()
+    assert "logistics_N" in inv.skill_rects
+    assert "tactics_N" in inv.skill_rects
 
 
-def test_skill_acquisition_per_tree(monkeypatch):
+def test_skill_acquisition_multiple_branches(monkeypatch):
     monkeypatch.setattr(pygame, "Rect", Rect)
     screen, hero = make_screen_and_hero()
-    hero.skill_points = 1
+    hero.skill_points = 2
     inv = InventoryScreen(screen, {}, hero)
     inv.active_tab = "skills"
     monkeypatch.setattr(
@@ -89,11 +88,8 @@ def test_skill_acquisition_per_tree(monkeypatch):
     inv._draw_skills_content()
     rect = inv.skill_rects["logistics_N"]
     inv._on_lmb_down((rect.centerx, rect.centery))
-    assert "logistics_N" in hero.learned_skills["logistics"]
-
-    rect_tactics = inv.skill_tab_buttons["tactics"]
-    inv._check_skill_tab_click((rect_tactics.x + 1, rect_tactics.y + 1))
-    inv._draw_skills_content()
-    assert "tactics_N" in inv.skill_rects
-    assert hero.learned_skills.get("tactics", set()) == set()
+    rect2 = inv.skill_rects["tactics_N"]
+    inv._on_lmb_down((rect2.centerx, rect2.centery))
+    assert "logistics_N" in hero.learned_skills.get("logistics", set())
+    assert "tactics_N" in hero.learned_skills.get("tactics", set())
 

--- a/ui/inventory_tabs/skills.py
+++ b/ui/inventory_tabs/skills.py
@@ -20,80 +20,69 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def draw(screen: "InventoryScreen") -> None:
-    """Draw the content of the *Skills* tab."""
-    # Top skill tabs
-    for name, rect in screen.skill_tab_buttons.items():
-        col = (60, 62, 72) if name == screen.active_skill_tab else (46, 48, 56)
-        pygame.draw.rect(screen.screen, col, rect, border_radius=5)
-        pygame.draw.rect(screen.screen, COLOR_SLOT_BD, rect, 1, border_radius=5)
-        t = screen.font.render(name.title(), True, COLOR_TEXT)
-        screen.screen.blit(t, (rect.x + (rect.width - t.get_width()) // 2, rect.y + 4))
-
+    """Draw all skill branches simultaneously."""
     pts = screen.font.render(
         f"Skill Points: {screen.hero.skill_points}", True, COLOR_TEXT
     )
-    screen.screen.blit(pts, (screen.center_rect.x + 14, screen.center_rect.y + 90))
+    screen.screen.blit(pts, (screen.center_rect.x + 14, screen.center_rect.y + 44))
 
-    nodes = screen.skill_trees.get(screen.active_skill_tab, [])
-    positions = screen.skill_positions.get(screen.active_skill_tab, {})
-
-    # Grid & connectors (single column, four ranks)
-    cols, rows = 1, 4
-    gy = screen.center_rect.y + 110
+    cols = max(1, len(screen.SKILL_TABS))
+    rows = 4
+    gy = screen.center_rect.y + 74
     available_h = screen.center_rect.bottom - 40 - gy
     cell = min(100, available_h // rows)
     grid_w = cols * cell
     gx = screen.center_rect.x + (screen.center_rect.width - grid_w) // 2
 
-    # Draw links first
     def node_center(nid: str) -> Tuple[int, int]:
-        c, r = positions[nid]
+        branch = screen.skill_branch_of[nid]
+        c, r = screen.skill_positions[branch][nid]
         rect = pygame.Rect(gx + c * cell + 8, gy + r * cell + 8, cell - 16, cell - 16)
         return (rect.centerx, rect.centery)
 
-    for node in nodes:
-        for pre in node.requires:
-            p0 = node_center(pre)
-            p1 = node_center(node.id)
-            pygame.draw.line(screen.screen, COLOR_LINK, p0, p1, 3)
+    for branch, nodes in screen.skill_trees.items():
+        for node in nodes:
+            for pre in node.requires:
+                if pre in screen.skill_branch_of and screen.skill_branch_of[pre] == branch:
+                    p0 = node_center(pre)
+                    p1 = node_center(node.id)
+                    pygame.draw.line(screen.screen, COLOR_LINK, p0, p1, 3)
 
-    # Draw nodes
     screen.skill_rects.clear()
-    learned_set = screen.hero.learned_skills.get(screen.active_skill_tab, set())
-    for node in nodes:
-        c, r = positions[node.id]
-        rect = pygame.Rect(gx + c * cell + 8, gy + r * cell + 8, cell - 16, cell - 16)
-        learned = node.id in learned_set
-        available = (screen.hero.skill_points >= node.cost) and all(
-            req in learned_set for req in node.requires
-        )
-
-        state_col = (
-            COLOR_OK if learned else ((60, 120, 200) if available else COLOR_DISABLED)
-        )
-        pygame.draw.rect(screen.screen, COLOR_SLOT_BG, rect, border_radius=8)
-        pygame.draw.rect(screen.screen, state_col, rect, 3, border_radius=8)
-
-        # branch icon
-        icon = screen.assets.get(node.icon)
-        if icon:
-            icon = pygame.transform.smoothscale(
-                icon, (rect.width - 12, rect.height - 46)
+    for branch, nodes in screen.skill_trees.items():
+        learned_set = screen.hero.learned_skills.get(branch, set())
+        for node in nodes:
+            c, r = screen.skill_positions[branch][node.id]
+            rect = pygame.Rect(gx + c * cell + 8, gy + r * cell + 8, cell - 16, cell - 16)
+            learned = node.id in learned_set
+            available = (screen.hero.skill_points >= node.cost) and all(
+                req in learned_set for req in node.requires
             )
-            screen.screen.blit(icon, (rect.x + 6, rect.y + 6))
 
-        label = screen.font_small.render(node.rank, True, COLOR_TEXT)
-        screen.screen.blit(
-            label,
-            (
-                rect.centerx - label.get_width() // 2,
-                rect.bottom - label.get_height() - 6,
-            ),
-        )
+            state_col = (
+                COLOR_OK if learned else ((60, 120, 200) if available else COLOR_DISABLED)
+            )
+            pygame.draw.rect(screen.screen, COLOR_SLOT_BG, rect, border_radius=8)
+            pygame.draw.rect(screen.screen, state_col, rect, 3, border_radius=8)
 
-        screen.skill_rects[node.id] = rect
+            icon = screen.assets.get(f"skill_{node.id}.png")
+            if icon:
+                icon = pygame.transform.smoothscale(
+                    icon, (rect.width - 12, rect.height - 46)
+                )
+                screen.screen.blit(icon, (rect.x + 6, rect.y + 6))
 
-    # Hints
+            label = screen.font_small.render(node.rank, True, COLOR_TEXT)
+            screen.screen.blit(
+                label,
+                (
+                    rect.centerx - label.get_width() // 2,
+                    rect.bottom - label.get_height() - 6,
+                ),
+            )
+
+            screen.skill_rects[node.id] = rect
+
     hint = screen.font_small.render(
         "Left-click: Learn • Right-click: Refund (if no dependents)", True, COLOR_ACCENT
     )
@@ -113,25 +102,20 @@ def skill_tooltip(
     ]
     if node.requires:
         lines.append((f"Requires: {', '.join(node.requires)}", COLOR_TEXT))
-    learned = screen.hero.learned_skills.get(screen.active_skill_tab, set())
+    tree = screen.skill_branch_of.get(node.id, "")
+    learned = screen.hero.learned_skills.get(tree, set())
     if node.id in learned:
         lines.append(("Learned", COLOR_OK))
     else:
         ok = screen.hero.skill_points >= node.cost and all(
             req in learned for req in node.requires
         )
-        lines.append(
-            ("Available" if ok else "Locked", COLOR_OK if ok else COLOR_DISABLED)
-        )
+        lines.append(("Available" if ok else "Locked", COLOR_OK if ok else COLOR_DISABLED))
     return lines
 
 
 def check_tab_click(screen: "InventoryScreen", pos: Tuple[int, int]) -> bool:
-    """Handle click on skill sub-tab buttons."""
-    for name, rect in screen.skill_tab_buttons.items():
-        if rect.collidepoint(pos):
-            screen.active_skill_tab = name
-            return True
+    """Skill tabs are no longer used."""
     return False
 
 
@@ -144,12 +128,12 @@ def dependents_of(screen: "InventoryScreen", tree: str, nid: str) -> Set[str]:
     return deps
 
 
-def can_refund(screen: "InventoryScreen", nid: str) -> bool:
+def can_refund(screen: "InventoryScreen", tree: str, nid: str) -> bool:
     """Check if a skill node can be safely refunded."""
-    learned = screen.hero.learned_skills.get(screen.active_skill_tab, set())
+    learned = screen.hero.learned_skills.get(tree, set())
     if nid not in learned:
         return False
-    for dep in dependents_of(screen, screen.active_skill_tab, nid):
+    for dep in dependents_of(screen, tree, nid):
         if dep in learned:
             return False
     return True


### PR DESCRIPTION
## Summary
- render all skill trees at once in the inventory
- fetch skill icons by `skill_<id>.png`
- test simultaneous branch drawing and acquisition

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5f454fa483219c2015f085758047