### PR TITLE
Display spell icons in spellbook overlay

### DIFF
--- a/assets/icons/icons.json
+++ b/assets/icons/icons.json
@@ -15,6 +15,7 @@
   "action_swap": "assets/icons/action_swap.png",
   "action_use_ability": "assets/icons/action_use_ability.png",
   "action_wait": "assets/icons/action_wait.png",
+  "spell_default": "assets/icons/spell_default.png",
   "end_turn": "assets/icons/end_turn.png",
 
   "poi_artifact": "assets/icons/artifact.png",

--- a/assets/spells/spells.json
+++ b/assets/spells/spells.json
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "default_icon": "spell_default",
   "schema": {
     "entry": {
       "id": "string",
@@ -19,7 +20,8 @@
       "tags": [
         "keywords"
       ],
-      "fx_asset": "string or null"
+      "fx_asset": "string or null",
+      "icon": "string or null"
     }
   },
   "aliases": {


### PR DESCRIPTION
## Summary
- allow spells to declare an icon and provide a default spell icon
- render spell icons in the spellbook overlay using IconLoader

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b00f9efc3c8321a49eeeb4f0bbff30