### PR TITLE
feat: add spell info overlay

### DIFF
--- a/tests/test_spellbook_info_overlay.py
+++ b/tests/test_spellbook_info_overlay.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+from core.spell import Spell
+
+
+class DummyCombat:
+    def __init__(self):
+        self.hero_spells = {"fireball": 1}
+        self.spell_defs = {
+            "fireball": Spell(
+                id="fireball",
+                school="",
+                cost_mana=5,
+                cooldown=0,
+                range=5,
+                passive=False,
+                data={},
+            )
+        }
+
+
+def _make_event(t, **kw):
+    return SimpleNamespace(type=t, **kw)
+
+
+def test_click_spell_opens_info(pygame_stub):
+    pygame = pygame_stub(MOUSEBUTTONDOWN=1, KEYDOWN=2)
+    pygame.Rect.collidepoint = lambda self, pos: self.x <= pos[0] < self.x + self.width and self.y <= pos[1] < self.y + self.height
+    import importlib
+    import ui.spell_info_overlay as sio
+    import ui.spellbook_overlay as sb
+    importlib.reload(sio)
+    importlib.reload(sb)
+    SpellbookOverlay = sb.SpellbookOverlay
+    SpellInfoOverlay = sio.SpellInfoOverlay
+
+    screen = pygame.Surface((200, 200))
+    overlay = SpellbookOverlay(screen, DummyCombat())
+    overlay.draw()
+    rect, name = overlay._label_rects[0]
+
+    closed = overlay.handle_event(
+        _make_event(pygame.MOUSEBUTTONDOWN, button=1, pos=rect.center)
+    )
+    assert closed is False
+    assert isinstance(overlay.info_overlay, SpellInfoOverlay)
+    assert overlay.info_overlay.lines == overlay._spell_tooltip(name)

--- a/ui/spell_info_overlay.py
+++ b/ui/spell_info_overlay.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pygame
+import theme
+
+
+class SpellInfoOverlay:
+    """Small panel showing spell details."""
+
+    BG = theme.PALETTE.get("background", (40, 42, 50))
+    TEXT = theme.PALETTE.get("text", (230, 230, 230))
+
+    def __init__(self, screen: pygame.Surface, lines: list[str]) -> None:
+        self.screen = screen
+        self.lines = lines
+        self.font = theme.get_font(16) or pygame.font.SysFont(None, 16)
+        self.rect = pygame.Rect(0, 0, 0, 0)
+
+    # ------------------------------------------------------------------ events
+    def handle_event(self, event: pygame.event.Event) -> bool:
+        """Return ``True`` to close the overlay."""
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            return True
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            return True
+        return False
+
+    # ------------------------------------------------------------------ drawing
+    def draw(self) -> None:
+        texts = [self.font.render(t, True, self.TEXT) for t in self.lines]
+        w = max(t.get_width() for t in texts) + 20 if texts else 100
+        h = sum(t.get_height() for t in texts) + 20 if texts else 40
+        surface = pygame.Surface((w, h), pygame.SRCALPHA)
+        surface.fill((*self.BG, 230))
+        theme.draw_frame(surface, surface.get_rect())
+        y = 10
+        for t in texts:
+            surface.blit(t, (10, y))
+            y += t.get_height()
+        sw, sh = self.screen.get_size()
+        x = (sw - w) // 2
+        y = (sh - h) // 2
+        self.rect = pygame.Rect(x, y, w, h)
+        self.screen.blit(surface, (x, y))


### PR DESCRIPTION
## Summary
- keep spellbook open when clicking a spell and show a popup with spell details
- add SpellInfoOverlay component to render spell details
- test spellbook opening of spell information panel

## Testing
- `pytest tests/test_spellbook_overlay.py tests/test_spellbook_overlay_town.py tests/test_spellbook_info_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_68b025a41b8c832192de5906a47ca08e