### PR TITLE
Gracefully handle unknown units in saves

### DIFF
--- a/tests/test_unknown_unit_load.py
+++ b/tests/test_unknown_unit_load.py
@@ -1,0 +1,31 @@
+import types
+import sys
+import json
+
+pygame_stub = types.SimpleNamespace()
+sys.modules.setdefault("pygame", pygame_stub)
+
+from core.game import Game
+from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.world import WorldMap
+
+
+def test_load_game_with_unknown_unit(tmp_path):
+    game = Game.__new__(Game)
+    game.world = WorldMap(width=3, height=3, num_obstacles=0, num_treasures=0, num_enemies=0)
+    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])
+    game.hero = hero
+    hero.equipment = {}
+
+    save_path = tmp_path / "save.json"
+    game.save_game(save_path)
+
+    with save_path.open() as f:
+        data = json.load(f)
+    data["hero"]["army"][0]["name"] = "mystery_unit"
+    with save_path.open("w") as f:
+        json.dump(data, f)
+
+    game2 = Game.__new__(Game)
+    game2.load_game(save_path)
+    assert game2.hero.units == []

--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -137,7 +137,12 @@ class MainScreen:
         profile = getattr(self.game, "default_profile_path", None)
         if cb and path:
             if os.path.exists(path):
-                cb(path, profile)
+                try:
+                    cb(path, profile)
+                except Exception as exc:  # pragma: no cover - defensive
+                    EVENT_BUS.publish(
+                        ON_INFO_MESSAGE, f"Failed to load save: {exc}"
+                    )
             else:
                 EVENT_BUS.publish(ON_INFO_MESSAGE, f"Save file not found: {path}")
 


### PR DESCRIPTION
## Summary
- prevent crashes when loading saves with missing unit types by skipping unknown units
- show a user-friendly message if loading a save fails
- regression test for loading saves containing unknown units

## Testing
- `pytest tests/test_army_serialization.py tests/test_save_load_roundtrip.py tests/test_unknown_unit_load.py`

------
https://chatgpt.com/codex/tasks/task_e_68af69a5d54c832193a2b1eb7f4a252a