### PR TITLE
feat: make biome cache configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ file in the project root. Setting `FG_DEBUG_BUILDINGS=1` (or adding
 `"debug_buildings": true` to `settings.json`) draws debug markers for building
 positions in the world renderer. Additional entries such as
 `animation_speed`, `tooltip_read_mode` and `keymap` allow tuning animation
-speed, enabling a reader-friendly tooltip mode and remapping controls.
+speed, enabling a reader-friendly tooltip mode and remapping controls. The
+world renderer's biome caching can be tuned with `biome_chunk_tiles` (tiles per
+chunk) and `biome_cache_size` (maximum cached chunks).
 
 ## Roadmap and Ideas
 

--- a/render/world_renderer.py
+++ b/render/world_renderer.py
@@ -21,9 +21,8 @@ from graphics.scale import scale_surface
 
 logger = logging.getLogger(__name__)
 
-# Number of tiles per cached biome chunk
-BIOME_CHUNK_TILES = 32
-BIOME_CACHE_SIZE = 64
+# Number of tiles per cached biome chunk and cache size are configurable
+# via :mod:`settings`.
 
 
 class WorldRenderer:
@@ -88,7 +87,7 @@ class WorldRenderer:
             self._pending_chunks.add((cx, cy))
         world = self.world
         tile_size = constants.TILE_SIZE
-        chunk = BIOME_CHUNK_TILES
+        chunk = settings.BIOME_CHUNK_TILES
         start_x = cx * chunk
         start_y = cy * chunk
         chunk_w = min(chunk, world.width - start_x)
@@ -116,7 +115,7 @@ class WorldRenderer:
             self._pending_chunks.discard((cx, cy))
             self._biome_chunks[(cx, cy)] = surf
             self._biome_chunks.move_to_end((cx, cy))
-            if len(self._biome_chunks) > BIOME_CACHE_SIZE:
+            if len(self._biome_chunks) > settings.BIOME_CACHE_SIZE:
                 self._biome_chunks.popitem(last=False)
 
     def _generate_biome_chunks(self) -> None:
@@ -135,7 +134,7 @@ class WorldRenderer:
                 break
         # Queue up all biome chunks for background generation so the
         # renderer has them ready when needed.
-        chunk = BIOME_CHUNK_TILES
+        chunk = settings.BIOME_CHUNK_TILES
         world = self.world
         chunks_x = math.ceil(world.width / chunk)
         chunks_y = math.ceil(world.height / chunk)
@@ -147,8 +146,8 @@ class WorldRenderer:
         """Invalidate the cached chunk containing tile ``(x, y)``."""
         if not self.world:
             return
-        cx = x // BIOME_CHUNK_TILES
-        cy = y // BIOME_CHUNK_TILES
+        cx = x // settings.BIOME_CHUNK_TILES
+        cy = y // settings.BIOME_CHUNK_TILES
         with self._biome_lock:
             self._biome_chunks.pop((cx, cy), None)
             self._prefetch_set.discard((cx, cy))
@@ -187,7 +186,7 @@ class WorldRenderer:
     ) -> None:
         if not self.world:
             return
-        chunk = BIOME_CHUNK_TILES
+        chunk = settings.BIOME_CHUNK_TILES
         world = self.world
         chunks_x = math.ceil(world.width / chunk)
         chunks_y = math.ceil(world.height / chunk)
@@ -345,7 +344,7 @@ class WorldRenderer:
             return (x1, y1, x2 - x1, y2 - y1)
 
         # Biome layer via cached chunks
-        chunk = BIOME_CHUNK_TILES
+        chunk = settings.BIOME_CHUNK_TILES
         chunk_start_x = start_x // chunk
         chunk_end_x = math.ceil(end_x / chunk)
         chunk_start_y = start_y // chunk

--- a/settings.json
+++ b/settings.json
@@ -10,6 +10,8 @@
   "animation_speed": 1.0,
   "tooltip_read_mode": false,
   "super_user_mode": false,
+  "biome_chunk_tiles": 32,
+  "biome_cache_size": 64,
   "keymap": {
     "pan_left": ["K_LEFT", "K_a"],
     "pan_right": ["K_RIGHT", "K_d"],

--- a/settings.py
+++ b/settings.py
@@ -82,6 +82,16 @@ VOLUME: float = _get_float("FG_VOLUME", "volume", 1.0)
 # Map scroll speed in pixels per key press
 SCROLL_SPEED: int = _get_int("FG_SCROLL_SPEED", "scroll_speed", 20)
 
+# Number of tiles per cached biome chunk in the world renderer
+BIOME_CHUNK_TILES: int = _get_int(
+    "FG_BIOME_CHUNK_TILES", "biome_chunk_tiles", 32
+)
+
+# Maximum number of biome chunks stored in the cache
+BIOME_CACHE_SIZE: int = _get_int(
+    "FG_BIOME_CACHE_SIZE", "biome_cache_size", 64
+)
+
 # Animation speed multiplier for game visuals
 ANIMATION_SPEED: float = _get_float(
     "FG_ANIMATION_SPEED", "animation_speed", 1.0
@@ -133,6 +143,8 @@ __all__ = [
     "LANGUAGE",
     "VOLUME",
     "SCROLL_SPEED",
+    "BIOME_CHUNK_TILES",
+    "BIOME_CACHE_SIZE",
     "ANIMATION_SPEED",
     "TOOLTIP_READ_MODE",
     "SUPER_USER_MODE",


### PR DESCRIPTION
## Summary
- expose biome chunk size and cache size as settings
- use global settings in world renderer
- document biome caching options

## Testing
- `pre-commit run --files settings.json settings.py render/world_renderer.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0368a0cac8321b0d1882aadbeb391