### PR TITLE
Document Ctrl shortcut and fast test environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ The resulting executable and bundled assets are placed in `dist/fantaisie/`.
 A status panel along the bottom of the window displays your hero's gold,
 mana, army composition and remaining action points.  During exploration you
 can click the on-screen **End Turn** and **Heal** buttons (or press **T** and
-**H**) to manage your army.
+**H**) to manage your army.  The **Next Town** button cycles through player
+towns; hold **Ctrl** while activating it to open the highlighted town
+immediately.  Modifier keys are detected via `pygame.key.get_mods`.
 
 ## Assets
 
@@ -223,6 +225,13 @@ Pytest provides several options to iterate quickly during development:
   `make lf` exposes this behaviour.
 * `pytest --randomly-seed=0` (requires the `pytest-randomly` plugin) fixes the
   random seed to help detect order-dependent failures.
+
+### Fast test mode
+
+The test suite honours the `FG_FAST_TESTS` environment variable.  When set to
+`1`, the game skips some heavy asset loading paths to make tests run more
+quickly.  This variable is set automatically in the test harness and **should
+remain unset in production** so the full game behaviour is exercised.
 
 
 ## Configuration

--- a/core/game.py
+++ b/core/game.py
@@ -3255,6 +3255,9 @@ class Game:
         if scene_path is None and town is not None:
             fast_tests = os.environ.get("FG_FAST_TESTS") == "1"
             mods = getattr(getattr(pygame, "key", None), "get_mods", lambda: 0)()
+            # ``pygame.key.get_mods`` is used here instead of relying on an
+            # event object so that modifier keys like Ctrl are honoured when the
+            # method is called from UI widgets.
             if not fast_tests and not (mods & getattr(pygame, "KMOD_CTRL", 0)):
                 scene_path = os.path.join(
                     self.ctx.repo_root,

--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -156,6 +156,9 @@ class MainScreen:
         if cb:
             cb()
             mods = getattr(getattr(pygame, "key", None), "get_mods", lambda: 0)()
+            # ``pygame.key.get_mods`` reports the currently held modifier keys.
+            # Use it to allow Ctrl-clicking the next-town button to open the town
+            # immediately.
             if mods & getattr(pygame, "KMOD_CTRL", 0):
                 open_cb = getattr(self.game, "open_town", None)
                 if open_cb:


### PR DESCRIPTION
## Summary
- clarify that FG_FAST_TESTS env var is for tests only and must stay unset in production
- document Ctrl detection for town shortcut and describe key handling in code

## Testing
- `pytest tests/test_game_controls.py::test_ctrl_click_next_town_opens_town tests/test_overlay_rendering.py::test_world_overlay_uses_additive_blending -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a0a9057c83218333f64468d5f4eb