### PR TITLE
feat: add town scene preview

### DIFF
--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -157,11 +157,21 @@ class MainScreen:
             cb()
             mods = getattr(getattr(pygame, "key", None), "get_mods", lambda: 0)()
             if mods & getattr(pygame, "KMOD_CTRL", 0):
-                town = getattr(self.game, "_focused_town", None)
-                pos = getattr(self.game, "_focused_town_pos", None)
                 open_cb = getattr(self.game, "open_town", None)
-                if town and open_cb:
-                    open_cb(town, town_pos=pos)
+                if open_cb:
+                    path = os.path.join("assets", "towns", "towns_red_knights.json")
+                    town = getattr(self.game, "_focused_town", None)
+                    pos = getattr(self.game, "_focused_town_pos", None)
+                    try:
+                        if town:
+                            open_cb(town, town_pos=pos, scene_path=path)
+                        else:
+                            open_cb(scene_path=path)
+                    except TypeError:
+                        if town:
+                            open_cb(town, town_pos=pos)
+                        else:
+                            open_cb()
 
     def end_day(self) -> None:
         cb = getattr(self.game, "end_day", None)

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Minimal screen to render a town scene using :class:`TownSceneRenderer`."""
+
+import os
+from typing import Any
+
+import pygame
+import constants
+
+from loaders.town_scene_loader import TownScene
+from render.town_scene_renderer import TownSceneRenderer
+
+
+class TownSceneScreen:
+    """Display a static town scene.
+
+    Parameters
+    ----------
+    screen:
+        Target surface to draw onto.
+    scene:
+        Parsed scene definition.
+    assets:
+        Asset manager providing access to loaded images.
+    clock:
+        Optional pygame clock for regulating the loop.
+    """
+
+    def __init__(self, screen: pygame.Surface, scene: TownScene, assets: Any, clock: pygame.time.Clock | None = None) -> None:
+        self.screen = screen
+        self.clock = clock or pygame.time.Clock()
+        self.renderer = TownSceneRenderer(scene, assets)
+
+    def run(self) -> None:
+        running = True
+        fast_tests = os.environ.get("FG_FAST_TESTS") == "1"
+        while running:
+            events = pygame.event.get()
+            if not events and fast_tests:
+                break
+            for event in events:
+                if event.type == pygame.KEYDOWN and getattr(event, "key", None) == pygame.K_ESCAPE:
+                    running = False
+            self.renderer.draw(self.screen, {})
+            pygame.display.flip()
+            self.clock.tick(getattr(constants, "FPS", 60))
+
+
+__all__ = ["TownSceneScreen"]


### PR DESCRIPTION
## Summary
- preview town scenes via new TownSceneScreen using TownSceneRenderer
- allow Game.open_town to render optional town scene before opening town screen
- load default `towns_red_knights.json` when cycling towns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0939b49e48321a08433d061d9f377