### PR TITLE
Affiche la croissance hebdomadaire et le stock dans les cartes de bâtiments

### DIFF
--- a/tests/pygame_stub/__init__.py
+++ b/tests/pygame_stub/__init__.py
@@ -34,15 +34,62 @@ class Rect:
         self.y = y
         self.width = w
         self.height = h
-        self.bottom = y + h
+
+    @property
+    def left(self):
+        return self.x
+
+    @left.setter
+    def left(self, value):
+        self.x = value
+
+    @property
+    def top(self):
+        return self.y
+
+    @top.setter
+    def top(self, value):
+        self.y = value
+
+    @property
+    def right(self):
+        return self.x + self.width
+
+    @right.setter
+    def right(self, value):
+        self.x = value - self.width
+
+    @property
+    def bottom(self):
+        return self.y + self.height
+
+    @bottom.setter
+    def bottom(self, value):
+        self.y = value - self.height
+
+    @property
+    def centerx(self):
+        return self.x + self.width // 2
+
+    @centerx.setter
+    def centerx(self, value):
+        self.x = value - self.width // 2
+
+    @property
+    def centery(self):
+        return self.y + self.height // 2
+
+    @centery.setter
+    def centery(self, value):
+        self.y = value - self.height // 2
 
     @property
     def topleft(self):
-        return (self.x, self.y)
+        return (self.left, self.top)
 
     @property
     def center(self):
-        return (self.x + self.width // 2, self.y + self.height // 2)
+        return (self.centerx, self.centery)
 
     @property
     def size(self):
@@ -51,32 +98,30 @@ class Rect:
     @size.setter
     def size(self, value):
         self.width, self.height = value
-        self.bottom = self.y + self.height
 
     @property
     def midtop(self):
-        return (self.x + self.width // 2, self.y)
+        return (self.centerx, self.top)
 
     @midtop.setter
     def midtop(self, pos):
         cx, cy = pos
-        self.x = cx - self.width // 2
-        self.y = cy
-        self.bottom = self.y + self.height
+        self.centerx = cx
+        self.top = cy
 
     @property
     def midbottom(self):
-        return (self.x + self.width // 2, self.y + self.height)
+        return (self.centerx, self.bottom)
 
     @midbottom.setter
     def midbottom(self, pos):
         cx, cy = pos
-        self.x = cx - self.width // 2
-        self.y = cy - self.height
-        self.bottom = self.y + self.height
+        self.centerx = cx
+        self.bottom = cy
 
     def collidepoint(self, pos):
-        return False
+        x, y = pos
+        return self.left <= x < self.right and self.top <= y < self.bottom
 
     def move(self, dx, dy):
         return Rect(self.x + dx, self.y + dy, self.width, self.height)
@@ -138,6 +183,24 @@ class draw:
     @staticmethod
     def ellipse(surface, colour, rect, width=0):
         pass
+
+
+class transform:
+    @staticmethod
+    def scale(img, size):
+        return img
+
+    @staticmethod
+    def smoothscale(img, size):
+        return img
+
+    @staticmethod
+    def flip(img, xbool, ybool):
+        return img
+
+    @staticmethod
+    def rotate(img, angle):
+        return img
 
 
 class display:

--- a/tests/test_spellbook_info_overlay.py
+++ b/tests/test_spellbook_info_overlay.py
@@ -27,6 +27,8 @@ def test_click_spell_opens_info(pygame_stub):
     pygame = pygame_stub(MOUSEBUTTONDOWN=1, KEYDOWN=2)
     pygame.Rect.collidepoint = lambda self, pos: self.x <= pos[0] < self.x + self.width and self.y <= pos[1] < self.y + self.height
     import importlib
+    import theme
+    importlib.reload(theme)
     import ui.spell_info_overlay as sio
     import ui.spellbook_overlay as sb
     importlib.reload(sio)

--- a/tests/test_spellbook_overlay.py
+++ b/tests/test_spellbook_overlay.py
@@ -27,7 +27,10 @@ def _make_event(t, **kw):
 def test_pagination_and_tooltip(pygame_stub):
     pygame = pygame_stub(KEYDOWN=1, MOUSEBUTTONDOWN=2, K_RIGHT=3, K_LEFT=4,
                          K_s=5, K_ESCAPE=6, K_PAGEDOWN=7, K_PAGEUP=8)
-    from ui.spellbook_overlay import SpellbookOverlay
+    import importlib
+    import ui.spellbook_overlay as sb
+    importlib.reload(sb)
+    SpellbookOverlay = sb.SpellbookOverlay
     screen = pygame.Surface((200, 200))
     combat = DummyCombat()
     overlay = SpellbookOverlay(screen, combat)

--- a/ui/town_screen.py
+++ b/ui/town_screen.py
@@ -404,13 +404,26 @@ class TownScreen:
             self._blit_wrapped(self.font_small, desc, (card.x + 10, desc_y), card.width - 20, COLOR_TEXT)
 
         if built:
+            units = self.town.recruitable_units(sid)
+            line_h = self.font_small.get_linesize()
+            y = card.bottom - 28 - line_h * (2 * len(units))
+            for uid in units:
+                growth = self.town.growth_per_week.get(uid, 0)
+                stock = self.town.stock.get(uid, 0)
+                grow_txt = f"{uid}: +{growth}/semaine"
+                self.screen.blit(
+                    self.font_small.render(grow_txt, True, COLOR_TEXT),
+                    (card.x + 10, y),
+                )
+                y += line_h
+                stock_txt = f"En stock : {stock}"
+                self.screen.blit(
+                    self.font_small.render(stock_txt, True, COLOR_TEXT),
+                    (card.x + 10, y),
+                )
+                y += line_h
             lab = self.font.render("Built", True, COLOR_OK)
             self.screen.blit(lab, (card.x + 10, card.bottom - 28))
-            units = self.town.recruitable_units(sid)
-            counts = self.town.available_units(sid)
-            if counts:
-                stock_txt = " / ".join(f"{k}:{v}" for k, v in counts.items())
-                self.screen.blit(self.font_small.render(stock_txt, True, COLOR_TEXT), (card.x + 10, card.bottom - 44))
             hint_text = None
             if sid == "market":
                 hint_text = "Click to trade"


### PR DESCRIPTION
## Summary
- Show weekly unit growth and current stock directly on town building cards
- Expand pygame test stub with Rect helpers and transform utilities
- Reload overlay modules in tests to use updated stubs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03405df048321a182f3c4b7fa8c42