### PR TITLE
Link spellbook overlay and scale hero army panel

### DIFF
--- a/ui/spellbook_overlay.py
+++ b/ui/spellbook_overlay.py
@@ -94,7 +94,8 @@ class SpellbookOverlay:
 
     def _load_town_spells(self) -> None:
         """Load spells grouped by school for town view."""
-        path = os.path.join("assets", "spells", "spells.json")
+        base = os.path.dirname(os.path.dirname(__file__))
+        path = os.path.join(base, "assets", "spells", "spells.json")
         try:
             with open(path, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
@@ -197,6 +198,12 @@ class SpellbookOverlay:
                 overlay.blit(label, (rect.x + 10, rect.y + 5))
                 self._tab_rects.append((rect.move(offset_x, offset_y), cat))
                 x += rect.width + 5
+
+        if not self.spell_names:
+            msg = self.font.render(self.texts.get("No spells", "No spells"), True, self.TEXT)
+            overlay.blit(msg, ((w - msg.get_width()) // 2, (h - msg.get_height()) // 2))
+            self.screen.blit(overlay, (offset_x, offset_y))
+            return
 
         # Grid drawing
         grid_x = 20

--- a/ui/widgets/hero_army_panel.py
+++ b/ui/widgets/hero_army_panel.py
@@ -35,6 +35,8 @@ class HeroArmyPanel:
     GRID_ROWS = len(GRID_LAYOUT)
     GRID_COLS = max(cols + (offset + 1) // 2 for cols, offset in GRID_LAYOUT)
     GRID_CELLS = sum(cols for cols, _ in GRID_LAYOUT)
+    MAX_PORTRAIT = 96
+    MAX_CELL = 72
 
     FORMATION_BUTTON_HEIGHT = 20
     SPLIT_BUTTON_HEIGHT = 20
@@ -105,21 +107,45 @@ class HeroArmyPanel:
         """
 
         content_h = max(1, rect.height - self.FORMATION_BUTTON_HEIGHT - self.PADDING)
-        portrait_max_h = max(1, content_h - self.SPLIT_BUTTON_HEIGHT - self.PADDING)
+        portrait_max_h = min(
+            self.MAX_PORTRAIT, content_h - self.SPLIT_BUTTON_HEIGHT - self.PADDING
+        )
         grid_min_w = self.GRID_COLS * 1 + (self.GRID_COLS - 1) * self.PADDING
-        portrait_max_w = max(1, rect.width - grid_min_w - 2 * self.PADDING)
+        portrait_max_w = min(
+            self.MAX_PORTRAIT, rect.width - grid_min_w - 2 * self.PADDING
+        )
         portrait_size = max(1, min(portrait_max_h, portrait_max_w))
 
         avail_w = max(1, rect.width - portrait_size - 2 * self.PADDING)
         cell_w = max(
-            1, (avail_w - (self.GRID_COLS - 1) * self.PADDING) // self.GRID_COLS
+            1,
+            min(
+                (avail_w - (self.GRID_COLS - 1) * self.PADDING) // self.GRID_COLS,
+                self.MAX_CELL,
+            ),
         )
         cell_h = max(
-            1, (content_h - (self.GRID_ROWS - 1) * self.PADDING) // self.GRID_ROWS
+            1,
+            min(
+                (content_h - (self.GRID_ROWS - 1) * self.PADDING) // self.GRID_ROWS,
+                self.MAX_CELL,
+            ),
         )
         cell_size = max(1, min(cell_w, cell_h))
 
         grid_w = self.GRID_COLS * cell_size + (self.GRID_COLS - 1) * self.PADDING
+        if grid_w > avail_w:
+            portrait_size = max(1, rect.width - grid_w - 2 * self.PADDING)
+            avail_w = max(1, rect.width - portrait_size - 2 * self.PADDING)
+            cell_w = max(
+                1,
+                min(
+                    (avail_w - (self.GRID_COLS - 1) * self.PADDING) // self.GRID_COLS,
+                    self.MAX_CELL,
+                ),
+            )
+            cell_size = max(1, min(cell_w, cell_h))
+            grid_w = self.GRID_COLS * cell_size + (self.GRID_COLS - 1) * self.PADDING
         grid_h = self.GRID_ROWS * cell_size + (self.GRID_ROWS - 1) * self.PADDING
 
         gx = rect.x + portrait_size + self.PADDING + max(0, (avail_w - grid_w) // 2)


### PR DESCRIPTION
## Summary
- Ensure Magic School opens populated spellbook overlay with message when no spells
- Constrain hero army panel portrait and grid sizes to stay within widget

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbfa160488321aa78e32780f70170