### PR TITLE
Enable town scenic view and add manifest test

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -3243,12 +3243,22 @@ class Game:
     ) -> None:
         """Open a town management screen or selection overlay.
 
-        If ``scene_path`` is provided a scenic view defined by the JSON
-        manifest is rendered using :class:`TownSceneRenderer` before displaying
-        the normal town interface.  Supplying ``town`` keeps the previous
-        behaviour of opening the full :class:`TownScreen`.  When no ``town`` is
-        given a :class:`TownOverlay` listing all player-owned towns is shown.
+        By default a scenic view defined by the ``towns_red_knights.json``
+        manifest is shown before the regular town interface.  Holding
+        ``Ctrl`` while triggering this method skips the scenic view and opens
+        the traditional interface directly.  Supplying ``town`` keeps the
+        previous behaviour of opening the full :class:`TownScreen`.  When no
+        ``town`` is given a :class:`TownOverlay` listing all player-owned towns
+        is shown.
         """
+
+        if scene_path is None and town is not None:
+            fast_tests = os.environ.get("FG_FAST_TESTS") == "1"
+            mods = getattr(getattr(pygame, "key", None), "get_mods", lambda: 0)()
+            if not fast_tests and not (mods & getattr(pygame, "KMOD_CTRL", 0)):
+                scene_path = os.path.join(
+                    "assets", "towns", "towns_red_knights.json"
+                )
 
         scene = None
         if scene_path:

--- a/tests/test_town_scene_manifest_loading.py
+++ b/tests/test_town_scene_manifest_loading.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from loaders.town_scene_loader import load_town_scene
+
+
+def test_load_towns_red_knights_scene():
+    path = Path("assets/towns/towns_red_knights.json")
+
+    calls = []
+
+    class DummyAssets:
+        def get(self, key, default=None):
+            calls.append(key)
+            return object()
+
+    scene = load_town_scene(str(path), DummyAssets())
+
+    assert scene.size == (1920, 1080)
+    assert [layer.id for layer in scene.layers] == [
+        "background",
+        "midground",
+        "foreground",
+    ]
+    assert {b.id for b in scene.buildings} == {"town_hall", "blacksmith"}
+    assert set(calls) >= {
+        "towns/red_knights/background.png",
+        "towns/red_knights/midground.png",
+        "towns/red_knights/foreground.png",
+        "towns/red_knights/buildings/town_hall.png",
+        "towns/red_knights/buildings/blacksmith.png",
+    }

--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -159,14 +159,13 @@ class MainScreen:
             if mods & getattr(pygame, "KMOD_CTRL", 0):
                 open_cb = getattr(self.game, "open_town", None)
                 if open_cb:
-                    path = os.path.join("assets", "towns", "towns_red_knights.json")
                     town = getattr(self.game, "_focused_town", None)
                     pos = getattr(self.game, "_focused_town_pos", None)
                     try:
                         if town:
-                            open_cb(town, town_pos=pos, scene_path=path)
+                            open_cb(town, town_pos=pos)
                         else:
-                            open_cb(scene_path=path)
+                            open_cb()
                     except TypeError:
                         if town:
                             open_cb(town, town_pos=pos)


### PR DESCRIPTION
## Summary
- Show towns_red_knights scenic view by default when opening a town; hold Ctrl to skip
- Allow next_town debug shortcut to open town without scenic view
- Add test verifying towns_red_knights scene loads

## Testing
- `pytest -q`
- `pre-commit run --files core/game.py ui/main_screen.py tests/test_town_scene_manifest_loading.py`


------
https://chatgpt.com/codex/tasks/task_e_68b09742f3e48321935d3387f080a076