### PR TITLE
Stabilize combat HUD actions and hover tooltips

### DIFF
--- a/ui/widgets/icon_button.py
+++ b/ui/widgets/icon_button.py
@@ -111,4 +111,7 @@ class IconButton:
     def get_tooltip(self) -> str:
         """Return the tooltip string for the button."""
 
-        return self.tooltip
+        if self.hovered:
+            return self.tooltip
+        mouse_get_pos = getattr(getattr(pygame, "mouse", None), "get_pos", lambda: (0, 0))
+        return self.tooltip if self.collidepoint(mouse_get_pos()) else ""


### PR DESCRIPTION
## Summary
- Fix combat HUD action bar layout with fixed slots and disabled placeholders
- Enlarge action buttons and show tooltips near cursor for hovered buttons
- Ensure IconButton tooltips appear only when hovered

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b01353cae48321b7dab7eb436f6509