### PR TITLE
Render combat grid for all cells

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -129,11 +129,6 @@ def draw(combat, frame: int = 0) -> None:
     # Hex grid overlay
     for x in range(constants.COMBAT_GRID_WIDTH):
         for y in range(constants.COMBAT_GRID_HEIGHT):
-            if (
-                x in (0, constants.COMBAT_GRID_WIDTH - 1)
-                or y in (0, constants.COMBAT_GRID_HEIGHT - 1)
-            ):
-                continue
             rect = combat.cell_rect(x, y)
             draw_hex(overlay, rect, theme.PALETTE["panel"], 15, width=1)
 


### PR DESCRIPTION
## Summary
- Draw hex overlay on every combat grid cell, including borders
- Keep grid subtle with low alpha and thin stroke

## Testing
- `pytest tests/test_overlay_rendering.py::test_combat_overlay_uses_additive_blending -q`
- `python - <<'PY'
import os
os.environ['SDL_VIDEODRIVER'] = 'dummy'
import pygame
pygame.init()
import constants
from core.combat import Combat
from core.entities import UnitStats, Unit
from core import combat_render
stats = UnitStats(name='a', max_hp=1, attack_min=1, attack_max=1,
                  defence_melee=0, defence_ranged=0, defence_magic=0,
                  speed=1, attack_range=1, initiative=1,
                  sheet='', hero_frames=(0,0), enemy_frames=(0,0))
hero = Unit(stats, 1, 'hero')
enemy = Unit(stats, 1, 'enemy')
screen = pygame.Surface((800, 600))
combat = Combat(screen, assets={}, hero_units=[hero], enemy_units=[enemy])
combat_render.draw(combat)
print('render complete')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af6a396e8883219b28d574a9a018b7