### PR TITLE
feat: automated caravans and caravansary

### DIFF
--- a/assets/town_buildings.json
+++ b/assets/town_buildings.json
@@ -21,6 +21,13 @@
     "image": "buildings/tavern.png"
   },
   {
+    "id": "caravansary",
+    "cost": {},
+    "prereq": [],
+    "desc": "Organize caravans between towns.",
+    "image": "buildings/market.png"
+  },
+  {
     "id": "bounty_board",
     "cost": {},
     "prereq": [],

--- a/core/world.py
+++ b/core/world.py
@@ -1453,16 +1453,18 @@ class WorldMap:
         return towns
 
 
-    def advance_day(self) -> None:
+    def advance_day(self, hero: Optional["Hero"] = None) -> None:
         """Advance daily progression for all towns on the map.
 
-        This currently forwards to each town's ``advance_day`` method so that
-        caravan orders continue their journey across the world.
+        This forwards to each town's ``advance_day`` method so that caravan
+        orders continue their journey across the world.  When ``hero`` is
+        provided, towns may automatically expédier des renforts vers lui ou
+        vers des alliés.
         """
 
         for town in self.towns:
             if hasattr(town, "advance_day"):
-                town.advance_day()
+                town.advance_day(hero, self)
 
 
     def find_building_pos(self, building: Building) -> Optional[Tuple[int, int]]:

--- a/state/game_state.py
+++ b/state/game_state.py
@@ -123,12 +123,13 @@ class GameState:
 
         economy.advance_day(self.economy)
         if self.world is not None:
+            hero = self.heroes[0] if self.heroes else None
             if hasattr(self.world, "advance_day"):
-                self.world.advance_day()
+                self.world.advance_day(hero)
             else:
                 for town in self.world.towns:
                     if hasattr(town, "advance_day"):
-                        town.advance_day()
+                        town.advance_day(hero, self.world)
         self.turn.turn_index += 1
         if self.economy.calendar.day == 1:
             self._advance_towns_week()

--- a/ui/town_screen.py
+++ b/ui/town_screen.py
@@ -211,6 +211,19 @@ class TownScreen:
             return True
         return False
 
+    def cancel_caravan(self, index: int) -> bool:
+        """Annuler une caravane existante et rapatrier les unités."""
+
+        return self.town.cancel_caravan(index)
+
+    def intercept_caravan(self, index: int) -> bool:
+        """Intercepter une caravane en cours et ajouter les unités au héros."""
+
+        hero = getattr(self.game, "hero", None)
+        if hero is None:
+            return False
+        return self.town.intercept_caravan(index, hero)
+
     def _invalidate(self, rect: Optional[pygame.Rect] = None) -> None:
         """Mark a region of the town screen as needing redraw."""
         if rect is None:


### PR DESCRIPTION
## Summary
- expand caravan support to heroes and add auto-dispatch toward heroes or allied towns
- expose caravan creation, cancellation and interception in the town UI
- define a generic caravansary town building

## Testing
- `pre-commit run --files tests/test_caravan.py`
- `pytest tests/test_caravan.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03a24f2b88321b87c2574df958200