### PR TITLE
Add LRU caching for surface scaling

### DIFF
--- a/tests/test_scale_surface_cache.py
+++ b/tests/test_scale_surface_cache.py
@@ -1,0 +1,46 @@
+import gc
+import gc
+import gc
+import types
+
+import graphics.scale as scale_mod
+
+
+def _patched_scale(monkeypatch):
+    calls = []
+
+    def fake_scale(surface, size):
+        calls.append((id(surface), size))
+        return scale_mod.pygame.Surface(size)
+
+    stub = types.SimpleNamespace(
+        Surface=scale_mod.pygame.Surface,
+        transform=types.SimpleNamespace(scale=fake_scale, smoothscale=fake_scale),
+    )
+    monkeypatch.setattr(scale_mod, "pygame", stub)
+    return stub, calls
+
+
+def test_scale_surface_uses_cache(monkeypatch):
+    stub, calls = _patched_scale(monkeypatch)
+
+    surf = stub.Surface((10, 10))
+    scaled1 = scale_mod.scale_surface(surf, (5, 5))
+    scaled2 = scale_mod.scale_surface(surf, (5, 5))
+
+    assert scaled1 is scaled2
+    assert len(calls) == 1
+
+
+def test_scale_surface_invalidates_on_free(monkeypatch):
+    stub, calls = _patched_scale(monkeypatch)
+
+    surf = stub.Surface((10, 10))
+    scale_mod.scale_surface(surf, (5, 5))
+    del surf
+    gc.collect()
+
+    surf2 = stub.Surface((10, 10))
+    scale_mod.scale_surface(surf2, (5, 5))
+
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- cache scaled surfaces with a tiny LRU keyed by surface id, size and smoothing
- drop cache entries when surfaces disappear and add unit tests for the cache

## Testing
- `pre-commit run --files graphics/scale.py tests/test_scale_surface_cache.py` *(fails: tests/test_spellbook_info_overlay.py::test_click_spell_opens_info - AttributeError: 'Rect' object has no attribute 'left')*
- `pytest tests/test_scale_surface_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0343ebf9083219d4da777c85226e7