### PR TITLE
Refactor market rate constant

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -16,6 +16,8 @@ import json
 import os
 from typing import Dict, List
 
+from core.economy import DEFAULT_MARKET_RATES
+
 import settings
 from loaders.i18n import load_locale
 
@@ -152,10 +154,7 @@ UNIT_RECRUIT_COSTS = {
     "Archer": {"gold": 75},
 }
 # for futur market rates and buildings
-MARKET_RATES = {
-    ("gold","wood"): 100, ("gold","stone"): 100, ("gold","crystal"): 250,
-    ("wood","gold"): 8, ("stone","gold"): 8, ("crystal","gold"): 25,
-}
+MARKET_RATES = DEFAULT_MARKET_RATES
 
 # Combat settings
 # Battlefield dimensions for tactical combat

--- a/core/buildings.py
+++ b/core/buildings.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Optional, Set, List, Tuple
 
 import constants
+from core.economy import DEFAULT_MARKET_RATES
 from loaders import building_loader
 from loaders.building_loader import BuildingAsset
 from loaders.core import Context
@@ -240,14 +241,6 @@ class Town(Building):
         # File d'ordres pour les caravanes en transit
         self.caravan_orders: List[Caravan] = []
 
-        DEFAULT_MARKET_RATES = {
-            ("gold", "wood"): 100,
-            ("gold", "stone"): 100,
-            ("gold", "crystal"): 250,
-            ("wood", "gold"): 8,
-            ("stone", "gold"): 8,
-            ("crystal", "gold"): 25,
-        }
         self.market_rates = getattr(constants, "MARKET_RATES", DEFAULT_MARKET_RATES)
         self.built_today = False
 

--- a/tests/test_town_market_rates.py
+++ b/tests/test_town_market_rates.py
@@ -1,0 +1,10 @@
+import os
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+from core.buildings import Town
+from core.economy import DEFAULT_MARKET_RATES
+
+def test_town_uses_shared_market_rates():
+    town = Town()
+    assert town.market_rates is DEFAULT_MARKET_RATES
+


### PR DESCRIPTION
## Summary
- centralise `DEFAULT_MARKET_RATES` in the economy module and expose through constants
- use shared market rates in `Town` instead of local copy
- add test ensuring towns reference the shared rates table

## Testing
- `pytest tests/test_town_market_rates.py`
- `pytest tests/test_building_economy.py::test_building_income_added_each_turn`


------
https://chatgpt.com/codex/tasks/task_e_68af89b080b48321b74f55c4047c7554