### PR TITLE
Load extra unit images and index by display names

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -802,14 +802,14 @@ class Game:
         self.artifacts_manifest = load_artifact_manifest(repo_root, self.assets)
 
         # Load unit and creature sprites using metadata from the loaders
-        image_files: Set[str] = {
+        images: Set[str] = {
             info.get("image")
             for extras in (self.unit_extra, self.creature_extra)
             for info in extras.values()
             if info.get("image")
         }
-        if image_files:
-            self.load_additional_assets(list(image_files))
+        if images:
+            self.load_additional_assets(list(images))
 
         self.unit_shadow_baked = {}
         for extras in (self.unit_extra, self.creature_extra):
@@ -825,6 +825,10 @@ class Game:
                     smooth=True,
                 )
                 self.assets[uid] = surf
+                name = info.get("name")
+                if name:
+                    self.assets[name] = surf
+                    self.assets[name.lower().replace(" ", "_")] = surf
                 self.unit_shadow_baked[uid] = bool(info.get("shadow_baked", False))
 
         # Load hero portraits and map icons declared in assets/units/heroes.json


### PR DESCRIPTION
## Summary
- Preload all unit and creature images and load missing assets beforehand
- Allow unit assets to be retrieved by id, display name or normalised name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b076871b748321923c21686a6e9829