### PR TITLE
Add explicit skill icons

### DIFF
--- a/assets/skills/skills_red_knights.json
+++ b/assets/skills/skills_red_knights.json
@@ -1,28 +1,138 @@
 {
-  "sheet": "red_knights_skills.png",
   "logistics": {
-    "N": {"id": "logistics_N", "name": "Crimson Surge", "desc": "", "cost": 1, "effects": [], "coords": [2, 2]},
-    "A": {"id": "logistics_A", "name": "Valiant Charge", "desc": "", "cost": 1, "effects": [], "coords": [3, 0]},
-    "E": {"id": "logistics_E", "name": "Rally on the Road", "desc": "", "cost": 1, "effects": [], "coords": [0, 0]},
-    "M": {"id": "logistics_M", "name": "Sapper’s Path", "desc": "", "cost": 1, "effects": [], "coords": [0, 3]}
+    "N": {
+      "id": "logistics_N",
+      "name": "Crimson Surge",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/logistics_N.png"
+    },
+    "A": {
+      "id": "logistics_A",
+      "name": "Valiant Charge",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/logistics_A.png"
+    },
+    "E": {
+      "id": "logistics_E",
+      "name": "Rally on the Road",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/logistics_E.png"
+    },
+    "M": {
+      "id": "logistics_M",
+      "name": "Sapper’s Path",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/logistics_M.png"
+    }
   },
   "tactics": {
-    "N": {"id": "tactics_N", "name": "Guard Order", "desc": "", "cost": 1, "effects": [], "coords": [1, 0]},
-    "A": {"id": "tactics_A", "name": "Deploy Stakes", "desc": "", "cost": 1, "effects": [], "coords": [3, 2]},
-    "E": {"id": "tactics_E", "name": "Aegis Wedge", "desc": "", "cost": 1, "effects": [], "coords": [1, 1]},
-    "M": {"id": "tactics_M", "name": "Mass Bless", "desc": "", "cost": 1, "effects": [], "coords": [0, 1]}
+    "N": {
+      "id": "tactics_N",
+      "name": "Guard Order",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/tactics_N.png"
+    },
+    "A": {
+      "id": "tactics_A",
+      "name": "Deploy Stakes",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/tactics_A.png"
+    },
+    "E": {
+      "id": "tactics_E",
+      "name": "Aegis Wedge",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/tactics_E.png"
+    },
+    "M": {
+      "id": "tactics_M",
+      "name": "Mass Bless",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/tactics_M.png"
+    }
   },
   "marksmanship": {
-    "N": {"id": "marksmanship_N", "name": "Firebolt Drills", "desc": "", "cost": 1, "effects": [], "coords": [1, 3]},
-    "A": {"id": "marksmanship_A", "name": "Volley", "desc": "", "cost": 1, "effects": [], "coords": [2, 0]},
-    "E": {"id": "marksmanship_E", "name": "Armor Traverse", "desc": "", "cost": 1, "effects": [], "coords": [2, 3]},
-    "M": {"id": "marksmanship_M", "name": "Deadeye", "desc": "", "cost": 1, "effects": [], "coords": [2, 1]}
+    "N": {
+      "id": "marksmanship_N",
+      "name": "Firebolt Drills",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/marksmanship_N.png"
+    },
+    "A": {
+      "id": "marksmanship_A",
+      "name": "Volley",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/marksmanship_A.png"
+    },
+    "E": {
+      "id": "marksmanship_E",
+      "name": "Armor Traverse",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/marksmanship_E.png"
+    },
+    "M": {
+      "id": "marksmanship_M",
+      "name": "Deadeye",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/marksmanship_M.png"
+    }
   },
   "weaponsmithing": {
-    "N": {"id": "weaponsmithing_N", "name": "Intimidate", "desc": "", "cost": 1, "effects": [], "coords": [1, 2]},
-    "A": {"id": "weaponsmithing_A", "name": "Sharpen", "desc": "", "cost": 1, "effects": [], "coords": [3, 1]},
-    "E": {"id": "weaponsmithing_E", "name": "Steel Discipline", "desc": "", "cost": 1, "effects": [], "coords": [3, 3]},
-    "M": {"id": "weaponsmithing_M", "name": "Overrun", "desc": "", "cost": 1, "effects": [], "coords": [0, 2]}
+    "N": {
+      "id": "weaponsmithing_N",
+      "name": "Intimidate",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/weaponsmithing_N.png"
+    },
+    "A": {
+      "id": "weaponsmithing_A",
+      "name": "Sharpen",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/weaponsmithing_A.png"
+    },
+    "E": {
+      "id": "weaponsmithing_E",
+      "name": "Steel Discipline",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/weaponsmithing_E.png"
+    },
+    "M": {
+      "id": "weaponsmithing_M",
+      "name": "Overrun",
+      "desc": "",
+      "cost": 1,
+      "effects": [],
+      "icon": "icons/weaponsmithing_M.png"
+    }
   }
 }
