### PR TITLE
Ensure inventory grid respects available area

### DIFF
--- a/tests/test_inventory_grid_bounds.py
+++ b/tests/test_inventory_grid_bounds.py
@@ -1,0 +1,78 @@
+import types
+import pytest
+import pygame
+import theme
+from core.entities import Hero, Unit, SWORDSMAN_STATS
+from ui.inventory_screen import InventoryScreen
+
+
+class DummySurface:
+    def __init__(self, size):
+        self._size = size
+
+    def fill(self, *args, **kwargs):
+        pass
+
+    def get_size(self):
+        return self._size
+
+    def blit(self, *args, **kwargs):
+        pass
+
+
+class Rect:
+    def __init__(self, x, y, w, h):
+        self.x, self.y, self.width, self.height = x, y, w, h
+
+    @property
+    def size(self):
+        return (self.width, self.height)
+
+    @property
+    def centerx(self):
+        return self.x + self.width // 2
+
+    @property
+    def centery(self):
+        return self.y + self.height // 2
+
+    @property
+    def right(self):
+        return self.x + self.width
+
+    @property
+    def bottom(self):
+        return self.y + self.height
+
+    @property
+    def topleft(self):
+        return (self.x, self.y)
+
+    def collidepoint(self, pos):
+        px, py = pos
+        return self.x <= px < self.right and self.y <= py < self.bottom
+
+
+@pytest.mark.parametrize("size", [(800, 600), (640, 480), (400, 300)])
+def test_inventory_grid_fits_center_rect(monkeypatch, size):
+    monkeypatch.setattr(pygame, "Rect", Rect)
+    monkeypatch.setattr(pygame, "draw", types.SimpleNamespace(rect=lambda *a, **k: None))
+    monkeypatch.setattr(theme, "draw_frame", lambda *a, **k: None)
+
+    screen = DummySurface(size)
+    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])
+    inv = InventoryScreen(screen, {}, hero)
+    inv.active_tab = "inventory"
+
+    inv._draw_inventory_content()
+
+    gx, gy = inv.inventory_grid_origin
+    cell = inv.inventory_cell_size
+    grid_w = cell * 4
+    grid_h = cell * 4
+
+    assert gx >= inv.center_rect.x
+    assert gy >= inv.center_rect.y
+    assert gx + grid_w <= inv.center_rect.right
+    assert gy + grid_h <= inv.center_rect.bottom
+    assert inv.next_page_rect.bottom <= inv.center_rect.bottom

--- a/ui/inventory_tabs/inventory.py
+++ b/ui/inventory_tabs/inventory.py
@@ -80,8 +80,17 @@ def draw(screen: "InventoryScreen") -> None:
     start = screen.inventory_offset
     screen.item_rects = []
     gx = screen.center_rect.x + 12
-    gy = screen.center_rect.y + 120
-    cell = (screen.center_rect.width - 24) // 4
+    top_offset = 120
+    # Each cell is bounded by both available width and height and capped at 64px
+    btn_w, btn_h = 32, 24
+    avail_w = screen.center_rect.width - 24
+    avail_h = screen.center_rect.height - top_offset
+    max_cell_w = avail_w // 4
+    max_cell_h = max((avail_h - btn_h - 10) // 4, 1)
+    cell = min(max_cell_w, max_cell_h, 64)
+    grid_h = cell * 4
+    # Center the grid vertically within the available space
+    gy = screen.center_rect.y + top_offset + (avail_h - (grid_h + btn_h + 10)) // 2
     screen.inventory_grid_origin = (gx, gy)
     screen.inventory_cell_size = cell
     for row in range(4):
@@ -111,7 +120,6 @@ def draw(screen: "InventoryScreen") -> None:
                 screen.item_rects.append((None, rect))
 
     # Pagination buttons
-    btn_w, btn_h = 32, 24
     btn_y = gy + 4 * cell + 10
     prev_rect = pygame.Rect(gx, btn_y, btn_w, btn_h)
     next_rect = pygame.Rect(gx + 4 * cell - btn_w, btn_y, btn_w, btn_h)


### PR DESCRIPTION
## Summary
- Limit inventory grid cell size based on both available width and height (max 64px)
- Center the inventory grid vertically and adjust pagination buttons accordingly
- Add regression test verifying 4x4 grid stays within center panel for multiple screen sizes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6fb03584832180f6936ada65927f