### PR TITLE
Use economy API for structure building and upgrades

### DIFF
--- a/tests/test_ai_recruitment.py
+++ b/tests/test_ai_recruitment.py
@@ -21,7 +21,11 @@ def test_ai_weekly_recruitment_consumes_resources():
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
     hero.gold = 100
-    assert town.build_structure('barracks', hero)
+    player = economy.PlayerEconomy()
+    player.resources['wood'] = 5
+    player.resources['stone'] = 5
+    player.resources['gold'] = 100
+    assert town.build_structure('barracks', hero, player)
 
     state = GameState(world=world)
     state.economy.players[1] = economy.PlayerEconomy()

--- a/tests/test_building_upgrade.py
+++ b/tests/test_building_upgrade.py
@@ -16,6 +16,8 @@ def test_building_upgrade_updates_income_and_resources():
     hero = Hero(0, 0, [])
     hero.gold = 150
     hero.resources = {}
+    player = economy.PlayerEconomy()
+    player.resources["gold"] = 150
     b = Building()
     b.production_per_level = {"gold": 5}
     b.income = {"gold": 5}
@@ -27,7 +29,7 @@ def test_building_upgrade_updates_income_and_resources():
         upgrade_cost=dict(b.upgrade_cost),
         production_per_level=dict(b.production_per_level),
     )
-    assert b.upgrade(hero, econ_b)
+    assert b.upgrade(hero, player, econ_b)
     assert b.level == 2
     assert b.income["gold"] == 10
     assert hero.gold == 50
@@ -43,6 +45,8 @@ def test_building_upgrade_persisted(tmp_path):
     game.hero.equipment = {}
     game.hero.apply_bonuses_to_army()
     game.hero.gold = 200
+    player = economy.PlayerEconomy()
+    player.resources["gold"] = 200
 
     b = Building()
     b.name = "mine"
@@ -65,7 +69,7 @@ def test_building_upgrade_persisted(tmp_path):
     game.state.economy.buildings.append(econ_b)
     game.state.economy.players[0] = economy.PlayerEconomy()
 
-    assert b.upgrade(game.hero, econ_b)
+    assert b.upgrade(game.hero, player, econ_b)
 
     save_path = tmp_path / "save.json"
     game.save_game(save_path)

--- a/tests/test_dwelling_growth.py
+++ b/tests/test_dwelling_growth.py
@@ -40,6 +40,10 @@ def test_town_available_units():
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
     hero.gold = 100
-    assert town.build_structure('barracks', hero)
+    player = economy.PlayerEconomy()
+    player.resources['wood'] = 5
+    player.resources['stone'] = 5
+    player.resources['gold'] = 100
+    assert town.build_structure('barracks', hero, player)
     town.next_week()
     assert town.available_units('barracks').get('Swordsman') == 10

--- a/tests/test_game_state_weekly_town_growth.py
+++ b/tests/test_game_state_weekly_town_growth.py
@@ -8,6 +8,7 @@ from core.buildings import Town
 from core.world import WorldMap
 from core.entities import Hero
 from state.game_state import GameState
+from core import economy
 
 
 def test_weekly_growth_via_next_day():
@@ -21,7 +22,11 @@ def test_weekly_growth_via_next_day():
     hero.resources["wood"] = 5
     hero.resources["stone"] = 5
     hero.gold = 100
-    assert town.build_structure("barracks", hero)
+    player = economy.PlayerEconomy()
+    player.resources["wood"] = 5
+    player.resources["stone"] = 5
+    player.resources["gold"] = 100
+    assert town.build_structure("barracks", hero, player)
     assert town.available_units("barracks").get("Swordsman") == 5
 
     for _ in range(7):

--- a/tests/test_payment_failures.py
+++ b/tests/test_payment_failures.py
@@ -1,0 +1,41 @@
+import os
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+
+from core.buildings import Town, Building
+from core.entities import Hero
+from core import economy
+
+
+def test_build_structure_payment_failure():
+    pygame.init()
+    town = Town(faction_id="red_knights")
+    hero = Hero(0, 0, [])
+    hero.gold = 0
+    hero.resources["wood"] = 0
+    hero.resources["stone"] = 0
+    player = economy.PlayerEconomy()
+    # Resources mirror hero
+    player.resources["gold"] = 0
+    player.resources["wood"] = 0
+    player.resources["stone"] = 0
+    assert not town.build_structure("barracks", hero, player)
+    assert "barracks" not in town.built_structures
+    assert not town.built_today
+    assert hero.gold == 0
+    assert player.resources["wood"] == 0
+
+
+def test_building_upgrade_payment_failure():
+    hero = Hero(0, 0, [])
+    hero.gold = 50
+    player = economy.PlayerEconomy()
+    player.resources["gold"] = 50
+    b = Building()
+    b.upgrade_cost = {"gold": 100}
+    econ_b = economy.Building(id="mine", upgrade_cost=dict(b.upgrade_cost))
+    assert not b.upgrade(hero, player, econ_b)
+    assert b.level == 1
+    assert hero.gold == 50
+    assert econ_b.level == 1

--- a/tests/test_town_build_limit.py
+++ b/tests/test_town_build_limit.py
@@ -15,12 +15,16 @@ def test_one_structure_per_day():
     hero.resources["wood"] = 10
     hero.resources["stone"] = 10
     hero.gold = 1000
+    player = economy.PlayerEconomy()
+    player.resources["wood"] = 10
+    player.resources["stone"] = 10
+    player.resources["gold"] = 1000
 
-    assert town.build_structure("barracks", hero)
-    assert not town.build_structure("market", hero)
+    assert town.build_structure("barracks", hero, player)
+    assert not town.build_structure("market", hero, player)
 
     town.advance_day()