-

--- a/assets/skills/skills_solaceheim.json
+++ b/assets/skills/skills_solaceheim.json
@@ -1,28 +1,114 @@
 {
-  "sheet": "solaceheim_skills.png",
   "solar_doctrine": {
-    "N": {"id": "sun_blessing_n", "name": "Aurore Bienveillante", "desc": "Bless 1 stack (1t) au début du combat."},
-    "A": {"id": "hymn_of_light_a", "name": "Hymne Lumineux", "type": "order", "cd": 3, "desc": "Cône court: alliés ATK +1~+1 (1t), ennemis defence_magic -1 (1t)."},
-    "E": {"id": "lumen_matrix_e", "name": "Lumen Matrix", "desc": "Lumière/Ordre +15% puissance; coût -1 mana (min 1)."},
-    "M": {"id": "solar_zenith_m", "name": "Zénith du Soleil", "desc": "Aura 2 hex: initiative +1, morale +1; 1x/comb. Sunburst gratuit."}
+    "N": {
+      "id": "sun_blessing_n",
+      "name": "Aurore Bienveillante",
+      "desc": "Bless 1 stack (1t) au début du combat.",
+      "icon": "icons/sun_blessing_n.png"
+    },
+    "A": {
+      "id": "hymn_of_light_a",
+      "name": "Hymne Lumineux",
+      "type": "order",
+      "cd": 3,
+      "desc": "Cône court: alliés ATK +1~+1 (1t), ennemis defence_magic -1 (1t).",
+      "icon": "icons/hymn_of_light_a.png"
+    },
+    "E": {
+      "id": "lumen_matrix_e",
+      "name": "Lumen Matrix",
+      "desc": "Lumière/Ordre +15% puissance; coût -1 mana (min 1).",
+      "icon": "icons/lumen_matrix_e.png"
+    },
+    "M": {
+      "id": "solar_zenith_m",
+      "name": "Zénith du Soleil",
+      "desc": "Aura 2 hex: initiative +1, morale +1; 1x/comb. Sunburst gratuit.",
+      "icon": "icons/solar_zenith_m.png"
+    }
   },
   "desert_way": {
-    "N": {"id": "dune_march_n", "name": "Marche des Dunes", "desc": "PM +5% sur carte."},
-    "A": {"id": "sand_step_a", "name": "Pas de Sable", "desc": "PM +10%; ignore malus de sable/dunes."},
-    "E": {"id": "sirocco_e", "name": "Brise du Sirocco", "desc": "En désert: alliés +1 initiative au 1er round."},
-    "M": {"id": "sun_paths_m", "name": "Chemins Solaires", "desc": "PM +15%; vision +1 désert; immunité sandstorm."}
+    "N": {
+      "id": "dune_march_n",
+      "name": "Marche des Dunes",
+      "desc": "PM +5% sur carte.",
+      "icon": "icons/dune_march_n.png"
+    },
+    "A": {
+      "id": "sand_step_a",
+      "name": "Pas de Sable",
+      "desc": "PM +10%; ignore malus de sable/dunes.",
+      "icon": "icons/sand_step_a.png"
+    },
+    "E": {
+      "id": "sirocco_e",
+      "name": "Brise du Sirocco",
+      "desc": "En désert: alliés +1 initiative au 1er round.",
+      "icon": "icons/sirocco_e.png"
+    },
+    "M": {
+      "id": "sun_paths_m",
+      "name": "Chemins Solaires",
+      "desc": "PM +15%; vision +1 désert; immunité sandstorm.",
+      "icon": "icons/sun_paths_m.png"
+    }
   },
   "resonant_tactics": {
-    "N": {"id": "ritual_beats_n", "name": "Battements Rituels", "desc": "+1 initiative aux T1–T3."},
-    "A": {"id": "maneuver_chorale_a", "name": "Chorale de Manœuvre", "type": "order", "cd": 3, "desc": "Repositionne 1 stack de 1 hex et lui donne morale +1 (1t)."},
-    "E": {"id": "harmony_formation_e", "name": "Formation Harmonie", "desc": "1er round: projectiles reçus -1 pour lignes adjacentes."},
-    "M": {"id": "ascetic_cadence_m", "name": "Cadence Ascétique", "desc": "Repositionne 2 stacks; flanking allié +10% dégâts ce round."}
+    "N": {
+      "id": "ritual_beats_n",
+      "name": "Battements Rituels",
+      "desc": "+1 initiative aux T1–T3.",
+      "icon": "icons/ritual_beats_n.png"
+    },
+    "A": {
+      "id": "maneuver_chorale_a",
+      "name": "Chorale de Manœuvre",
+      "type": "order",
+      "cd": 3,
+      "desc": "Repositionne 1 stack de 1 hex et lui donne morale +1 (1t).",
+      "icon": "icons/maneuver_chorale_a.png"
+    },
+    "E": {
+      "id": "harmony_formation_e",
+      "name": "Formation Harmonie",
+      "desc": "1er round: projectiles reçus -1 pour lignes adjacentes.",
+      "icon": "icons/harmony_formation_e.png"
+    },
+    "M": {
+      "id": "ascetic_cadence_m",
+      "name": "Cadence Ascétique",
+      "desc": "Repositionne 2 stacks; flanking allié +10% dégâts ce round.",
+      "icon": "icons/ascetic_cadence_m.png"
+    }
   },
   "sutra_guard": {
-    "N": {"id": "mantra_ward_n", "name": "Mantra de Protection", "desc": "Alliés defence_magic +1."},
-    "A": {"id": "sutra_aegis_a", "name": "Aegis des Sutras", "type": "order", "cd": 2, "desc": "Cible: defence_melee +2, defence_magic +2, dissipe 1 malus (1t)."},
-    "E": {"id": "guardian_intercession_e", "name": "Intercession du Gardien", "desc": "1x/tour: si allié ≤30% HP dans 2 hex est frappé, -20% dégâts."},
-    "M": {"id": "solar_bulwark_m", "name": "Rempart Solaire", "type": "order", "cd": 3, "desc": "Cible: insensible aux sorts et -30% AoE (1t)."}
+    "N": {
+      "id": "mantra_ward_n",
+      "name": "Mantra de Protection",
+      "desc": "Alliés defence_magic +1.",
+      "icon": "icons/mantra_ward_n.png"
+    },
+    "A": {
+      "id": "sutra_aegis_a",
+      "name": "Aegis des Sutras",
+      "type": "order",
+      "cd": 2,
+      "desc": "Cible: defence_melee +2, defence_magic +2, dissipe 1 malus (1t).",
+      "icon": "icons/sutra_aegis_a.png"
+    },
+    "E": {
+      "id": "guardian_intercession_e",
+      "name": "Intercession du Gardien",
+      "desc": "1x/tour: si allié ≤30% HP dans 2 hex est frappé, -20% dégâts.",
+      "icon": "icons/guardian_intercession_e.png"
+    },
+    "M": {
+      "id": "solar_bulwark_m",
+      "name": "Rempart Solaire",
+      "type": "order",
+      "cd": 3,
+      "desc": "Cible: insensible aux sorts et -30% AoE (1t).",
+      "icon": "icons/solar_bulwark_m.png"
+    }
   }
 }
