### PR TITLE
Log town scene load failures

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -3275,7 +3275,8 @@ class Game:
                 run = getattr(scn_screen, "run", None)
                 if callable(run):
                     run()
-            except Exception:
+            except Exception as exc:
+                logger.warning("Failed to load town scene %s: %s", scene_path, exc)
                 scene = None
             if town is None:
                 return


### PR DESCRIPTION
## Summary
- log exceptions when town scenes fail to load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b09fdd68ac83218958df1a28de3c06