### PR TITLE
Make HeroArmyPanel layout proportional and responsive

### DIFF
--- a/tests/test_hero_army_panel.py
+++ b/tests/test_hero_army_panel.py
@@ -71,3 +71,21 @@ def test_callbacks_for_right_click_and_double_click():
     )
     panel.handle_event(evt_double, rect)
     assert opened == [hero]
+
+
+def test_cells_remain_inside_panel_after_resize():
+    hero = DummyHero([])
+    panel = HeroArmyPanel(hero)
+
+    rect_large = pygame.Rect(0, 0, 300, 200)
+    # compute initial layout
+    for idx in range(panel.GRID_CELLS):
+        panel._cell_rect(idx, rect_large)
+
+    rect_small = pygame.Rect(10, 5, 60, 80)
+    for idx in range(panel.GRID_CELLS):
+        cell = panel._cell_rect(idx, rect_small)
+        assert rect_small.x <= cell.x
+        assert rect_small.y <= cell.y
+        assert cell.x + cell.width <= rect_small.x + rect_small.width
+        assert cell.y + cell.height <= rect_small.y + rect_small.height


### PR DESCRIPTION
## Summary
- compute hero portrait and grid layout proportionally to widget rectangle
- clamp grid origin to keep cells inside the panel after resizing
- add regression test for layout staying within bounds after resize

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af6ce9941c832181b814c14456c47e