### PR TITLE
Add battlefields for each biome and verify loading

### DIFF
--- a/assets/battlefields/battlefields.json
+++ b/assets/battlefields/battlefields.json
@@ -13,5 +13,45 @@
     "id": "scarletia_echo_plain",
     "image": "battlefields/scarletia_echo_plain.png",
     "hero_pos": [120, 0]
+  },
+  {
+    "id": "scarletia_crimson_forest",
+    "image": "battlefields/scarletia_crimson_forest.png",
+    "hero_pos": [160, 0]
+  },
+  {
+    "id": "scarletia_volcanic",
+    "image": "battlefields/scarletia_volcanic.png",
+    "hero_pos": [200, 0]
+  },
+  {
+    "id": "mountain",
+    "image": "battlefields/mountain.png",
+    "hero_pos": [240, 0]
+  },
+  {
+    "id": "hills",
+    "image": "battlefields/hills.png",
+    "hero_pos": [280, 0]
+  },
+  {
+    "id": "swamp",
+    "image": "battlefields/swamp.png",
+    "hero_pos": [320, 0]
+  },
+  {
+    "id": "jungle",
+    "image": "battlefields/jungle.png",
+    "hero_pos": [360, 0]
+  },
+  {
+    "id": "ice",
+    "image": "battlefields/ice.png",
+    "hero_pos": [400, 0]
+  },
+  {
+    "id": "river",
+    "image": "battlefields/river.png",
+    "hero_pos": [440, 0]
   }
 ]

--- a/tests/test_battlefield_selection.py
+++ b/tests/test_battlefield_selection.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+import os
+
+from core.game import Game
+from loaders.battlefield_loader import load_battlefields
+import pytest
+
+
+def test_battlefield_matches_tile_biome(monkeypatch):
+    monkeypatch.setattr("core.game.audio.play_sound", lambda *args, **kwargs: None)
+
+    class DummyUnit:
+        def __init__(self):
+            self.count = 1
+            self.current_hp = 1
+
+    class DummyHero:
+        def __init__(self):
+            self.x = 0
+            self.y = 0
+            self.army = [DummyUnit()]
+            self.mana = 0
+            self.max_mana = 0
+            self.spells = {}
+            self.faction = None
+            self.naval_unit = None
+
+        def gain_exp(self, amount: int) -> None:
+            pass
+
+    class DummyEnemy:
+        def __init__(self):
+            self.x = 0
+            self.y = 0
+            self.army = [DummyUnit()]
+
+    class DummyTile:
+        def __init__(self, biome):
+            self.biome = biome
+            self.enemy_units = [DummyUnit()]
+
+    class DummyWorld:
+        flora_loader = None
+
+        def __init__(self, biome):
+            self.grid = [[DummyTile(biome)]]
+            self.width = 1
+            self.height = 1
+
+    hero = DummyHero()
+    enemy = DummyEnemy()
+    world = DummyWorld("mountain")
+
+    game = Game.__new__(Game)
+    game.screen = SimpleNamespace()
+    game.assets = {}
+    game.hero = hero
+    game.enemy_heroes = [enemy]
+    game.world = world
+    game.biome_tilesets = {}
+    game.unit_shadow_baked = {}
+    game._update_caches_for_tile = lambda x, y: None
+    game._notify = lambda msg: None
+    game.quit_to_menu = False
+
+    bf_path = os.path.join("assets", "battlefields", "battlefields.json")
+    game.battlefields = load_battlefields(bf_path)
+
+    captured = {}
+
+    class DummyCombat:
+        def __init__(self, *args, **kwargs):
+            captured["battlefield_id"] = kwargs["battlefield"].id
+            self.hero_units = args[2]
+            self.enemy_units = args[3]
+            self.exit_to_menu = False
+
+        def run(self):
+            return True, 0
+
+    monkeypatch.setattr("core.combat.Combat", DummyCombat)
+
+    game.combat_with_enemy_hero(enemy, initiated_by="enemy")
+
+    assert captured["battlefield_id"] == "mountain"

--- a/tests/test_battlefields_manifest.py
+++ b/tests/test_battlefields_manifest.py
@@ -1,0 +1,11 @@
+import os
+
+from loaders.battlefield_loader import load_battlefields
+from core.world import BIOME_CHAR_MAP
+
+
+def test_battlefields_manifest_contains_all_biomes():
+    path = os.path.join(os.path.dirname(__file__), "..", "assets", "battlefields", "battlefields.json")
+    defs = load_battlefields(path)
+    expected = set(BIOME_CHAR_MAP.values()) | {"default"}
+    assert expected.issubset(defs.keys())


### PR DESCRIPTION
## Summary
- add battlefield entries for forest, desert, mountains and other biomes
- ensure loader exposes all battlefields
- test that combat selects battlefield based on tile biome

## Testing
- `pytest tests/test_battlefields_manifest.py tests/test_battlefield_selection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0230483d8832194148affbbe3f443