-    assert town.build_structure("market", hero)
+    assert town.build_structure("market", hero, player)
 
 
 def test_economy_build_lock():

--- a/tests/test_town_recruitment.py
+++ b/tests/test_town_recruitment.py
@@ -10,6 +10,7 @@ import types
 from core.buildings import Town
 from core.world import WorldMap
 from core.entities import Hero
+from core import economy
 
 
 def _create_game_with_town():
@@ -34,7 +35,11 @@ def test_town_build_and_recruit():
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
     hero.gold = 100
-    town.build_structure('barracks', hero)
+    player = economy.PlayerEconomy()
+    player.resources['wood'] = 5
+    player.resources['stone'] = 5
+    player.resources['gold'] = 100
+    town.build_structure('barracks', hero, player)
     town.next_week()
     town.recruit_units('Swordsman', hero, count=1)
     assert 'barracks' in town.built_structures
@@ -51,7 +56,11 @@ def test_town_recruitment_limited_by_stock():
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
     hero.gold = 1000
-    assert town.build_structure('barracks', hero)
+    player = economy.PlayerEconomy()
+    player.resources['wood'] = 5
+    player.resources['stone'] = 5
+    player.resources['gold'] = 1000
+    assert town.build_structure('barracks', hero, player)
     town.next_week()
     # 5 initial + 5 weekly growth
     assert town.available_units('barracks').get('Swordsman') == 10
@@ -67,7 +76,11 @@ def test_recruit_into_garrison():
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
     hero.gold = 1000
-    assert town.build_structure('barracks', hero)
+    player = economy.PlayerEconomy()
+    player.resources['wood'] = 5
+    player.resources['stone'] = 5
+    player.resources['gold'] = 1000
+    assert town.build_structure('barracks', hero, player)
     town.next_week()
     assert town.recruit_units('Swordsman', hero, count=2, target_units=town.garrison)
     assert any(u.stats.name == 'Swordsman' and u.count == 2 for u in town.garrison)
@@ -82,7 +95,11 @@ def test_recruit_into_visiting_army():
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
     hero.gold = 1000
-    assert town.build_structure('barracks', hero)
+    player = economy.PlayerEconomy()
+    player.resources['wood'] = 5
+    player.resources['stone'] = 5
+    player.resources['gold'] = 1000
+    assert town.build_structure('barracks', hero, player)
     town.next_week()
     assert town.recruit_units('Swordsman', hero, count=3, target_units=visiting.army)
     assert any(u.stats.name == 'Swordsman' and u.count == 3 for u in visiting.army)
@@ -111,7 +128,11 @@ def test_townscreen_recruit_with_hero_goes_to_garrison(monkeypatch, pygame_stub)
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
     hero.gold = 1000
-    assert town.build_structure('barracks', hero)
+    player = economy.PlayerEconomy()
+    player.resources['wood'] = 5
+    player.resources['stone'] = 5
+    player.resources['gold'] = 1000
+    assert town.build_structure('barracks', hero, player)
     town.next_week()
 
     game = types.SimpleNamespace(hero=hero)
@@ -158,7 +179,11 @@ def test_townscreen_recruit_visiting_army(monkeypatch, pygame_stub):
     hero.resources['wood'] = 5
     hero.resources['stone'] = 5
     hero.gold = 1000
-    assert town.build_structure('barracks', hero)
+    player = economy.PlayerEconomy()
+    player.resources['wood'] = 5
+    player.resources['stone'] = 5
+    player.resources['gold'] = 1000
+    assert town.build_structure('barracks', hero, player)
     town.next_week()
 
     visiting = Army(0, 0, [], ap=4)

--- a/ui/building_info.py
+++ b/ui/building_info.py
@@ -59,7 +59,10 @@ def open_panel(
                 if close_rect.collidepoint(event.pos):
                     return
                 if building.upgrade_cost and upgrade_rect.collidepoint(event.pos):
-                    building.upgrade(hero, econ_building)
+                    player = economy.PlayerEconomy()
+                    player.resources.update(hero.resources)
+                    player.resources["gold"] = hero.gold
+                    building.upgrade(hero, player, econ_building)
         screen.blit(background, (0, 0))
         dim = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
         dim.fill((*theme.PALETTE["background"], 200))

--- a/ui/town_screen.py
+++ b/ui/town_screen.py
@@ -508,8 +508,11 @@ class TownScreen:
                         return
                     cost = self.town.structure_cost(sid)
                     if self._can_afford(self.hero, cost):
-                        self.town.build_structure(sid, self.hero)
-                        self._publish_resources()
+                        player = economy.PlayerEconomy()
+                        player.resources.update(self.hero.resources)
+                        player.resources["gold"] = self.hero.gold
+                        if self.town.build_structure(sid, self.hero, player):
+                            self._publish_resources()
                 else:
                     if sid == "market":
                         market_screen.open(self.screen, self.game, self.town, self.hero, self.clock)


### PR DESCRIPTION
## Summary
- Use `economy.can_afford` and `economy.pay` in town structure building and building upgrades
- Accept `PlayerEconomy` in these methods and propagate payments to heroes
- Add unit tests covering payment failures

## Testing
- `pre-commit run --files core/buildings.py ui/building_info.py ui/town_screen.py tests/test_ai_recruitment.py tests/test_building_upgrade.py tests/test_dwelling_growth.py tests/test_game_state_weekly_town_growth.py tests/test_town_build_limit.py tests/test_town_recruitment.py tests/test_payment_failures.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af872024288321bcc8313cf5b7095f