### PR TITLE
Add SUPER_USER_MODE for debugging cheats and map reveal

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -22,6 +22,7 @@ import pygame
 import audio
 import constants
 import theme
+import settings
 from graphics.scale import scale_surface, scale_with_anchor
 from ui.inventory_screen import InventoryScreen
 from loaders.asset_manager import AssetManager
@@ -468,6 +469,17 @@ class Game:
             self._load_sea_chain()
         # Initialise vision for the starting player
         self._update_player_visibility()
+        if settings.SUPER_USER_MODE:
+            self.hero.gold = 1000
+            for name in constants.RESOURCES:
+                self.hero.resources[name] = 1000
+            self.hero.max_ap = self.hero.ap = 9999
+            self.world.reveal(
+                0,
+                self.hero.x,
+                self.hero.y,
+                radius=max(self.world.width, self.world.height),
+            )
         # Remember the player's starting town to detect loss later
         self.starting_town: Optional[Tuple[int, int]] = self.world.hero_town
         # Flag to avoid showing the game over screen multiple times
@@ -1449,6 +1461,24 @@ class Game:
                         self.hero.choose_skill('tactics')
                     elif event.key == pygame.K_4:
                         self.hero.choose_skill('logistics')
+                    elif (
+                        event.key == pygame.K_F12
+                        and event.mod & pygame.KMOD_CTRL
+                        and event.mod & pygame.KMOD_SHIFT
+                    ):
+                        settings.SUPER_USER_MODE = not settings.SUPER_USER_MODE
+                        if settings.SUPER_USER_MODE:
+                            self.hero.gold = 1000
+                            for name in constants.RESOURCES:
+                                self.hero.resources[name] = 1000
+                            self.hero.max_ap = self.hero.ap = 9999
+                            self.world.reveal(
+                                0,
+                                self.hero.x,
+                                self.hero.y,
+                                radius=max(self.world.width, self.world.height),
+                            )
+                        continue
                     elif event.key == pygame.K_F11:
                         pygame.display.toggle_fullscreen()
                         self.screen = pygame.display.get_surface()

--- a/render/world_renderer.py
+++ b/render/world_renderer.py
@@ -309,8 +309,10 @@ class WorldRenderer:
         }
         vis_grid = world.visible.get(0)
         exp_grid = world.explored.get(0)
-        use_fog = bool(vis_grid and exp_grid)
-        fog_surface = pygame.Surface((dest_w, dest_h), pygame.SRCALPHA) if use_fog else None
+        use_fog = bool(vis_grid and exp_grid) and not settings.SUPER_USER_MODE
+        fog_surface = (
+            pygame.Surface((dest_w, dest_h), pygame.SRCALPHA) if use_fog else None
+        )
         tall_draw: List[Tuple[int, ...]] = []
 
         def grid_to_screen(x: int, y: int) -> Tuple[int, int]:

--- a/settings.json
+++ b/settings.json
@@ -9,6 +9,7 @@
   "scroll_speed": 20,
   "animation_speed": 1.0,
   "tooltip_read_mode": false,
+  "super_user_mode": false,
   "keymap": {
     "pan_left": ["K_LEFT", "K_a"],
     "pan_right": ["K_RIGHT", "K_d"],

--- a/settings.py
+++ b/settings.py
@@ -92,6 +92,9 @@ TOOLTIP_READ_MODE: bool = _get_bool(
     "FG_TOOLTIP_READ_MODE", "tooltip_read_mode", False
 )
 
+# Enable super user mode for debugging and cheats
+SUPER_USER_MODE: bool = _get_bool("FG_SUPER_USER", "super_user_mode", False)
+
 _DEFAULT_KEYMAP: Dict[str, List[str]] = {
     "pan_left": ["K_LEFT", "K_a"],
     "pan_right": ["K_RIGHT", "K_d"],
@@ -132,6 +135,7 @@ __all__ = [
     "SCROLL_SPEED",
     "ANIMATION_SPEED",
     "TOOLTIP_READ_MODE",
+    "SUPER_USER_MODE",
     "KEYMAP",
     "save_settings",
     "remap_key",


### PR DESCRIPTION
## Summary
- add SUPER_USER_MODE setting and default config
- grant abundant resources and reveal map when super user mode is active
- ignore fog and toggle super user mode with secret shortcut

## Testing
- `pre-commit run --files settings.py settings.json core/game.py render/world_renderer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b01c20f2408321ac04240cc0bfc836