### PR TITLE
Load AI difficulty presets from asset file

### DIFF
--- a/assets/ai_difficulty.json
+++ b/assets/ai_difficulty.json
@@ -1,0 +1,5 @@
+{
+  "Novice": {"hero_weight": 4, "resource_weight": 3, "building_weight": 3, "avoid_enemies": true},
+  "Intermédiaire": {"hero_weight": 8, "resource_weight": 4, "building_weight": 5, "avoid_enemies": true},
+  "Avancé": {"hero_weight": 12, "resource_weight": 4, "building_weight": 6, "avoid_enemies": false}
+}

--- a/tests/test_difficulty_config.py
+++ b/tests/test_difficulty_config.py
@@ -1,0 +1,19 @@
+import json
+
+import pytest
+
+from core import exploration_ai
+
+
+def test_difficulty_config_levels():
+    params = exploration_ai.DIFFICULTY_PARAMS
+    assert {"Novice", "Intermédiaire", "Avancé"} <= params.keys()
+    for p in params.values():
+        assert set(p.keys()) == {"hero_weight", "resource_weight", "building_weight", "avoid_enemies"}
+
+
+def test_invalid_difficulty_config(tmp_path):
+    bad_cfg = tmp_path / "bad.json"
+    bad_cfg.write_text(json.dumps({"Novice": {"hero_weight": 1}}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        exploration_ai._load_difficulty_params(bad_cfg)


### PR DESCRIPTION
## Summary
- move AI difficulty parameters into a JSON asset
- load and validate difficulty parameters at module import
- test configuration validity and coverage across difficulty levels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af89d5bbb08321a54f4af9855ebaef