### PR TITLE
Add Red Knights town manifest and schema test

### DIFF
--- a/assets/towns/towns_red_knights.json
+++ b/assets/towns/towns_red_knights.json
@@ -1,0 +1,26 @@
+{
+  "size": [1920, 1080],
+  "layers": [
+    {"id": "background", "image": "towns/red_knights/background.png"},
+    {"id": "midground", "image": "towns/red_knights/midground.png"},
+    {"id": "foreground", "image": "towns/red_knights/foreground.png"}
+  ],
+  "buildings": [
+    {
+      "id": "town_hall",
+      "layer": "midground",
+      "pos": [640, 480],
+      "states": {"default": "towns/red_knights/buildings/town_hall.png"},
+      "hotspot": [630, 470, 680, 520],
+      "tooltip": "Town Hall"
+    },
+    {
+      "id": "blacksmith",
+      "layer": "midground",
+      "pos": [800, 500],
+      "states": {"default": "towns/red_knights/buildings/blacksmith.png"},
+      "hotspot": [790, 490, 840, 540],
+      "tooltip": "Blacksmith"
+    }
+  ]
+}

--- a/tests/test_towns_manifest.py
+++ b/tests/test_towns_manifest.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+
+def test_towns_red_knights_manifest_schema() -> None:
+    path = Path("assets/towns/towns_red_knights.json")
+    data = json.loads(path.read_text())
+
+    assert data["size"] == [1920, 1080]
+
+    layers = data["layers"]
+    assert isinstance(layers, list) and layers
+    layer_ids = set()
+    for layer in layers:
+        assert "id" in layer and "image" in layer
+        assert isinstance(layer["id"], str)
+        assert isinstance(layer["image"], str)
+        layer_ids.add(layer["id"])
+
+    buildings = data["buildings"]
+    assert isinstance(buildings, list)
+    for b in buildings:
+        for key in ["id", "layer", "pos", "states", "hotspot", "tooltip"]:
+            assert key in b
+        assert b["layer"] in layer_ids
+        assert isinstance(b["pos"], list) and len(b["pos"]) == 2
+        assert all(isinstance(v, int) for v in b["pos"])
+        assert isinstance(b["states"], dict) and b["states"]
+        assert all(isinstance(v, str) for v in b["states"].values())
+        assert isinstance(b["hotspot"], list) and len(b["hotspot"]) == 4
+        assert all(isinstance(v, int) for v in b["hotspot"])
+        assert isinstance(b["tooltip"], str)


### PR DESCRIPTION
## Summary
- add Red Knights town manifest with layers and buildings
- validate town manifest structure with a dedicated test

## Testing
- `pre-commit run --files assets/towns/towns_red_knights.json tests/test_towns_manifest.py`
- `pytest tests/test_towns_manifest.py`


------
https://chatgpt.com/codex/tasks/task_e_68b08da86e4883219f499f8b1414ec06