### PR TITLE
feat: improve hero stats presentation

### DIFF
--- a/ui/inventory_screen.py
+++ b/ui/inventory_screen.py
@@ -132,6 +132,9 @@ class InventoryScreen:
         # Equipment
         self.slot_rects: Dict[EquipmentSlot, pygame.Rect] = {}
 
+        # Stat icons (Stats tab)
+        self.stat_rects: List[Tuple[str, pygame.Rect]] = []
+
         # Skills --------------------------------------------------------------
         self.skill_trees: Dict[str, List[SkillNode]] = {}
         self.skill_positions: Dict[str, Dict[str, Tuple[int, int]]] = {}
@@ -191,7 +194,7 @@ class InventoryScreen:
 
         self.resbar_rect = pygame.Rect(0, H - RESBAR_H, W, RESBAR_H)
         self.tabs_rect = pygame.Rect(0, 0, tab_w, body_h)
-        self.center_rect = pygame.Rect(tab_w, 0, W - tab_w - equip_w, body_h)
+        self.center_rect = pygame.Rect(tab_w, 0, W - tab_w - equip_w, H)
         self.centre_rect = self.center_rect  # alias for compatibility
         self.equip_rect = pygame.Rect(W - equip_w, 0, equip_w, body_h)
 
@@ -487,6 +490,20 @@ class InventoryScreen:
                         if node:
                             lines = self._skill_tooltip(node)
                         break
+            elif self.active_tab == "stats":
+                for name, rect in self.stat_rects:
+                    if rect.collidepoint(mouse):
+                        lines = [(name, COLOR_TEXT)]
+                        break
+                if not lines:
+                    for slot, rect in self.slot_rects.items():
+                        if rect.collidepoint(mouse):
+                            item = self.hero.equipment.get(slot)
+                            if item:
+                                lines = self._item_tooltip(item, equip=False)
+                            else:
+                                lines = [(slot.name.title(), COLOR_TEXT)]
+                            break
             else:
                 for slot, rect in self.slot_rects.items():
                     if rect.collidepoint(mouse):

--- a/ui/inventory_tabs/stats.py
+++ b/ui/inventory_tabs/stats.py
@@ -42,10 +42,15 @@ def draw(screen: "InventoryScreen") -> None:
     y = screen.center_rect.y + 52
     x = screen.center_rect.x + 16
 
-    # Portrait
-    hero_img = screen.assets.get(constants.IMG_HERO_PORTRAIT)
+    # Portrait (use hero.portrait with fallback to default asset)
+    hero_img = getattr(screen.hero, "portrait", None)
+    if hero_img is None:
+        hero_img = screen.assets.get(constants.IMG_HERO_PORTRAIT)
     if hero_img:
-        hero_img = pygame.transform.scale(hero_img, (120, 120))
+        try:
+            hero_img = pygame.transform.scale(hero_img, (120, 120))
+        except (AttributeError, TypeError):
+            pass
         screen.screen.blit(hero_img, (x, y))
         x += 140
 
@@ -78,16 +83,19 @@ def draw(screen: "InventoryScreen") -> None:
         pairs.append((school, f"{value}%"))
     y2 = y + len(lines) * 26 + 8
     size = 24
+    screen.stat_rects = []
     for j, (key, val) in enumerate(pairs):
         icon_id = _STAT_ICON_IDS.get(key)
         icon = IconLoader.get(icon_id, size) if icon_id else None
+        rect = pygame.Rect(x, y2 + j * 24, size, size)
         if icon:
-            screen.screen.blit(icon, (x, y2 + j * 24))
+            screen.screen.blit(icon, rect.topleft)
         else:
             placeholder = screen.font.render(str(key)[:2], True, COLOR_TEXT)
-            screen.screen.blit(placeholder, (x, y2 + j * 24))
+            screen.screen.blit(placeholder, rect.topleft)
+        screen.stat_rects.append((key, rect))
         t2 = screen.font.render(str(val), True, COLOR_TEXT)
-        screen.screen.blit(t2, (x + size + 4, y2 + j * 24))
+        screen.screen.blit(t2, (rect.x + size + 4, rect.y))
 
     # Army 7x1
     font_big = screen.font_big or screen.font


### PR DESCRIPTION
## Summary
- load hero portrait from `hero.portrait` with default fallback
- enlarge stats panel layout for more vertical room
- show tooltips for stat icons in inventory stats tab

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af62f158d88321b079fea702ade7af