### PR TITLE
Add morale and luck FX events

### DIFF
--- a/assets/vfx/vfx.json
+++ b/assets/vfx/vfx.json
@@ -7,5 +7,7 @@
   {"id": "focus", "image": "vfx/focus.png"},
   {"id": "shield_block", "image": "vfx/shield_block.png"},
   {"id": "charge", "image": "vfx/charge.png"},
-  {"id": "dragon_breath", "image": "vfx/dragon_breath.png"}
+  {"id": "dragon_breath", "image": "vfx/dragon_breath.png"},
+  {"id": "morale_fx", "image": "icons/stat_morale.png"},
+  {"id": "luck_fx", "image": "icons/stat_luck.png"}
 ]

--- a/core/combat.py
+++ b/core/combat.py
@@ -899,8 +899,10 @@ class Combat:
         luck_mul = result.get("luck", 1.0)
         if luck_mul > 1.0:
             self.add_log(f"Lucky strike by {attacker.stats.name}!")
+            self.show_effect("luck_fx", (attacker.x, attacker.y))
         elif luck_mul < 1.0:
             self.add_log(f"Unlucky hit by {attacker.stats.name}.")
+            self.show_effect("luck_fx", (attacker.x, attacker.y))
         if flank > 1.0:
             print("Flanking attack!")
 
@@ -1105,12 +1107,14 @@ class Combat:
     def check_morale(self, unit: Unit) -> None:
         """Apply morale effects to a unit at the start of its turn."""
         outcome = combat_rules.roll_morale(unit.stats.morale)
-        if outcome == "extra":
+        if outcome > 0:
             unit.extra_turns = 1
             self.add_log(f"{unit.stats.name} is inspired and gains an extra action!")
-        elif outcome == "penalty":
+            self.show_effect("morale_fx", (unit.x, unit.y))
+        elif outcome < 0:
             unit.skip_turn = True
             self.add_log(f"{unit.stats.name} falters and loses its action!")
+            self.show_effect("morale_fx", (unit.x, unit.y))
 
     def get_available_actions(self, unit: Unit) -> List[str]:
         """Return the list of action identifiers available to ``unit``."""

--- a/core/combat_rules.py
+++ b/core/combat_rules.py
@@ -15,17 +15,32 @@ class UnitView:
     facing: Tuple[int,int] = (0, 1)  # optionnel: orientation (dx,dy)
 
 # ---- Morale & Chance ----
-def roll_morale(morale: int) -> str:
-    """retourne 'extra', 'penalty' ou 'normal'."""
-    table = {0: 0.0, 1: 1 / 24, 2: 2 / 24, 3: 3 / 24}
+def roll_morale(morale: int) -> int:
+    """Return -1, 0 or +1 depending on morale.
+
+    The probabilities are capped to the ``[-3..3]`` range with the following
+    chances of triggering an effect:
+
+    ``[-3..3] -> [12.5%, 8.3%, 4.2%, 0, 4.2%, 8.3%, 12.5%]``
+    """
+
+    table = {
+        -3: 0.125,
+        -2: 0.083,
+        -1: 0.042,
+        0: 0.0,
+        1: 0.042,
+        2: 0.083,
+        3: 0.125,
+    }
     m = max(-3, min(3, morale))
-    p = table[abs(m)]
+    p = table[m]
     r = random.random()
     if m > 0 and r < p:
-        return "extra"
+        return 1
     if m < 0 and r < p:
-        return "penalty"
-    return "normal"
+        return -1
+    return 0
 
 def roll_luck(luck: int) -> float:
     """retourne multiplicateur de dégâts (0.5, 1.0, 1.5)."""

--- a/tests/test_luck_log.py
+++ b/tests/test_luck_log.py
@@ -5,27 +5,36 @@ from dataclasses import replace
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
 from core.entities import Unit, SWORDSMAN_STATS
+import pygame
 
 
 def test_positive_luck_logs(monkeypatch, simple_combat):
     hero_stats = replace(SWORDSMAN_STATS, luck=1)
     hero = Unit(hero_stats, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = simple_combat([hero], [enemy])
+    pygame.init()
+    assets = {"luck_fx": pygame.Surface((1, 1))}
+    combat = simple_combat([hero], [enemy], assets=assets)
     attacker = combat.hero_units[0]
     defender = combat.enemy_units[0]
     monkeypatch.setattr(random, 'random', lambda: 0.0)
+    before = len(combat.fx_queue._events)
     combat.resolve_attack(attacker, defender, 'melee')
     assert combat.log[-1] == 'Lucky strike by Swordsman!'
+    assert len(combat.fx_queue._events) > before
 
 
 def test_negative_luck_logs(monkeypatch, simple_combat):
     hero_stats = replace(SWORDSMAN_STATS, luck=-1)
     hero = Unit(hero_stats, 1, 'hero')
     enemy = Unit(SWORDSMAN_STATS, 1, 'enemy')
-    combat = simple_combat([hero], [enemy])
+    pygame.init()
+    assets = {"luck_fx": pygame.Surface((1, 1))}
+    combat = simple_combat([hero], [enemy], assets=assets)
     attacker = combat.hero_units[0]
     defender = combat.enemy_units[0]
     monkeypatch.setattr(random, 'random', lambda: 0.0)
+    before = len(combat.fx_queue._events)
     combat.resolve_attack(attacker, defender, 'melee')
     assert combat.log[-1] == 'Unlucky hit by Swordsman.'
+    assert len(combat.fx_queue._events) > before

--- a/tests/test_roll_tables.py
+++ b/tests/test_roll_tables.py
@@ -5,16 +5,16 @@ from core.combat_rules import roll_morale, roll_luck
 
 def test_roll_morale_table(monkeypatch):
     monkeypatch.setattr(random, 'random', lambda: 0.03)
-    assert roll_morale(1) == 'extra'
+    assert roll_morale(1) == 1
     monkeypatch.setattr(random, 'random', lambda: 0.05)
-    assert roll_morale(1) == 'normal'
+    assert roll_morale(1) == 0
     monkeypatch.setattr(random, 'random', lambda: 0.12)
-    assert roll_morale(3) == 'extra'
+    assert roll_morale(3) == 1
     monkeypatch.setattr(random, 'random', lambda: 0.13)
-    assert roll_morale(3) == 'normal'
+    assert roll_morale(3) == 0
     monkeypatch.setattr(random, 'random', lambda: 0.0)
-    assert roll_morale(5) == 'extra'
-    assert roll_morale(-5) == 'penalty'
+    assert roll_morale(5) == 1
+    assert roll_morale(-5) == -1
 
 
 def test_roll_luck_table(monkeypatch):


### PR DESCRIPTION
## Summary
- apply explicit morale probability table and return action delta
- show morale and luck icons when their bonuses trigger
- cover morale and luck visuals with tests and asset manifest

## Testing
- `pre-commit run --files core/combat_rules.py core/combat.py assets/vfx/vfx.json tests/test_roll_tables.py tests/test_morale.py tests/test_luck_log.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b039f525748321b26a7241d6cd6723