### PR TITLE
Allow unit lookup by id or name

### DIFF
--- a/core/entities.py
+++ b/core/entities.py
@@ -736,7 +736,7 @@ def _load_stats(manifest: str, section: str) -> Dict[str, UnitStats]:
     stats_map, _ = load_units(ctx, manifest, section=section)
 
     out = {uid: st for uid, st in stats_map.items()}
-    out.update({st.name: st for st in stats_map.values()})
+    out.update({st.name: st for uid, st in stats_map.items()})
     return out
 
 

--- a/tests/test_actor_icon_stability.py
+++ b/tests/test_actor_icon_stability.py
@@ -2,7 +2,9 @@ import pygame
 import constants
 from render.world_renderer import WorldRenderer
 from core.world import WorldMap
-from core.entities import Army, Unit, SWORDSMAN_STATS
+from core.entities import Army, Unit, RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 class DummyCarrier:
     def __init__(self, x, y, colour):
         self.x = x

--- a/tests/test_ai_fow.py
+++ b/tests/test_ai_fow.py
@@ -6,7 +6,7 @@ from core.entities import EnemyHero, Unit, Hero
 from tests.unit_stats import get_unit_stats
 from core.buildings import Town, Building
 
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
 
 
 def _basic_world():

--- a/tests/test_army_actions.py
+++ b/tests/test_army_actions.py
@@ -1,6 +1,9 @@
 import sys
 import sys
 import types
