### PR TITLE
Ensure HP bar draws above stack in combat view

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -323,20 +323,26 @@ def draw(combat, frame: int = 0) -> None:
         bar_h = max(2, round(1.5 * combat.zoom))
         hp_rect = pygame.Rect(0, 0, stack_rect.width, bar_h)
         hp_rect.midbottom = stack_rect.midtop
-        pygame.draw.rect(combat.screen, constants.BLACK, hp_rect)
+        colour = constants.BLUE if unit.side == "hero" else constants.RED
+        pygame.draw.rect(combat.screen, colour, stack_rect)
+        hp_surface = pygame.Surface(hp_rect.size, pygame.SRCALPHA)
+        pygame.draw.rect(
+            hp_surface, (*constants.BLACK, 255), hp_surface.get_rect()
+        )
         max_hp = getattr(unit.stats, "max_hp", 0) or 0
         if max_hp > 0:
             ratio = unit.current_hp / max_hp
             ratio = max(0.0, min(1.0, ratio))
             green_w = int(hp_rect.width * ratio)
             if green_w > 0:
-                green_rect = pygame.Rect(
-                    hp_rect.left, hp_rect.top, green_w, hp_rect.height
+                green_rect = pygame.Rect(0, 0, green_w, hp_rect.height)
+                pygame.draw.rect(
+                    hp_surface, (*constants.GREEN, 255), green_rect
                 )
-                pygame.draw.rect(combat.screen, constants.GREEN, green_rect)
-        pygame.draw.rect(combat.screen, theme.PALETTE["panel"], hp_rect, 1)
-        colour = constants.BLUE if unit.side == "hero" else constants.RED
-        pygame.draw.rect(combat.screen, colour, stack_rect)
+        pygame.draw.rect(
+            hp_surface, (*theme.PALETTE["panel"], 255), hp_surface.get_rect(), 1
+        )
+        combat.screen.blit(hp_surface, hp_rect.topleft)
         font = pygame.font.SysFont(None, int(14 * combat.zoom))
         text = font.render(str(unit.count), True, theme.PALETTE["text"])
         text_rect = text.get_rect(center=stack_rect.center)


### PR DESCRIPTION
## Summary
- Render stack size boxes before HP bars so the health bar overlays properly
- Draw HP bars on an SRCALPHA surface with opaque colours to avoid transparency

## Testing
- `python -m pytest --maxfail=1 -q -m "not slow and not worldgen and not combat and not serial"`
- `python - <<'PY'
import pygame
import constants, theme
pygame.init()
def render_bar(zoom):
    stack_w = int(30 * zoom)
    stack_h = int(20 * zoom)
    stack_rect = pygame.Rect(0, 0, stack_w, stack_h)
    bar_h = max(2, round(1.5 * zoom))
    hp_rect = pygame.Rect(0, 0, stack_rect.width, bar_h)
    hp_surface = pygame.Surface(hp_rect.size, pygame.SRCALPHA)
    pygame.draw.rect(hp_surface, (*constants.BLACK, 255), hp_surface.get_rect())
    ratio = 0.5
    green_w = int(hp_rect.width * ratio)
    if green_w > 0:
        pygame.draw.rect(
            hp_surface, (*constants.GREEN, 255), pygame.Rect(0, 0, green_w, hp_rect.height)
        )
    pygame.draw.rect(
        hp_surface, (*theme.PALETTE["panel"], 255), hp_surface.get_rect(), 1
    )
    return hp_rect.size, hp_surface.get_at((0,0))[3]
for z in [0.5, 1.0, 2.0]:
    size, alpha = render_bar(z)
    print(f"zoom={z}: hp_size={size}, alpha={alpha}")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b0258dc60c8321a287239f86ed5e49