-

--- a/assets/skills/skills_sylvan.json
+++ b/assets/skills/skills_sylvan.json
@@ -1,28 +1,114 @@
 {
-  "sheet": "sylvan_skills.png",
   "Verdant_Grace": {
-    "N": {"id": "dew_mend_n", "name": "Dew Mend", "desc": "Cleanse (retire Poison/Brûlure/Lenteur)"},
-    "A": {"id": "ripple_shield_a", "name": "Ripple Shield", "type": "order", "cd": 3, "desc": "(+armure magique mono, courte durée)."},
-    "E": {"id": "rebirth_chance_e", "name": "Rebirth Chance", "desc": "+10 % chance de relever 1 unité T1–T3 à la fin du combat"},
-    "M": {"id": "sanctuary_m", "name": "Sanctuary", "desc": "zone sacrée : alliés reçoivent +defense & regen légère dans l’aire"}
+    "N": {
+      "id": "dew_mend_n",
+      "name": "Dew Mend",
+      "desc": "Cleanse (retire Poison/Brûlure/Lenteur)",
+      "icon": "icons/dew_mend_n.png"
+    },
+    "A": {
+      "id": "ripple_shield_a",
+      "name": "Ripple Shield",
+      "type": "order",
+      "cd": 3,
+      "desc": "(+armure magique mono, courte durée).",
+      "icon": "icons/ripple_shield_a.png"
+    },
+    "E": {
+      "id": "rebirth_chance_e",
+      "name": "Rebirth Chance",
+      "desc": "+10 % chance de relever 1 unité T1–T3 à la fin du combat",
+      "icon": "icons/rebirth_chance_e.png"
+    },
+    "M": {
+      "id": "sanctuary_m",
+      "name": "Sanctuary",
+      "desc": "zone sacrée : alliés reçoivent +defense & regen légère dans l’aire",
+      "icon": "icons/sanctuary_m.png"
+    }
   },
   "Mists_Streams": {
-    "N": {"id": "mist_veil_n", "name": "Mist Veil", "desc": "nuage de brume, −LoS & −def_ranged ennemie dans l’aire"},
-    "A": {"id": "Slick_Ground_a", "name": "Slick Ground", "desc": "terrain glissant, −init & malus de déplacement sur quelques cases"},
-    "E": {"id": "Whirlpool_Pull_e", "name": "Whirlpool Pull", "desc": "attire légèrement les cibles au centre, petite zone"},
-    "M": {"id": "Mist_Portal_m", "name": "Mist Portal", "desc": "téléport court mono-cible alliée, ligne de vue non requise mais portée limitée"}
+    "N": {
+      "id": "mist_veil_n",
+      "name": "Mist Veil",
+      "desc": "nuage de brume, −LoS & −def_ranged ennemie dans l’aire",
+      "icon": "icons/mist_veil_n.png"
+    },
+    "A": {
+      "id": "Slick_Ground_a",
+      "name": "Slick Ground",
+      "desc": "terrain glissant, −init & malus de déplacement sur quelques cases",
+      "icon": "icons/Slick_Ground_a.png"
+    },
+    "E": {
+      "id": "Whirlpool_Pull_e",
+      "name": "Whirlpool Pull",
+      "desc": "attire légèrement les cibles au centre, petite zone",
+      "icon": "icons/Whirlpool_Pull_e.png"
+    },
+    "M": {
+      "id": "Mist_Portal_m",
+      "name": "Mist Portal",
+      "desc": "téléport court mono-cible alliée, ligne de vue non requise mais portée limitée",
+      "icon": "icons/Mist_Portal_m.png"
+    }
   },
   "Song_Wind": {
-    "N": {"id": "Zephyr_Step_n", "name": "Zephyr Step", "desc": "+AP ou +1 case de déplacement au tour en cours"},
-    "A": {"id": "Gust_a", "name": "Gust", "type": "order", "cd": 3, "desc": "cône, repousse de 1 case, −1 initiative"},
-    "E": {"id": "Lullaby_e", "name": "Lullaby", "desc": "sommeil 1 tour sur cible unique, test de résistance"},
-    "M": {"id": "Wind_Chorus_m", "name": "Wind Chorus", "desc": "Mass Haste : +init/+speed de l’armée 1 tour"}
+    "N": {
+      "id": "Zephyr_Step_n",
+      "name": "Zephyr Step",
+      "desc": "+AP ou +1 case de déplacement au tour en cours",
+      "icon": "icons/Zephyr_Step_n.png"
+    },
+    "A": {
+      "id": "Gust_a",
+      "name": "Gust",
+      "type": "order",
+      "cd": 3,
+      "desc": "cône, repousse de 1 case, −1 initiative",
+      "icon": "icons/Gust_a.png"
+    },
+    "E": {
+      "id": "Lullaby_e",
+      "name": "Lullaby",
+      "desc": "sommeil 1 tour sur cible unique, test de résistance",
+      "icon": "icons/Lullaby_e.png"
+    },
+    "M": {
+      "id": "Wind_Chorus_m",
+      "name": "Wind Chorus",
+      "desc": "Mass Haste : +init/+speed de l’armée 1 tour",
+      "icon": "icons/Wind_Chorus_m.png"
+    }
   },
   "Sylvan_Heart": {
-    "N": {"id": "Entangling_Vines_n", "name": "Entangling Vines", "desc": "Entravé 1 tour, −init"},
-    "A": {"id": "Bramble_Field_a", "name": "Bramble Field", "type": "order", "cd": 2, "desc": "pièges d’épines, dégâts & lenteur à l’entrée"},
-    "E": {"id": "Summon_Sprite_e", "name": "Summon Sprite", "desc": "petite unité faë éphémère T1"},
-    "M": {"id": "Forest_Heart_m", "name": "Forest Heart", "type": "order", "cd": 3, "desc": "totem/semis : petite zone qui soigne alliés et inflige épines aux ennemis"}
+    "N": {
+      "id": "Entangling_Vines_n",
+      "name": "Entangling Vines",
+      "desc": "Entravé 1 tour, −init",
+      "icon": "icons/Entangling_Vines_n.png"
+    },
+    "A": {
+      "id": "Bramble_Field_a",
+      "name": "Bramble Field",
+      "type": "order",
+      "cd": 2,
+      "desc": "pièges d’épines, dégâts & lenteur à l’entrée",
+      "icon": "icons/Bramble_Field_a.png"
+    },
+    "E": {
+      "id": "Summon_Sprite_e",
+      "name": "Summon Sprite",
+      "desc": "petite unité faë éphémère T1",
+      "icon": "icons/Summon_Sprite_e.png"
+    },
+    "M": {
+      "id": "Forest_Heart_m",
+      "name": "Forest Heart",
+      "type": "order",
+      "cd": 3,
+      "desc": "totem/semis : petite zone qui soigne alliés et inflige épines aux ennemis",
+      "icon": "icons/Forest_Heart_m.png"
+    }
   }
 }
