### PR TITLE
Show numeric progress on loading screen

### DIFF
--- a/ui/loading_screen.py
+++ b/ui/loading_screen.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 import pygame
 
 import constants
@@ -12,10 +13,26 @@ class LoadingScreen:
     def __init__(self, screen: pygame.Surface) -> None:
         self.screen = screen
         self.progress = 0.0
+        self.done = 0
+        self.total = 0
+
+        # Font for progress text
+        font_path = Path(__file__).resolve().parent.parent / "fonts" / "roboto.ttf"
+        if hasattr(pygame, "font") and not pygame.font.get_init():
+            pygame.font.init()
+        try:  # pragma: no cover
+            self.font = pygame.font.Font(str(font_path), 20)
+        except Exception:  # pragma: no cover
+            self.font = (
+                pygame.font.SysFont("arial", 20) if hasattr(pygame, "font") else None
+            )
+
         EVENT_BUS.subscribe(ON_ASSET_LOAD_PROGRESS, self._on_progress)
         self._render()
 
     def _on_progress(self, done: int, total: int) -> None:
+        self.done = done
+        self.total = total
         self.progress = done / total if total else 1.0
         self._render()
 
@@ -31,4 +48,13 @@ class LoadingScreen:
             pygame.draw.rect(
                 self.screen, constants.GREEN, (x + 2, y + 2, inner - 4, height - 4)
             )
+
+        if getattr(self, "font", None):  # pragma: no branch
+            percent = int(self.progress * 100)
+            text = f"{self.done}/{self.total} – {percent}%"
+            surf = self.font.render(text, True, constants.WHITE)
+            rect = surf.get_rect()
+            rect.midtop = (self.screen.get_width() // 2, y + height + 10)
+            self.screen.blit(surf, rect)
+
         pygame.display.flip()


### PR DESCRIPTION
## Summary
- Track completed and total assets during loading
- Render "{done}/{total} – {percent}%" beneath the loading bar using a font

## Testing
- `pre-commit run --files ui/loading_screen.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03798120c8321b2cca3242e20e6a5