+from core.entities import RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def setup_game(monkeypatch, pygame_stub):
@@ -19,7 +22,7 @@ def setup_game(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
 
     from core.world import WorldMap
-    from core.entities import Hero, Army, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Army, Unit
     from core.game import Game
     from loaders.biomes import BiomeCatalog
     from loaders.core import Context

--- a/tests/test_army_serialization.py
+++ b/tests/test_army_serialization.py
@@ -5,8 +5,10 @@ pygame_stub = types.SimpleNamespace()
 sys.modules.setdefault("pygame", pygame_stub)
 
 from core.game import Game
-from core.entities import Hero, Army, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Army, Unit, RECRUITABLE_UNITS
 from core.world import WorldMap
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_armies_persist_across_save_load(tmp_path):

--- a/tests/test_auto_mode_hotkey.py
+++ b/tests/test_auto_mode_hotkey.py
@@ -4,7 +4,9 @@ import pygame
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
-from core.entities import Unit, SWORDSMAN_STATS
+from core.entities import Unit, RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 pygame.init()
 

--- a/tests/test_auto_resolve_preview.py
+++ b/tests/test_auto_resolve_preview.py
@@ -5,7 +5,8 @@ import copy
 
 
 def test_preview_returns_losses(monkeypatch):
-    from core.entities import Unit, SWORDSMAN_STATS
+    from core.entities import Unit, RECRUITABLE_UNITS
+    SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
     import core.auto_resolve as ar
 
     def fake_sim(hero_units, enemy_units):
@@ -134,7 +135,8 @@ def test_prompt_displays_losses(monkeypatch, pygame_stub):
     import core.game as game_mod
     monkeypatch.setattr(theme, "pygame", pg)
     monkeypatch.setattr(game_mod, "pygame", pg)
-    from core.entities import Unit, SWORDSMAN_STATS, Hero
+    from core.entities import Unit, RECRUITABLE_UNITS, Hero
+    SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
     Game = game_mod.Game
     import core.auto_resolve as ar
     from ui import dialogs

--- a/tests/test_boat_exchange.py
+++ b/tests/test_boat_exchange.py
@@ -18,7 +18,7 @@ def test_boat_garrison_exchange(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.entities import Hero, Unit, Boat
     from tests.unit_stats import get_unit_stats
-    SWORDSMAN_STATS = get_unit_stats("Swordsman")
+    SWORDSMAN_STATS = get_unit_stats("swordsman")
     from ui.boat_screen import BoatScreen
 
     hero = Hero(0, 0, [Unit(SWORDSMAN_STATS, 1, "hero")])

--- a/tests/test_building_economy.py
+++ b/tests/test_building_economy.py
@@ -6,7 +6,9 @@ import importlib, sys
 
 from core.buildings import create_building
 from core.world import WorldMap
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def _create_game_with_mine():

--- a/tests/test_building_interaction.py
+++ b/tests/test_building_interaction.py
@@ -1,6 +1,8 @@
 import sys
 import types
-from core.entities import Unit, SWORDSMAN_STATS
+from core.entities import Unit, RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def setup_game_with_building(monkeypatch, pygame_stub):
@@ -18,7 +20,7 @@ def setup_game_with_building(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     monkeypatch.setitem(sys.modules, "pygame", pg)
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
     from core.buildings import create_building
     from core.game import Game
     import constants
@@ -69,7 +71,7 @@ def setup_game_with_town(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.image", pg.image)
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
     from core.buildings import Town
     from core.game import Game
     import constants

--- a/tests/test_building_upgrade.py
+++ b/tests/test_building_upgrade.py
@@ -5,11 +5,13 @@ pygame_stub = types.SimpleNamespace()
 sys.modules.setdefault("pygame", pygame_stub)
 
 from core.buildings import Building
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
 from core import economy
 from core.game import Game
 from core.world import WorldMap
 from state.game_state import GameState
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_building_upgrade_updates_income_and_resources():

--- a/tests/test_caravan.py
+++ b/tests/test_caravan.py
@@ -1,11 +1,14 @@
 import types
 import sys
+from core.entities import RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_caravan_travel_and_arrival():
     from core.world import WorldMap
     from core.buildings import Town
-    from core.entities import Unit, SWORDSMAN_STATS
+    from core.entities import Unit
     from state.game_state import GameState
 
     world = WorldMap(width=5, height=1, biome_weights={"scarletia_echo_plain": 1.0}, num_obstacles=0, num_treasures=0, num_enemies=0)
@@ -40,7 +43,7 @@ def test_townscreen_launches_caravan(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
 
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
     from core.buildings import Town
     from ui.town_screen import TownScreen
 
@@ -78,7 +81,7 @@ def test_townscreen_selects_and_sends_queue(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
 
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
     from core.buildings import Town
     from ui.town_screen import TownScreen
 
@@ -107,7 +110,7 @@ def test_townscreen_selects_and_sends_queue(monkeypatch, pygame_stub):
 def test_world_map_advances_caravans():
     from core.world import WorldMap
     from core.buildings import Town
-    from core.entities import Unit, SWORDSMAN_STATS
+    from core.entities import Unit
 
     world = WorldMap(width=3, height=1, biome_weights={"scarletia_echo_plain": 1.0}, num_obstacles=0, num_treasures=0, num_enemies=0)
     t1, t2 = Town("A"), Town("B")
@@ -124,7 +127,7 @@ def test_world_map_advances_caravans():
 def test_auto_caravan_to_nearest_ally():
     from core.world import WorldMap
     from core.buildings import Town
-    from core.entities import Unit, SWORDSMAN_STATS, Hero
+    from core.entities import Unit, Hero
 
     world = WorldMap(width=5, height=1, biome_weights={"scarletia_echo_plain": 1.0}, num_obstacles=0, num_treasures=0, num_enemies=0)
     t1, t2 = Town("A"), Town("B")
@@ -160,7 +163,7 @@ def test_townscreen_cancel_and_intercept(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
 
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
     from core.buildings import Town
     from ui.town_screen import TownScreen
 

--- a/tests/test_combat_ai.py
+++ b/tests/test_combat_ai.py
@@ -7,10 +7,10 @@ os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 from core.entities import Unit
 from tests.unit_stats import get_unit_stats
 
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
-DRAGON_STATS = get_unit_stats("Dragon")
-MAGE_STATS = get_unit_stats("Mage")
-ARCHER_STATS = get_unit_stats("Archer")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
+DRAGON_STATS = get_unit_stats("dragon")
+MAGE_STATS = get_unit_stats("mage")
+ARCHER_STATS = get_unit_stats("archer")
 from core.combat_ai import ai_take_turn, allied_ai_turn, select_spell, _a_star
 import constants
 

--- a/tests/test_combat_cleanup.py
+++ b/tests/test_combat_cleanup.py
@@ -1,7 +1,9 @@
 import pygame
 import pytest
 
-from core.entities import Unit, SWORDSMAN_STATS
+from core.entities import Unit, RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 import audio
 import core.combat_render as combat_render
 pytestmark = pytest.mark.combat

--- a/tests/test_combat_show_stats_screen.py
+++ b/tests/test_combat_show_stats_screen.py
@@ -4,8 +4,10 @@ import pygame
 import theme
 import pytest
 
-from core.entities import Unit, SWORDSMAN_STATS
+from core.entities import Unit, RECRUITABLE_UNITS
 from ui import combat_summary
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 pytestmark = pytest.mark.combat

--- a/tests/test_encounter_priority.py
+++ b/tests/test_encounter_priority.py
@@ -1,5 +1,10 @@
 import types
 import sys
+from core.entities import RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
+
+
 def setup_basic_game(monkeypatch, pygame_stub):
     pg = pygame_stub(
         image=types.SimpleNamespace(load=lambda path: None),
@@ -14,7 +19,7 @@ def setup_basic_game(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
 
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
     from core.game import Game
     from loaders.biomes import BiomeCatalog
     from loaders.core import Context

--- a/tests/test_end_conditions.py
+++ b/tests/test_end_conditions.py
@@ -4,7 +4,7 @@ from core.world import WorldMap
 from core.entities import Hero, Unit
 from tests.unit_stats import get_unit_stats
 
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
 from core.buildings import Town
 from state.game_state import GameState
 from core import economy

--- a/tests/test_enemy_ai.py
+++ b/tests/test_enemy_ai.py
@@ -10,7 +10,7 @@ from core.ai.faction_ai import FactionAI
 from core.entities import Hero, EnemyHero, Unit
 from tests.unit_stats import get_unit_stats
 
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
 from core.buildings import Town
 from state.game_state import GameState
 from core import economy

--- a/tests/test_enemy_step_performance.py
+++ b/tests/test_enemy_step_performance.py
@@ -2,9 +2,11 @@ import time
 import pytest
 
 from core.world import WorldMap
-from core.entities import Hero, EnemyHero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, EnemyHero, Unit, RECRUITABLE_UNITS
 from core.game import Game
 import core.exploration_ai as exploration_ai
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def _make_world(width, height):

--- a/tests/test_faction_skill_catalog.py
+++ b/tests/test_faction_skill_catalog.py
@@ -4,7 +4,7 @@ import core.entities as entities
 from core.entities import Hero, Unit
 from tests.unit_stats import get_unit_stats
 
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
 from core.faction import FactionDef
 from ui.inventory_screen import InventoryScreen
 

--- a/tests/test_factions.py
+++ b/tests/test_factions.py
@@ -4,7 +4,9 @@ import pygame
 
 from loaders.core import Context
 from loaders.faction_loader import load_factions
-from core.entities import Unit, SWORDSMAN_STATS
+from core.entities import Unit, RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def _ctx():

--- a/tests/test_hero_serialization.py
+++ b/tests/test_hero_serialization.py
@@ -8,11 +8,13 @@ from core.game import Game
 from core.entities import (
     Hero,
     Unit,
-    SWORDSMAN_STATS,
+    RECRUITABLE_UNITS,
     Item,
     EquipmentSlot,
     HeroStats,
 )
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 from core.world import WorldMap
 
 

--- a/tests/test_inventory_drag_double_click.py
+++ b/tests/test_inventory_drag_double_click.py
@@ -1,8 +1,10 @@
 import types
 import pygame
 
-from core.entities import Hero, Unit, SWORDSMAN_STATS, Item, EquipmentSlot, HeroStats
+from core.entities import Hero, Unit, RECRUITABLE_UNITS, Item, EquipmentSlot, HeroStats
 from ui.inventory_screen import InventoryScreen
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 class DummySurface:

--- a/tests/test_inventory_grid_bounds.py
+++ b/tests/test_inventory_grid_bounds.py
@@ -2,8 +2,10 @@ import types
 import pytest
 import pygame
 import theme
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
 from ui.inventory_screen import InventoryScreen
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 class DummySurface:

--- a/tests/test_inventory_screen_draw_background.py
+++ b/tests/test_inventory_screen_draw_background.py
@@ -1,6 +1,8 @@
 import theme
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
 from ui.inventory_screen import InventoryScreen
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 class DummySurface:

--- a/tests/test_inventory_skill_layout.py
+++ b/tests/test_inventory_skill_layout.py
@@ -2,8 +2,10 @@ import types
 
 import pygame
 
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
 from ui.inventory_screen import InventoryScreen
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 class DummySurface:

--- a/tests/test_luck_log.py
+++ b/tests/test_luck_log.py
@@ -4,8 +4,10 @@ from dataclasses import replace
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
-from core.entities import Unit, SWORDSMAN_STATS
+from core.entities import Unit, RECRUITABLE_UNITS
 import pygame
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_positive_luck_logs(monkeypatch, simple_combat):

--- a/tests/test_min_range_and_retaliation.py
+++ b/tests/test_min_range_and_retaliation.py
@@ -4,7 +4,10 @@ os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 
 from dataclasses import replace
 
-from core.entities import Unit, ARCHER_STATS, SWORDSMAN_STATS
+from core.entities import Unit, RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
+ARCHER_STATS = RECRUITABLE_UNITS["archer"]
 
 
 def test_archer_min_range_excludes_adjacent(simple_combat):

--- a/tests/test_morale.py
+++ b/tests/test_morale.py
@@ -4,8 +4,10 @@ from dataclasses import replace
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
-from core.entities import Unit, SWORDSMAN_STATS
+from core.entities import Unit, RECRUITABLE_UNITS
 import pygame
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_positive_morale_grants_extra_turn(monkeypatch, simple_combat):

--- a/tests/test_movement_cost.py
+++ b/tests/test_movement_cost.py
@@ -1,6 +1,9 @@
 import sys
 import types
 import pytest
+from core.entities import RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def setup_game(monkeypatch, pygame_stub):
@@ -18,7 +21,7 @@ def setup_game(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.image", pg.image)
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
     from core.game import Game
     from loaders.biomes import BiomeCatalog
     from loaders.core import Context

--- a/tests/test_multi_terrain_movement.py
+++ b/tests/test_multi_terrain_movement.py
@@ -1,6 +1,9 @@
 import sys
 import types
 import pytest
+from core.entities import RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def setup_game(monkeypatch, pygame_stub):
@@ -18,7 +21,7 @@ def setup_game(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.image", pg.image)
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit
     from core.game import Game
     from loaders.biomes import BiomeCatalog, Biome
     from loaders.core import Context

--- a/tests/test_ocean_buildings.py
+++ b/tests/test_ocean_buildings.py
@@ -2,7 +2,7 @@ from core.buildings import create_building
 from core.entities import Hero, Unit
 from tests.unit_stats import get_unit_stats
 
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
 from core.vision import compute_vision
 from core.world import WorldMap
 import constants

--- a/tests/test_pathfinding_enemies.py
+++ b/tests/test_pathfinding_enemies.py
@@ -1,8 +1,10 @@
 from core.world import WorldMap
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
 from core.game import Game
 import constants
 import types
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def _make_world(width, height):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -12,7 +12,7 @@ from tests.unit_stats import get_unit_stats
 from core.buildings import create_building
 from core.game import Game
 
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
 
 def test_place_resources_and_collect(rng, monkeypatch):
     monkeypatch.setattr("random.shuffle", rng.shuffle)

--- a/tests/test_save_load_roundtrip.py
+++ b/tests/test_save_load_roundtrip.py
@@ -9,12 +9,14 @@ from core.game import Game
 from core import auto_resolve
 from core.entities import (
     Unit,
-    SWORDSMAN_STATS,
+    RECRUITABLE_UNITS,
     Hero,
     Item,
     EquipmentSlot,
     HeroStats,
 )
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 from core.world import WorldMap
 from core.buildings import create_building
 

--- a/tests/test_save_upgrade.py
+++ b/tests/test_save_upgrade.py
@@ -6,8 +6,10 @@ pygame_stub = types.SimpleNamespace()
 sys.modules.setdefault("pygame", pygame_stub)
 
 from core.game import Game, SAVE_FORMAT_VERSION
-from core.entities import Unit, SWORDSMAN_STATS, Hero
+from core.entities import Unit, RECRUITABLE_UNITS, Hero
 from core.world import WorldMap
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_load_legacy_save(tmp_path):

--- a/tests/test_show_inventory_sheet_list.py
+++ b/tests/test_show_inventory_sheet_list.py
@@ -1,9 +1,11 @@
 import pygame
 from types import SimpleNamespace
 
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
 from core.game import Game
 from ui.inventory_screen import InventoryScreen
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_show_inventory_handles_list_sheet(monkeypatch):

--- a/tests/test_spawn_army.py
+++ b/tests/test_spawn_army.py
@@ -24,7 +24,7 @@ def test_drag_from_garrison_creates_army(monkeypatch, pygame_stub):
     from core.world import WorldMap
     from core.entities import Hero, Unit
     from tests.unit_stats import get_unit_stats
-    SWORDSMAN_STATS = get_unit_stats("Swordsman")
+    SWORDSMAN_STATS = get_unit_stats("swordsman")
     from core.buildings import Town
     from ui.town_screen import TownScreen
 
@@ -77,8 +77,8 @@ def test_hero_army_exchange_merge_delete(monkeypatch, pygame_stub):
     from core.world import WorldMap
     from core.entities import Hero, Army, Unit
     from tests.unit_stats import get_unit_stats
-    SWORDSMAN_STATS = get_unit_stats("Swordsman")
-    ARCHER_STATS = get_unit_stats("Archer")
+    SWORDSMAN_STATS = get_unit_stats("swordsman")
+    ARCHER_STATS = get_unit_stats("archer")
     from core.game import Game
     from ui.hero_exchange_screen import HeroExchangeScreen
 
@@ -152,9 +152,11 @@ def test_army_reintegrated_removes_ghost(monkeypatch, pygame_stub):
     monkeypatch.setitem(sys.modules, "pygame.draw", pg.draw)
     monkeypatch.setitem(sys.modules, "pygame.transform", pg.transform)
     from core.world import WorldMap
-    from core.entities import Hero, Unit, SWORDSMAN_STATS
+    from core.entities import Hero, Unit, RECRUITABLE_UNITS
     from core.buildings import Town
     from ui.town_screen import TownScreen
+
+    SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
     game = types.SimpleNamespace()
     wm = WorldMap(

--- a/tests/test_spells.py
+++ b/tests/test_spells.py
@@ -8,12 +8,12 @@ from dataclasses import replace
 from core.entities import Unit, apply_defence
 from tests.unit_stats import get_unit_stats
 
-ARCHER_STATS = get_unit_stats("Archer")
-CAVALRY_STATS = get_unit_stats("Cavalry")
-DRAGON_STATS = get_unit_stats("Dragon")
-MAGE_STATS = get_unit_stats("Mage")
-PRIEST_STATS = get_unit_stats("Priest")
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
+ARCHER_STATS = get_unit_stats("archer")
+CAVALRY_STATS = get_unit_stats("cavalry")
+DRAGON_STATS = get_unit_stats("dragon")
+MAGE_STATS = get_unit_stats("mage")
+PRIEST_STATS = get_unit_stats("priest")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
 
 
 def test_mage_action_panel_has_spell_not_ranged(simple_combat):

--- a/tests/test_stats_army_grid_bounds.py
+++ b/tests/test_stats_army_grid_bounds.py
@@ -3,8 +3,10 @@ import pytest
 import pygame
 import theme
 from loaders import icon_loader as IconLoader
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
 from ui.inventory_screen import InventoryScreen
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 class DummySurface:

--- a/tests/test_town_garrison.py
+++ b/tests/test_town_garrison.py
@@ -4,7 +4,9 @@ os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 import pygame
 
 from core.buildings import Town
-from core.entities import Hero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, Unit, RECRUITABLE_UNITS
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_garrison_transfer():

--- a/tests/test_units_abilities.py
+++ b/tests/test_units_abilities.py
@@ -6,7 +6,7 @@ os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 from dataclasses import replace
 from core.entities import (
     Unit,
-    SWORDSMAN_STATS,
+    RECRUITABLE_UNITS,
     CAVALRY_STATS,
     DRAGON_STATS,
     PRIEST_STATS,
@@ -15,6 +15,8 @@ from core.entities import (
 from core import combat_ai
 import constants
 from core import combat
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 
 def test_unit_stats_have_abilities():

--- a/tests/test_unknown_unit_load.py
+++ b/tests/test_unknown_unit_load.py
@@ -10,7 +10,7 @@ from core.entities import Hero, Unit
 from tests.unit_stats import get_unit_stats
 from core.world import WorldMap
 
-SWORDSMAN_STATS = get_unit_stats("Swordsman")
+SWORDSMAN_STATS = get_unit_stats("swordsman")
 
 
 def test_load_game_with_unknown_unit(tmp_path):

--- a/tests/test_world_ai.py
+++ b/tests/test_world_ai.py
@@ -1,5 +1,5 @@
 from core.world import WorldMap
-from core.entities import Hero, EnemyHero, Unit, SWORDSMAN_STATS
+from core.entities import Hero, EnemyHero, Unit, RECRUITABLE_UNITS
 from core.buildings import Town, Building
 from core.game import Game
 import core.exploration_ai as exploration_ai
@@ -8,6 +8,8 @@ from core.ai.creature_ai import GuardianAI, RoamingAI
 import pytest
 import random
 from pathlib import Path
+
+SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
 @pytest.fixture(scope="module")
 def _marine_world_base() -> WorldMap:

--- a/ui/town_screen.py
+++ b/ui/town_screen.py
@@ -11,8 +11,6 @@ from core.entities import (
     HeroStats,
     Unit,
     UnitStats,
-    SWORDSMAN_STATS,
-    ARCHER_STATS,
     RECRUITABLE_UNITS,
     Army,
 )
@@ -157,13 +155,13 @@ class TownScreen:
                 "name": "Bran",
                 "cost": 1500,
                 "stats": HeroStats(1, 1, 0, 0, 0, 0, 0, 0, 0),
-                "army": [Unit(SWORDSMAN_STATS, 10, "hero")],
+                "army": [Unit(RECRUITABLE_UNITS["swordsman"], 10, "hero")],
             },
             {
                 "name": "Luna",
                 "cost": 2500,
                 "stats": HeroStats(0, 0, 1, 1, 0, 0, 0, 0, 0),
-                "army": [Unit(ARCHER_STATS, 10, "hero")],
+                "army": [Unit(RECRUITABLE_UNITS["archer"], 10, "hero")],
             },
         ]
         # Sélection des unités à envoyer en caravane


### PR DESCRIPTION
## Summary
- support retrieving unit stats using both ids and display names
- simplify recruitment callers to use shared mapping
- update tests to obtain stats via unit ids

## Testing
- `pre-commit run --files core/entities.py ui/town_screen.py tests/test_actor_icon_stability.py tests/test_ai_fow.py tests/test_army_actions.py tests/test_army_serialization.py tests/test_auto_mode_hotkey.py tests/test_auto_resolve_preview.py tests/test_boat_exchange.py tests/test_building_economy.py tests/test_building_interaction.py tests/test_building_upgrade.py tests/test_caravan.py tests/test_combat_ai.py tests/test_combat_cleanup.py tests/test_combat_show_stats_screen.py tests/test_encounter_priority.py tests/test_end_conditions.py tests/test_enemy_ai.py tests/test_enemy_step_performance.py tests/test_faction_skill_catalog.py tests/test_factions.py tests/test_hero_serialization.py tests/test_inventory_drag_double_click.py tests/test_inventory_grid_bounds.py tests/test_inventory_screen_draw_background.py tests/test_inventory_skill_layout.py tests/test_luck_log.py tests/test_min_range_and_retaliation.py tests/test_morale.py tests/test_movement_cost.py tests/test_multi_terrain_movement.py tests/test_ocean_buildings.py tests/test_pathfinding_enemies.py tests/test_resources.py tests/test_save_load_roundtrip.py tests/test_save_upgrade.py tests/test_show_inventory_sheet_list.py tests/test_spawn_army.py tests/test_spells.py tests/test_stats_army_grid_bounds.py tests/test_town_garrison.py tests/test_units_abilities.py tests/test_unknown_unit_load.py tests/test_world_ai.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b06bd1ccdc8321936c53ccb85bc5d1