### PR TITLE
Add debug hotspot overlay for town scenes

### DIFF
--- a/assets/towns/towns_red_knights.json
+++ b/assets/towns/towns_red_knights.json
@@ -7,20 +7,20 @@
   ],
   "buildings": [
     {
-      "id": "barracks",
+      "id": "town_hall",
       "layer": "midground",
       "pos": [640, 480],
-      "states": {"unbuilt": "towns/red_knights/buildings/barracks.png"},
+      "states": {"unbuilt": "towns/red_knights/buildings/town_hall.png"},
       "hotspot": [630, 470, 680, 520],
-      "tooltip": "barracks"
+      "tooltip": "town_hall"
     },
     {
-      "id": "stables",
+      "id": "blacksmith",
       "layer": "midground",
       "pos": [800, 500],
-      "states": {"unbuilt": "towns/red_knights/buildings/stables.png"},
+      "states": {"unbuilt": "towns/red_knights/buildings/blacksmith.png"},
       "hotspot": [790, 490, 840, 540],
-      "tooltip": "stables"
+      "tooltip": "blacksmith"
     }
   ]
 }

--- a/render/town_scene_renderer.py
+++ b/render/town_scene_renderer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict, Mapping, Any
 
 import pygame
+import constants
 
 from loaders.town_scene_loader import TownScene
 
@@ -39,7 +40,7 @@ class TownSceneRenderer:
                     states[state] = img
             self._building_imgs[building.id] = states
 
-    def draw(self, surface: pygame.Surface, states: Mapping[str, str]) -> None:
+    def draw(self, surface: pygame.Surface, states: Mapping[str, str], debug: bool = False) -> None:
         """Render the scene to ``surface``.
 
         Parameters
@@ -68,6 +69,12 @@ class TownSceneRenderer:
 
             if img is not None:
                 surface.blit(img, building.pos)
+                if debug and getattr(building, "hotspot", None):
+                    hs = building.hotspot
+                    if len(hs) >= 4:
+                        x1, y1, x2, y2 = hs[0], hs[1], hs[2], hs[3]
+                        rect = pygame.Rect(x1, y1, x2 - x1, y2 - y1)
+                        pygame.draw.rect(surface, constants.MAGENTA, rect, 1)
 
 
 __all__ = ["TownSceneRenderer"]

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -42,7 +42,7 @@ class TownSceneScreen:
         # Placeholder action: override in subclass for real behaviour
         return False
 
-    def run(self) -> None:
+    def run(self, debug: bool = False) -> None:
         if not (self.renderer.scene.layers or self.renderer.scene.buildings):
             return
         running = True
@@ -65,7 +65,7 @@ class TownSceneScreen:
                             if self.on_building_click(building):
                                 running = False
                             break
-            self.renderer.draw(self.screen, {})
+            self.renderer.draw(self.screen, {}, debug=debug)
             pygame.display.flip()
             self.clock.tick(getattr(constants, "FPS", 60))
 


### PR DESCRIPTION
## Summary
- add optional `debug` flag to `TownSceneRenderer.draw` to outline building hotspots
- allow `TownSceneScreen.run` to toggle debug rendering
- fix towns_red_knights scene manifest to use expected building ids

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0aef25b648321a9d2a7f8980c9efa