### PR TITLE
Handle clicks in town scene and test invalid exit

### DIFF
--- a/tests/test_town_scene_screen.py
+++ b/tests/test_town_scene_screen.py
@@ -1,0 +1,24 @@
+from loaders.town_scene_loader import TownScene
+from ui.town_scene_screen import TownSceneScreen
+
+
+def test_run_exits_on_invalid_scene(monkeypatch):
+    import pygame
+
+    monkeypatch.setenv("FG_FAST_TESTS", "0")
+    screen = pygame.Surface((1, 1))
+    scene = TownScene(size=(0, 0), layers=[], buildings=[])
+    screen_wrapper = TownSceneScreen(screen, scene, assets={})
+
+    calls = {"n": 0}
+
+    def fake_get():
+        calls["n"] += 1
+        if calls["n"] > 2:
+            raise RuntimeError("event.get called repeatedly")
+        return []
+
+    monkeypatch.setattr(pygame.event, "get", fake_get)
+
+    screen_wrapper.run()
+    assert calls["n"] == 0

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -33,6 +33,8 @@ class TownSceneScreen:
         self.renderer = TownSceneRenderer(scene, assets)
 
     def run(self) -> None:
+        if not (self.renderer.scene.layers or self.renderer.scene.buildings):
+            return
         running = True
         fast_tests = os.environ.get("FG_FAST_TESTS") == "1"
         while running:
@@ -41,6 +43,8 @@ class TownSceneScreen:
                 break
             for event in events:
                 if event.type == pygame.KEYDOWN and getattr(event, "key", None) == pygame.K_ESCAPE:
+                    running = False
+                elif event.type == pygame.MOUSEBUTTONDOWN:
                     running = False
             self.renderer.draw(self.screen, {})
             pygame.display.flip()


### PR DESCRIPTION
## Summary
- Exit town scene on mouse clicks
- Skip scene when no layers or buildings loaded
- Add regression test for invalid town scene

## Testing
- `pre-commit run --files ui/town_scene_screen.py tests/test_town_scene_screen.py`
- `pytest tests/test_town_scene_screen.py`


------
https://chatgpt.com/codex/tasks/task_e_68b09b4a9b7483219ecd15d9e52430a1