### PR TITLE
Load unit spells from manifests

### DIFF
--- a/assets/units/creatures.json
+++ b/assets/units/creatures.json
@@ -31,7 +31,8 @@
       "biomes": ["scarletia_volcanic"],
       "behavior": "roamer",
       "guard_range": 3,
-      "battlefield_scale": 1.0
+      "battlefield_scale": 1.0,
+      "abilities": {}
     },
     {
       "id": "shadowleaf_wolf",
@@ -42,7 +43,8 @@
       "biomes": ["scarletia_crimson_forest"],
       "behavior": "roamer",
       "guard_range": 3,
-      "battlefield_scale": 1.0
+      "battlefield_scale": 1.0,
+      "abilities": {}
     },
     {
       "id": "boar_raven",
@@ -53,7 +55,8 @@
       "biomes": ["scarletia_echo_plain", "mountain"],
       "behavior": "roamer",
       "guard_range": 2,
-      "battlefield_scale": 1.0
+      "battlefield_scale": 1.0,
+      "abilities": {}
     },
     {
       "id": "hurlombe",
@@ -64,7 +67,8 @@
       "biomes": ["scarletia_crimson_forest", "mountain"],
       "behavior": "guardian",
       "guard_range": 2,
-      "battlefield_scale": 1.0
+      "battlefield_scale": 1.0,
+      "abilities": {}
     },
     {
       "id": "reef_serpent",
@@ -75,7 +79,8 @@
       "biomes": ["ocean"],
       "behavior": "roamer",
       "guard_range": 3,
-      "battlefield_scale": 1.75
+      "battlefield_scale": 1.75,
+      "abilities": {}
     }
   ]
 }

--- a/assets/units/units.json
+++ b/assets/units/units.json
@@ -32,7 +32,8 @@
       "image": "units/swordsman.png",
       "anchor_px": [32, 64],
       "shadow_baked": true,
-      "battlefield_scale": 1.0
+      "battlefield_scale": 1.0,
+      "abilities": {"Shield Block": 1}
     },
     {
       "id": "archer",
@@ -40,7 +41,8 @@
       "image": "units/archer.png",
       "anchor_px": [32, 64],
       "shadow_baked": true,
-      "battlefield_scale": 1.0
+      "battlefield_scale": 1.0,
+      "abilities": {"Focus": 1}
     },
     {
       "id": "mage",
@@ -48,7 +50,8 @@
       "image": "units/mage.png",
       "anchor_px": [32, 64],
       "shadow_baked": true,
-      "battlefield_scale": 1.0
+      "battlefield_scale": 1.0,
+      "abilities": {"Fireball": 1, "Chain Lightning": 2, "Ice Wall": 1}
     },
     {
       "id": "dragon",
@@ -56,7 +59,8 @@
       "image": "units/dragon.png",
       "anchor_px": [32, 64],
       "shadow_baked": true,
-      "battlefield_scale": 1.75
+      "battlefield_scale": 1.75,
+      "abilities": {"Dragon Breath": 2}
     },
     {
       "id": "priest",
@@ -64,7 +68,8 @@
       "image": "units/priest.png",
       "anchor_px": [32, 64],
       "shadow_baked": true,
-      "battlefield_scale": 1.0
+      "battlefield_scale": 1.0,
+      "abilities": {"Heal": 1}
     },
     {
       "id": "cavalry",
@@ -72,7 +77,8 @@
       "image": "units/cavalry.png",
       "anchor_px": [32, 64],
       "shadow_baked": true,
-      "battlefield_scale": 1.3
+      "battlefield_scale": 1.3,
+      "abilities": {"Charge": 1}
     }
   ]
 }

--- a/tests/test_units_abilities.py
+++ b/tests/test_units_abilities.py
@@ -14,6 +14,7 @@ from core.entities import (
 )
 from core import combat_ai
 import constants
+from core import combat
 
 
 def test_unit_stats_have_abilities():
@@ -21,6 +22,10 @@ def test_unit_stats_have_abilities():
     assert 'flying' in DRAGON_STATS.abilities
     assert 'multi_shot' in DRAGON_STATS.abilities
     assert 'passive_heal' in PRIEST_STATS.abilities
+
+
+def test_unit_spells_loaded_from_manifest():
+    assert combat.UNIT_SPELLS.get(SWORDSMAN_STATS.name, {}).get('Shield Block') == 1
 
 
 def test_multi_shot_double_damage(simple_combat):


### PR DESCRIPTION
## Summary
- add abilities to unit and creature manifests
- dynamically load unit spell costs from JSON and expose through `UNIT_SPELLS`
- verify dynamic spell mapping in unit ability tests

## Testing
- `pre-commit run --files assets/units/units.json assets/units/creatures.json core/combat.py tests/test_units_abilities.py`
- `pytest tests/test_units_abilities.py tests/test_spells.py tests/test_creatures_manifest_warning.py`

------
https://chatgpt.com/codex/tasks/task_e_68af80e61ce88321a187e4571f453cea