### PR TITLE
Adjust stats tab army grid position

### DIFF
--- a/tests/test_stats_army_grid_bounds.py
+++ b/tests/test_stats_army_grid_bounds.py
@@ -1,0 +1,74 @@
+import types
+import pytest
+import pygame
+import theme
+from loaders import icon_loader as IconLoader
+from core.entities import Hero, Unit, SWORDSMAN_STATS
+from ui.inventory_screen import InventoryScreen
+
+
+class DummySurface:
+    def __init__(self, size):
+        self._size = size
+
+    def fill(self, *args, **kwargs):
+        pass
+
+    def get_size(self):
+        return self._size
+
+    def blit(self, *args, **kwargs):
+        pass
+
+
+class Rect:
+    def __init__(self, x, y, w, h):
+        self.x, self.y, self.width, self.height = x, y, w, h
+
+    @property
+    def size(self):
+        return (self.width, self.height)
+
+    @property
+    def centerx(self):
+        return self.x + self.width // 2
+
+    @property
+    def centery(self):
+        return self.y + self.height // 2
+
+    @property
+    def right(self):
+        return self.x + self.width
+
+    @property
+    def bottom(self):
+        return self.y + self.height
+
+    @property
+    def topleft(self):
+        return (self.x, self.y)
+
+    def collidepoint(self, pos):
+        px, py = pos
+        return self.x <= px < self.right and self.y <= py < self.bottom
+
+
+@pytest.mark.parametrize("size", [(800, 600), (640, 480), (400, 300)])
+def test_army_grid_above_resbar(monkeypatch, size):
+    monkeypatch.setattr(pygame, "Rect", Rect)
+    monkeypatch.setattr(pygame, "draw", types.SimpleNamespace(rect=lambda *a, **k: None))
+    monkeypatch.setattr(theme, "draw_frame", lambda *a, **k: None)
+    monkeypatch.setattr(IconLoader, "get", lambda *a, **k: None)
+
+    screen = DummySurface(size)
+    hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])
+    inv = InventoryScreen(screen, {}, hero)
+    inv.active_tab = "stats"
+
+    inv._draw_stats_content()
+
+    gy = inv.army_rects[0][1].y
+    cell = inv.army_rects[0][1].height
+    assert gy + cell < inv.resbar_rect.y
+

--- a/ui/inventory_tabs/stats.py
+++ b/ui/inventory_tabs/stats.py
@@ -98,13 +98,14 @@ def draw(screen: "InventoryScreen") -> None:
         screen.screen.blit(t2, (rect.x + size + 4, rect.y))
 
     # Army 7x1
+    gy = screen.center_rect.y + int(screen.center_rect.height * 0.55)
     font_big = screen.font_big or screen.font
     if font_big:
         label = font_big.render("Hero Army", True, COLOR_TEXT)
-        gy = screen.center_rect.y + screen.center_rect.height - 120
-        screen.screen.blit(label, (screen.center_rect.x + 12, gy - 28))
-    else:
-        gy = screen.center_rect.y + screen.center_rect.height - 120
+        screen.screen.blit(
+            label,
+            (screen.center_rect.x + 12, gy - label.get_height() - 4),
+        )
     screen.army_rects = []
     cell = 84
     for idx in range(7):


### PR DESCRIPTION
## Summary
- Position stats tab army grid using a height percentage and relocate label accordingly
- Add regression test ensuring the stats grid stays above the resource bar

## Testing
- `pytest tests/test_inventory_grid_bounds.py tests/test_stats_army_grid_bounds.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af70f212848321924fd49bbc584645