-

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -52,7 +52,7 @@ def test_red_knights_manifest_and_icons():
             entry = next(e for e in entries if e["rank"] == rank)
             if prev_id:
                 assert prev_id in entry["requires"]
-            icon = assets.get(entry["id"])
+            icon = assets.get(entry["icon"])
             assert hasattr(icon, "get_width") and icon.get_width() > 0
             prev_id = entry["id"]
 

--- a/tools/skill_manifest.py
+++ b/tools/skill_manifest.py
@@ -35,8 +35,9 @@ def load_skill_manifest(
         directory.
     assets:
         Optional mapping where extracted icons will be stored.  When provided
-        the loader expects each manifest to specify a ``sheet`` key pointing to
-        a spritesheet containing the skill icons.
+        the loader expects each skill entry to either specify an ``icon``
+        pointing to an image file or to provide ``coords`` alongside a
+        manifest level ``sheet`` defining a spritesheet containing the icons.
     faction_id:
         Optional faction identifier limiting which modern manifest is loaded.
     """
@@ -97,9 +98,16 @@ def load_skill_manifest(
                         reqs.append(prev_id)
                     entry["requires"] = reqs
 
-                    if assets is not None and sheet_path and entry.get("coords") is not None:
-                        assets[entry["id"]] = get_icon(sheet_path, tuple(entry["coords"]))
-                        entry["icon"] = entry["id"]
+                    if assets is not None:
+                        key = f"skill_{entry['id']}"
+                        icon_path = entry.get('icon')
+                        if icon_path:
+                            img_path = os.path.join(repo_root, 'assets', icon_path)
+                            assets[key] = get_icon(img_path, (0, 0), grid=1)
+                            entry['icon'] = key
+                        elif sheet_path and entry.get('coords') is not None:
+                            assets[key] = get_icon(sheet_path, tuple(entry['coords']))
+                            entry['icon'] = key
 
                     entries.append(entry)
                     prev_id = entry["id"]

--- a/ui/inventory_tabs/skills.py
+++ b/ui/inventory_tabs/skills.py
@@ -76,7 +76,7 @@ def draw(screen: "InventoryScreen") -> None:
             pygame.draw.rect(screen.screen, COLOR_SLOT_BG, rect, border_radius=8)
             pygame.draw.rect(screen.screen, state_col, rect, 3, border_radius=8)
 
-            icon = screen.assets.get(f"skill_{node.id}.png")
+            icon = screen.assets.get(node.icon) if node.icon else None
             if icon:
                 icon = pygame.transform.smoothscale(
                     icon, (rect.width - 12, rect.height - 46)


### PR DESCRIPTION
## Summary
- Support per-skill icon paths in `load_skill_manifest`, caching them under unique keys
- Populate faction skill manifests with icon fields
- Display skill icons using `node.icon` reference in skill tab

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b022d6139c832181408043096053ee