### PR TITLE
feat: support unit templates and return stats mapping

### DIFF
--- a/core/entities.py
+++ b/core/entities.py
@@ -733,8 +733,8 @@ def _load_stats(manifest: str, section: str) -> Dict[str, UnitStats]:
 
     base = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets"))
     ctx = Context(base, [""])
-    data = load_units(ctx, manifest, section=section)
-    return {entry["stats"].name: entry["stats"] for entry in data.values()}
+    stats_map, _ = load_units(ctx, manifest, section=section)
+    return {st.name: st for st in stats_map.values()}
 
 
 # Units that can be recruited in towns

--- a/core/game.py
+++ b/core/game.py
@@ -231,11 +231,11 @@ class Game:
             )
 
             try:
-                self.unit_defs = units_loader.load_units(
+                self.unit_defs, self.unit_extra = units_loader.load_units(
                     self.ctx, "units/units.json"
                 )
             except Exception:
-                self.unit_defs = {}
+                self.unit_defs, self.unit_extra = {}, {}
             try:
                 self.hero_defs = load_heroes(self.ctx, "units/heroes.json")
             except Exception:

--- a/tests/test_units_loader.py
+++ b/tests/test_units_loader.py
@@ -1,0 +1,76 @@
+import json
+from loaders.units_loader import load_units
+from loaders.core import Context
+from core.entities import UnitStats
+
+
+def test_load_units_with_template(tmp_path):
+    manifest = tmp_path / "units.json"
+    data = {
+        "templates": {
+            "base": {
+                "abilities": {"a": 1},
+                "stats": {
+                    "name": "Base",
+                    "max_hp": 5,
+                    "attack_min": 1,
+                    "attack_max": 2,
+                    "defence_melee": 1,
+                    "defence_ranged": 1,
+                    "speed": 3,
+                    "attack_range": 1,
+                    "initiative": 4,
+                    "sheet": "s",
+                    "hero_frames": [0, 0],
+                    "enemy_frames": [0, 0],
+                },
+            }
+        },
+        "units": [
+            {
+                "id": "u1",
+                "template": "base",
+                "stats": {"attack_min": 2},
+            }
+        ],
+    }
+    manifest.write_text(json.dumps(data))
+    ctx = Context(str(tmp_path), [""])
+    stats, extras = load_units(ctx, manifest.name)
+    st = stats["u1"]
+    assert isinstance(st, UnitStats)
+    assert st.attack_min == 2
+    assert st.speed == 3
+    assert st.defence_magic == 0
+    assert st.abilities == ["a"]
+    assert extras["u1"]["abilities"] == [{"name": "a", "args": []}]
+    assert extras["u1"]["template"] == "base"
+
+
+def test_load_creatures_defaults(tmp_path):
+    manifest = tmp_path / "creatures.json"
+    data = {
+        "creatures": [
+            {
+                "id": "wolf",
+                "stats": {
+                    "name": "wolf",
+                    "max_hp": 10,
+                    "attack_min": 1,
+                    "attack_max": 2,
+                    "defence_melee": 1,
+                    "defence_ranged": 1,
+                    "speed": 3,
+                    "attack_range": 1,
+                },
+            }
+        ]
+    }
+    manifest.write_text(json.dumps(data))
+    ctx = Context(str(tmp_path), [""])
+    stats, extras = load_units(ctx, manifest.name)
+    st = stats["wolf"]
+    assert isinstance(st, UnitStats)
+    assert st.defence_magic == 0
+    assert st.sheet == ""
+    assert extras["wolf"]["abilities"] == []


### PR DESCRIPTION
## Summary
- support `templates` in unit manifests and merge entries with defaults
- map stats blocks directly to UnitStats and provide default values
- load_units now returns `{id: UnitStats}` plus extras; adapt game and entity loaders
- add tests for template merging and default handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b04df99edc8321bd21cd5201845dd0