### PR TITLE
Ensure town scene loader uses absolute paths

### DIFF
--- a/loaders/town_scene_loader.py
+++ b/loaders/town_scene_loader.py
@@ -61,6 +61,7 @@ def load_town_scene(path: str, assets: Any | None = None) -> TownScene:
         Parsed town scene with layers and buildings.
     """
 
+    path = os.path.abspath(path)
     ctx = Context(repo_root=os.path.dirname(path), search_paths=[""], asset_loader=None)
     try:
         data = read_json(ctx, os.path.basename(path))


### PR DESCRIPTION
## Summary
- Normalize town scene manifest paths to absolute before calculating repo root, guaranteeing consistent manifest lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a66cce6c8321a8a141878fd74f4d