### PR TITLE
Avoid combat with player's garrisons

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -2100,7 +2100,7 @@ class Game:
         if tile.building and not tile.building.passable:
             # Interact with the building without moving onto its tile
             self.hero.ap -= step_cost
-            if tile.building.garrison:
+            if tile.building.garrison and tile.building.owner != 0:
                 enemy = EnemyHero(nx, ny, tile.building.garrison)
                 engaged = self.combat_with_enemy_hero(enemy, initiated_by="hero")
                 if not engaged:
@@ -2289,7 +2289,7 @@ class Game:
                     self.refresh_army_list()
                     return
                 self.refresh_army_list()
-        if tile.building and tile.building.garrison:
+        if tile.building and tile.building.garrison and tile.building.owner != 0:
             enemy = EnemyHero(nx, ny, tile.building.garrison)
             engaged = self.combat_with_enemy_hero(enemy, initiated_by="hero")
             if not engaged:

--- a/tests/test_building_interaction.py
+++ b/tests/test_building_interaction.py
@@ -223,3 +223,24 @@ def test_try_move_into_owned_town_skips_interact(monkeypatch, pygame_stub):
     assert game.hero.ap == 1
     assert (game.hero.x, game.hero.y) == (0, 0)
 
+
+def test_try_move_into_owned_town_with_garrison_no_combat(monkeypatch, pygame_stub):
+    game, town, Game, constants = setup_game_with_town(monkeypatch, pygame_stub)
+    town.owner = 0
+    town.garrison = [Unit(SWORDSMAN_STATS, 1, 'hero')]
+    called = {}
+
+    def fake_combat(self, enemy, initiated_by='hero'):
+        called.setdefault('combat', True)
+        return True
+
+    monkeypatch.setattr(Game, 'combat_with_enemy_hero', fake_combat)
+    monkeypatch.setattr(
+        Game,
+        'open_town',
+        lambda self, t, army=None, town_pos=None: called.setdefault('open', True),
+    )
+    game.try_move_hero(1, 0)
+    assert 'combat' not in called
+    assert called.get('open') is True
+


### PR DESCRIPTION
## Summary
- Skip combat when interacting with buildings whose garrison belongs to the player
- Add regression test ensuring owned towns with garrisons open without combat

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0649f2c2083219c53911a5301a4a7