### PR TITLE
Refactor combat unit info overlay into drawable stack

### DIFF
--- a/ui/unit_info_overlay.py
+++ b/ui/unit_info_overlay.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pygame
@@ -180,18 +179,3 @@ class UnitInfoOverlay:
 
         self.screen.set_clip(prev_clip)
 
-    # ------------------------------------------------------------------ public API
-    def run(self) -> None:
-        clock = pygame.time.Clock()
-        running = True
-        while running:
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
-                if self.handle_event(event):
-                    running = False
-                    break
-            self.draw()
-            pygame.display.flip()
-            clock.tick(constants.FPS)


### PR DESCRIPTION
## Summary
- refactor unit info overlay to expose draw and handle_event without an internal loop
- manage overlays from combat loop and open unit info on right-click
- show spellbook overlay through same overlay stack

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0246f213c832186dd69e75472026d