### PR TITLE
Allow recruiting units by ID or name

### DIFF
--- a/core/entities.py
+++ b/core/entities.py
@@ -734,7 +734,10 @@ def _load_stats(manifest: str, section: str) -> Dict[str, UnitStats]:
     base = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets"))
     ctx = Context(base, [""])
     stats_map, _ = load_units(ctx, manifest, section=section)
-    return {st.name: st for st in stats_map.values()}
+
+    out = {uid: st for uid, st in stats_map.items()}
+    out.update({st.name: st for st in stats_map.values()})
+    return out
 
 
 # Units that can be recruited in towns
@@ -764,7 +767,7 @@ REEF_SERPENT_STATS = CREATURE_STATS.get("reef_serpent")
 
 def create_random_enemy_army() -> List[Unit]:
     """Generate a random selection of enemy units for the world map."""
-    stats_choices = list(RECRUITABLE_UNITS.values())
+    stats_choices = list({id(st): st for st in RECRUITABLE_UNITS.values()}.values())
     num_stacks = random.randint(1, 3)
     units: List[Unit] = []
     for _ in range(num_stacks):


### PR DESCRIPTION
## Summary
- Load unit stats into a mapping keyed by both unit IDs and their names
- Use the combined mapping throughout the game so buildings can recruit using lowercase IDs
- Deduplicate recruitable unit lists when generating random armies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b05eb45f7883218809ecc37a32c270