### PR TITLE
Use loader for unit stats in tests and document unit JSON schema

### DIFF
--- a/docs/unit_creature_schema.md
+++ b/docs/unit_creature_schema.md
@@ -1,0 +1,56 @@
+# Unit and Creature JSON Schema
+
+Unit and creature definitions are stored under `assets/units/*.json` and loaded
+through :func:`loaders.units_loader.load_units`.  Each manifest contains either a
+`"units"` or `"creatures"` array with entries of the following form:
+
+```json
+{
+  "id": "swordsman",          // unique identifier
+  "name": "Swordsman",        // optional display name
+  "image": "units/path.png",  // sprite relative to `assets/`
+  "anchor_px": [32, 64],       // drawing anchor in pixels
+  "shadow_baked": true,        // sprite already includes shadow
+  "battlefield_scale": 1.0,    // optional render scale
+  "abilities": {"Shield Block": 1}, // ability map or list
+  "stats": {
+    "name": "Swordsman",
+    "max_hp": 40,
+    "attack_min": 4,
+    "attack_max": 6,
+    "defence_melee": 3,
+    "defence_ranged": 3,
+    "defence_magic": 0,
+    "speed": 3,
+    "attack_range": 1,
+    "initiative": 5,
+    "sheet": "units",
+    "hero_frames": [0, 0],
+    "enemy_frames": [3, 3],
+    "morale": 0,
+    "luck": 0,
+    "abilities": ["shield_block"],
+    "role": "optional description",
+    "unit_type": "non-magic",
+    "mana": 1,
+    "min_range": 1,
+    "retaliations_per_round": 1,
+    "battlefield_scale": 1.0
+  }
+}
+```
+
+The `stats` block corresponds to the :class:`core.entities.UnitStats` dataclass
+and accepts any of its fields.  Values not supplied default to those of a
+minimal unit (1 HP, speed 1, etc.).
+
+Creature entries share the same structure and may include additional fields such
+as:
+
+* `biomes` – list of biome identifiers the creature can appear in.
+* `behavior` – roaming AI behaviour (e.g. `"roamer"`, `"guardian"`).
+* `guard_range` – tiles protected around the creature.
+
+Manifests may also provide a `templates` mapping used to supply default values
+for multiple units.  Each entry can reference a template via the `template`
+field; values from the entry override those supplied by the template.

--- a/tests/test_ai_fow.py
+++ b/tests/test_ai_fow.py
@@ -2,8 +2,11 @@ import pytest
 
 from core.world import WorldMap
 from core.ai.faction_ai import FactionAI
-from core.entities import EnemyHero, Unit, SWORDSMAN_STATS, Hero
+from core.entities import EnemyHero, Unit, Hero
+from tests.unit_stats import get_unit_stats
 from core.buildings import Town, Building
+
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
 
 
 def _basic_world():

--- a/tests/test_boat_exchange.py
+++ b/tests/test_boat_exchange.py
@@ -16,7 +16,9 @@ def test_boat_garrison_exchange(monkeypatch, pygame_stub):
     )
     monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
-    from core.entities import Hero, Unit, SWORDSMAN_STATS, Boat
+    from core.entities import Hero, Unit, Boat
+    from tests.unit_stats import get_unit_stats
+    SWORDSMAN_STATS = get_unit_stats("Swordsman")
     from ui.boat_screen import BoatScreen
 
     hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])

--- a/tests/test_combat_ai.py
+++ b/tests/test_combat_ai.py
@@ -4,13 +4,13 @@ import pytest
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
-from core.entities import (
-    Unit,
-    SWORDSMAN_STATS,
-    DRAGON_STATS,
-    MAGE_STATS,
-    ARCHER_STATS,
-)
+from core.entities import Unit
+from tests.unit_stats import get_unit_stats
+
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
+DRAGON_STATS = get_unit_stats("Dragon")
+MAGE_STATS = get_unit_stats("Mage")
+ARCHER_STATS = get_unit_stats("Archer")
 from core.combat_ai import ai_take_turn, allied_ai_turn, select_spell, _a_star
 import constants
 

--- a/tests/test_end_conditions.py
+++ b/tests/test_end_conditions.py
@@ -1,7 +1,10 @@
 import pygame
 from core.game import Game
 from core.world import WorldMap
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit
+from tests.unit_stats import get_unit_stats
+
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
 from core.buildings import Town
 from state.game_state import GameState
 from core import economy

--- a/tests/test_enemy_ai.py
+++ b/tests/test_enemy_ai.py
@@ -7,7 +7,10 @@ import pytest
 from core.world import WorldMap
 from core.game import Game
 from core.ai.faction_ai import FactionAI
-from core.entities import Hero, EnemyHero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, EnemyHero, Unit
+from tests.unit_stats import get_unit_stats
+
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
 from core.buildings import Town
 from state.game_state import GameState
 from core import economy

