### PR TITLE
Rename default town state and add renderer fallback

### DIFF
--- a/assets/towns/towns_red_knights.json
+++ b/assets/towns/towns_red_knights.json
@@ -7,20 +7,20 @@
   ],
   "buildings": [
     {
-      "id": "barracks",
+      "id": "town_hall",
       "layer": "midground",
       "pos": [640, 480],
-      "states": {"default": "towns/red_knights/buildings/barracks.png"},
+      "states": {"unbuilt": "towns/red_knights/buildings/town_hall.png"},
       "hotspot": [630, 470, 680, 520],
-      "tooltip": "barracks"
+      "tooltip": "town_hall"
     },
     {
-      "id": "archery_range",
+      "id": "blacksmith",
       "layer": "midground",
       "pos": [800, 500],
-      "states": {"default": "towns/red_knights/buildings/archery_range.png"},
+      "states": {"unbuilt": "towns/red_knights/buildings/blacksmith.png"},
       "hotspot": [790, 490, 840, 540],
-      "tooltip": "archery_range"
+      "tooltip": "blacksmith"
     }
   ]
 }

--- a/render/town_scene_renderer.py
+++ b/render/town_scene_renderer.py
@@ -60,7 +60,12 @@ class TownSceneRenderer:
         # Draw buildings according to their current state
         for building in self.scene.buildings:
             state = states.get(building.id, "unbuilt")
-            img = self._building_imgs.get(building.id, {}).get(state)
+            building_states = self._building_imgs.get(building.id, {})
+            img = building_states.get(state)
+
+            if img is None:
+                img = next(iter(building_states.values()), None)
+
             if img is not None:
                 surface.blit(img, building.pos)
 


### PR DESCRIPTION
## Summary
- rename red knights town building states from `default` to `unbuilt`
- ensure renderer falls back to first available building state
- update red knights town manifest to use town hall and blacksmith entries

## Testing
- `make precommit-test`

------
https://chatgpt.com/codex/tasks/task_e_68b0ac5297948321a4c4038128af2baf