### PR TITLE
Implement basic AI town construction logic

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -2875,6 +2875,7 @@ class Game:
     def _run_ai_turn(self) -> None:
         """Execute AI recruitment and movement for the turn."""
         if getattr(self, "ai_player", None):
+            self.ai_player.build_in_town()
             self._spawn_enemy_heroes()
         self.move_enemies_randomly()
         self.move_enemy_heroes()


### PR DESCRIPTION
## Summary
- Prioritise faction AI town construction: dwellings T1→T7 before utility buildings
- Ensure AI only builds structures it can afford and logs each choice
- Trigger town construction each AI turn

## Testing
- `pytest --maxfail=1 -q -m "not slow and not worldgen and not combat and not serial"`


------
https://chatgpt.com/codex/tasks/task_e_68b03902f0a88321984efb743facf24a