### PR TITLE
Add loader for town scene manifests

### DIFF
--- a/loaders/town_scene_loader.py
+++ b/loaders/town_scene_loader.py
@@ -1,0 +1,114 @@
+"""Loader for town scene manifests.
+
+This module provides a small helper to read town scene definitions from a
+JSON manifest. Each manifest describes the scene size, ordered image layers
+and buildings with their possible state images. All referenced images are
+preloaded via the provided :class:`~loaders.asset_manager.AssetManager`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, Any
+import os
+
+from .core import Context, read_json
+
+
+@dataclass
+class TownLayer:
+    """Represents a single visual layer within a town scene."""
+
+    id: str
+    image: str
+
+
+@dataclass
+class TownBuilding:
+    """Definition of a building displayed within the town scene."""
+
+    id: str
+    layer: str
+    pos: Tuple[int, int]
+    states: Dict[str, str]
+    hotspot: Tuple[int, int, int, int] | None = None
+    tooltip: str = ""
+
+
+@dataclass
+class TownScene:
+    """Container for a fully parsed town scene."""
+
+    size: Tuple[int, int]
+    layers: List[TownLayer] = field(default_factory=list)
+    buildings: List[TownBuilding] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+
+def load_town_scene(path: str, assets: Any | None = None) -> TownScene:
+    """Load a :class:`TownScene` definition from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the JSON manifest describing the town scene.
+    assets:
+        Optional asset manager used to preload all referenced images.
+
+    Returns
+    -------
+    TownScene
+        Parsed town scene with layers and buildings.
+    """
+
+    ctx = Context(repo_root=os.path.dirname(path), search_paths=[""], asset_loader=None)
+    try:
+        data = read_json(ctx, os.path.basename(path))
+    except Exception:
+        return TownScene(size=(0, 0))
+
+    size = tuple(data.get("size", [0, 0]))
+
+    layers: List[TownLayer] = []
+    for entry in data.get("layers", []):
+        image = entry.get("image", "")
+        if assets is not None and image:
+            try:
+                assets.get(image)
+            except Exception:
+                pass
+        layers.append(TownLayer(id=entry.get("id", ""), image=image))
+
+    buildings: List[TownBuilding] = []
+    for entry in data.get("buildings", []):
+        states = dict(entry.get("states", {}))
+        if assets is not None:
+            for img in states.values():
+                try:
+                    assets.get(img)
+                except Exception:
+                    pass
+        pos_list = entry.get("pos", [0, 0])
+        pos = (int(pos_list[0]), int(pos_list[1])) if len(pos_list) >= 2 else (0, 0)
+        hotspot_list = entry.get("hotspot")
+        hotspot = tuple(hotspot_list) if hotspot_list else None
+        buildings.append(
+            TownBuilding(
+                id=entry.get("id", ""),
+                layer=entry.get("layer", ""),
+                pos=pos,
+                states=states,
+                hotspot=hotspot,
+                tooltip=entry.get("tooltip", ""),
+            )
+        )
+
+    return TownScene(size=size, layers=layers, buildings=buildings)
+
+
+__all__ = [
+    "TownLayer",
+    "TownBuilding",
+    "TownScene",
+    "load_town_scene",
+]

--- a/tests/test_town_scene_loader.py
+++ b/tests/test_town_scene_loader.py
@@ -1,0 +1,37 @@
+import json
+
+from loaders.town_scene_loader import load_town_scene
+
+
+def test_load_town_scene_loads_assets(tmp_path):
+    manifest = {
+        "size": [100, 80],
+        "layers": [{"id": "bg", "image": "background.png"}],
+        "buildings": [
+            {
+                "id": "b1",
+                "layer": "bg",
+                "pos": [10, 20],
+                "states": {
+                    "built": "b1.png",
+                    "upgraded": "b1_up.png",
+                },
+            }
+        ],
+    }
+    path = tmp_path / "scene.json"
+    path.write_text(json.dumps(manifest))
+
+    calls = []
+
+    class DummyAssets:
+        def get(self, key, default=None):
+            calls.append(key)
+            return object()
+
+    scene = load_town_scene(str(path), DummyAssets())
+
+    assert scene.size == (100, 80)
+    assert [layer.id for layer in scene.layers] == ["bg"]
+    assert scene.buildings[0].states["built"] == "b1.png"
+    assert set(calls) == {"background.png", "b1.png", "b1_up.png"}


### PR DESCRIPTION
## Summary
- add `load_town_scene` to parse town scene JSON and preload assets
- define `TownScene`, `TownLayer`, and `TownBuilding` data classes
- test asset preloading during town scene loading

## Testing
- `pytest tests/test_town_scene_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b08f0c13e48321970207705bbbb0da