### PR TITLE
feat: paginate inventory grid

### DIFF
--- a/ui/inventory_screen.py
+++ b/ui/inventory_screen.py
@@ -102,6 +102,8 @@ class InventoryScreen:
         self.item_rects: List[Tuple[Optional[int], pygame.Rect]] = []
         self.inventory_grid_origin: Tuple[int, int] = (0, 0)
         self.inventory_cell_size: int = 0
+        self.prev_page_rect: Optional[pygame.Rect] = None
+        self.next_page_rect: Optional[pygame.Rect] = None
         self.drag_item: Optional[Item] = None
         self.drag_origin: Optional[int] = None
         self.drag_icon_size: Optional[Tuple[int, int]] = None
@@ -594,11 +596,11 @@ class InventoryScreen:
                     elif e.button in (4, 5) and self.active_tab == "inventory":
                         items = self._filtered_inventory()
                         if e.button == 4:
-                            self.inventory_offset = max(0, self.inventory_offset - 6)
+                            self.inventory_offset = max(0, self.inventory_offset - 16)
                         else:
-                            max_off = max(0, len(items) - 36)
+                            max_off = max(0, len(items) - 16)
                             self.inventory_offset = min(
-                                max_off, self.inventory_offset + 6
+                                max_off, self.inventory_offset + 16
                             )
 
                 elif e.type == pygame.MOUSEBUTTONUP and e.button == 1:
@@ -684,13 +686,22 @@ class InventoryScreen:
                     self.sort_mode = name
                     self.inventory_offset = 0
                     return
+            # Pagination buttons
+            if self.prev_page_rect and self.prev_page_rect.collidepoint(pos):
+                self.inventory_offset = max(0, self.inventory_offset - 16)
+                return
+            if self.next_page_rect and self.next_page_rect.collidepoint(pos):
+                items = self._filtered_inventory()
+                max_off = max(0, len(items) - 16)
+                self.inventory_offset = min(max_off, self.inventory_offset + 16)
+                return
             # Start drag from bag grid
             gx, gy = self.inventory_grid_origin
             size = self.inventory_cell_size
-            if size and gx <= pos[0] < gx + size * 6 and gy <= pos[1] < gy + size * 6:
+            if size and gx <= pos[0] < gx + size * 4 and gy <= pos[1] < gy + size * 4:
                 col = (pos[0] - gx) // size
                 row = (pos[1] - gy) // size
-                slot = row * 6 + col
+                slot = row * 4 + col
                 items = self._filtered_inventory()
                 idx = self.inventory_offset + slot
                 if idx < len(items):

--- a/ui/inventory_tabs/inventory.py
+++ b/ui/inventory_tabs/inventory.py
@@ -75,18 +75,18 @@ def draw(screen: "InventoryScreen") -> None:
     t = screen.font.render(screen.search_text or "Search...", True, COLOR_TEXT)
     screen.screen.blit(t, (screen.search_rect.x + 6, screen.search_rect.y + 6))
 
-    # Items grid 6x6
+    # Items grid 4x4 with pagination
     items = filtered_inventory(screen)
     start = screen.inventory_offset
     screen.item_rects = []
     gx = screen.center_rect.x + 12
     gy = screen.center_rect.y + 120
-    cell = (screen.center_rect.width - 24) // 6
+    cell = (screen.center_rect.width - 24) // 4
     screen.inventory_grid_origin = (gx, gy)
     screen.inventory_cell_size = cell
-    for row in range(6):
-        for col in range(6):
-            idx = start + row * 6 + col
+    for row in range(4):
+        for col in range(4):
+            idx = start + row * 4 + col
             rect = pygame.Rect(gx + col * cell, gy + row * cell, cell, cell)
             pygame.draw.rect(screen.screen, theme.PALETTE["panel"], rect)
             theme.draw_frame(screen.screen, rect)
@@ -109,6 +109,28 @@ def draw(screen: "InventoryScreen") -> None:
                 screen.item_rects.append((inv_idx, rect))
             else:
                 screen.item_rects.append((None, rect))
+
+    # Pagination buttons
+    btn_w, btn_h = 32, 24
+    btn_y = gy + 4 * cell + 10
+    prev_rect = pygame.Rect(gx, btn_y, btn_w, btn_h)
+    next_rect = pygame.Rect(gx + 4 * cell - btn_w, btn_y, btn_w, btn_h)
+    screen.prev_page_rect = prev_rect
+    screen.next_page_rect = next_rect
+    pygame.draw.rect(screen.screen, theme.PALETTE["panel"], prev_rect)
+    pygame.draw.rect(screen.screen, COLOR_SLOT_BD, prev_rect, 1)
+    pygame.draw.rect(screen.screen, theme.PALETTE["panel"], next_rect)
+    pygame.draw.rect(screen.screen, COLOR_SLOT_BD, next_rect, 1)
+    lt = screen.font.render("<", True, COLOR_TEXT)
+    rt = screen.font.render(">", True, COLOR_TEXT)
+    screen.screen.blit(
+        lt,
+        (prev_rect.centerx - lt.get_width() // 2, prev_rect.centery - lt.get_height() // 2),
+    )
+    screen.screen.blit(
+        rt,
+        (next_rect.centerx - rt.get_width() // 2, next_rect.centery - rt.get_height() // 2),
+    )
 
 
 def item_tooltip(


### PR DESCRIPTION
## Summary
- limit inventory grid to 4x4 cells with pagination controls
- update drag-and-drop and scrolling for page-sized navigation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af61e36af8832189621fb436eaa0e5