--- a/tests/test_faction_skill_catalog.py
+++ b/tests/test_faction_skill_catalog.py
@@ -1,7 +1,10 @@
 import pygame
 
 import core.entities as entities
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit
+from tests.unit_stats import get_unit_stats
+
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
 from core.faction import FactionDef
 from ui.inventory_screen import InventoryScreen
 

--- a/tests/test_ocean_buildings.py
+++ b/tests/test_ocean_buildings.py
@@ -1,5 +1,8 @@
 from core.buildings import create_building
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit
+from tests.unit_stats import get_unit_stats
+
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
 from core.vision import compute_vision
 from core.world import WorldMap
 import constants

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,9 +7,12 @@ pygame_stub = types.SimpleNamespace()
 sys.modules.setdefault("pygame", pygame_stub)
 
 from core.world import WorldMap
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit
+from tests.unit_stats import get_unit_stats
 from core.buildings import create_building
 from core.game import Game
+
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
 
 def test_place_resources_and_collect(rng, monkeypatch):
     monkeypatch.setattr("random.shuffle", rng.shuffle)

--- a/tests/test_spawn_army.py
+++ b/tests/test_spawn_army.py
@@ -22,7 +22,9 @@ def test_drag_from_garrison_creates_army(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
+    from tests.unit_stats import get_unit_stats
+    SWORDSMAN_STATS = get_unit_stats("Swordsman")
     from core.buildings import Town
     from ui.town_screen import TownScreen
 
@@ -73,7 +75,10 @@ def test_hero_army_exchange_merge_delete(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
-    from core.entities import Hero, Army, Unit, SWORDSMAN_STATS, ARCHER_STATS
+    from core.entities import Hero, Army, Unit
+    from tests.unit_stats import get_unit_stats
+    SWORDSMAN_STATS = get_unit_stats("Swordsman")
+    ARCHER_STATS = get_unit_stats("Archer")
     from core.game import Game
     from ui.hero_exchange_screen import HeroExchangeScreen
 

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -5,16 +5,15 @@ os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 import random
 from dataclasses import replace
 
-from core.entities import (
-    ARCHER_STATS,
-    CAVALRY_STATS,
-    DRAGON_STATS,
-    MAGE_STATS,
-    PRIEST_STATS,
-    SWORDSMAN_STATS,
-    Unit,
-    apply_defence,
-)
+from core.entities import Unit, apply_defence
+from tests.unit_stats import get_unit_stats
+
+ARCHER_STATS = get_unit_stats("Archer")
+CAVALRY_STATS = get_unit_stats("Cavalry")
+DRAGON_STATS = get_unit_stats("Dragon")
+MAGE_STATS = get_unit_stats("Mage")
+PRIEST_STATS = get_unit_stats("Priest")
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
 
 
 def test_mage_action_panel_has_spell_not_ranged(simple_combat):

--- a/tests/test_unknown_unit_load.py
+++ b/tests/test_unknown_unit_load.py
@@ -6,8 +6,11 @@ pygame_stub = types.SimpleNamespace()
 sys.modules.setdefault("pygame", pygame_stub)
 
 from core.game import Game
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit
+from tests.unit_stats import get_unit_stats
 from core.world import WorldMap
+
+SWORDSMAN_STATS = get_unit_stats("Swordsman")
 
 
 def test_load_game_with_unknown_unit(tmp_path):

--- a/tests/unit_stats.py
+++ b/tests/unit_stats.py
@@ -1,0 +1,20 @@
+import os
+from functools import lru_cache
+from loaders.units_loader import load_units
+from loaders.core import Context
+
+@lru_cache(maxsize=None)
+def _load_units():
+    base = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'assets'))
+    ctx = Context(base, [''])
+    stats, _ = load_units(ctx, 'units/units.json', section='units')
+    return stats
+
+def get_unit_stats(name: str):
+    units = _load_units()
+    if name in units:
+        return units[name]
+    for st in units.values():
+        if st.name == name:
+            return st
+    raise KeyError(name)


### PR DESCRIPTION
## Summary
- use `get_unit_stats` helper in tests instead of importing stat constants
- describe expected JSON schema for unit and creature manifests

## Testing
- `pytest tests/test_enemy_ai.py tests/test_boat_exchange.py tests/test_end_conditions.py tests/test_spells.py tests/test_ocean_buildings.py tests/test_combat_ai.py tests/test_spawn_army.py tests/test_unknown_unit_load.py tests/test_resources.py tests/test_ai_fow.py -q`
- `pre-commit run --files tests/unit_stats.py tests/test_enemy_ai.py tests/test_boat_exchange.py tests/test_end_conditions.py tests/test_spells.py tests/test_ocean_buildings.py tests/test_combat_ai.py tests/test_spawn_army.py tests/test_unknown_unit_load.py tests/test_resources.py tests/test_ai_fow.py docs/unit_creature_schema.md`


------
https://chatgpt.com/codex/tasks/task_e_68b05101d6048321866d790f99619a7c