### PR TITLE
Normalize hero unit identifiers and sprite fields

### DIFF
--- a/assets/units/heroes.json
+++ b/assets/units/heroes.json
@@ -99,7 +99,7 @@
       "starting_army": [
         {"unit": "Mist Dragon", "count": 22},
         {"unit": "Harmonia", "count": 30},
-        {"unit": "Mist Nymph", "count": 15},
+        {"unit": "Mist Nymph", "count": 15}
       ],
       "starting_skills": [
         {"branch": "Mists & Streams", "rank": "N", "id": "mist_veil_n"},
@@ -123,7 +123,7 @@
       "starting_army": [
         {"unit": "Mist Dragon", "count": 22},
         {"unit": "Harmonia", "count": 30},
-        {"unit": "Mist Nymph", "count": 15},
+        {"unit": "Mist Nymph", "count": 15}
       ],
       "starting_skills": [
         {"branch": "Sylvan Heart", "rank": "N", "id": "entangling_vines_n"},

--- a/core/game.py
+++ b/core/game.py
@@ -87,6 +87,10 @@ logger = logging.getLogger(__name__)
 # Fallback mapping for unit statistics used when a ``Game`` instance has not
 # initialised its own data yet (e.g. in certain unit tests).
 STATS_BY_NAME: Dict[str, UnitStats] = {**RECRUITABLE_UNITS, **CREATURE_STATS}
+for st in list(STATS_BY_NAME.values()):
+    STATS_BY_NAME.setdefault(st.name, st)
+    alias = str(st.name).lower().replace(" ", "_")
+    STATS_BY_NAME.setdefault(alias, st)
 
 
 # Filenames for save slots
@@ -222,6 +226,10 @@ class Game:
             except Exception:
                 self.creature_defs, self.creature_extra = {}, {}
             self._stats_by_name = {**self.unit_defs, **self.creature_defs}
+            for st in list(self._stats_by_name.values()):
+                self._stats_by_name.setdefault(st.name, st)
+                alias = str(st.name).lower().replace(" ", "_")
+                self._stats_by_name.setdefault(alias, st)
 
             # Asset loading needs ``unit_extra``/``creature_extra`` to bake unit
             # sprites, so perform it after the definitions are available.

--- a/loaders/hero_loader.py
+++ b/loaders/hero_loader.py
@@ -29,10 +29,12 @@ def _parse_army(items: List[Any]) -> List[Tuple[str, int]]:
             unit = entry.get("unit") or entry.get("id")
             if not unit:
                 continue
+            unit = str(unit).lower().replace(" ", "_")
             count = int(entry.get("count", 1))
             army.append((unit, count))
         elif isinstance(entry, str):
-            army.append((entry, 1))
+            unit = str(entry).lower().replace(" ", "_")
+            army.append((unit, 1))
     return army
 
 
@@ -69,6 +71,13 @@ def load_heroes(ctx: Context, manifest: str = "units/heroes.json") -> Dict[str, 
         stats = merged.get("stats", {})
         overworld = dict(merged.get("overworld", stats.get("overworld", {})))
         combat = dict(merged.get("combat", stats.get("combat", {})))
+        portrait = (
+            merged.get("hero_portrait")
+            or merged.get("portrait")
+            or merged.get("PortraitSprite")
+        )
+        overworld_sprite = merged.get("overworld_sprite") or merged.get("OverWorldSprite")
+        battlefield_sprite = merged.get("battlefield_sprite") or merged.get("BattlefieldSprite")
         hero = HeroDef(
             id=merged["id"],
             name=merged.get("name", merged["id"]),
@@ -78,9 +87,9 @@ def load_heroes(ctx: Context, manifest: str = "units/heroes.json") -> Dict[str, 
             starting_army=_parse_army(merged.get("starting_army", [])),
             starting_skills=[dict(s) for s in merged.get("starting_skills", [])],
             known_spells=list(merged.get("known_spells", [])),
-            portrait=merged.get("PortraitSprite"),
-            overworld_sprite=merged.get("OverWorldSprite"),
-            battlefield_sprite=merged.get("BattlefieldSprite"),
+            portrait=portrait,
+            overworld_sprite=overworld_sprite,
+            battlefield_sprite=battlefield_sprite,
         )
         heroes[hero.id] = hero
     return heroes

--- a/tests/test_hero_loader.py
+++ b/tests/test_hero_loader.py
@@ -10,4 +10,4 @@ def test_hero_loader_parses_manifest():
     assert "scarletia_aurianne" in heroes
     aurianne = heroes["scarletia_aurianne"]
     assert aurianne.faction == "red_knights"
-    assert any(u == "Swordsman" for u, _ in aurianne.starting_army)
+    assert any(u == "swordsman" for u, _ in aurianne.starting_army)


### PR DESCRIPTION
## Summary
- Canonicalize unit identifiers when parsing hero starting armies
- Accept portrait and sprite field variants when loading heroes
- Map UnitStats display-name aliases for more robust stat lookups
- Remove trailing commas from heroes manifest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b05cc651bc83219c43d488c21751f0