### PR TITLE
Display built town structures in scenic view

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -3272,8 +3272,19 @@ class Game:
                 from loaders.town_scene_loader import load_town_scene
                 from ui.town_scene_screen import TownSceneScreen
                 scene = load_town_scene(scene_path, self.assets)
+                states = {}
+                if town is not None and scene is not None:
+                    try:
+                        states = {
+                            b.id: (
+                                "built" if town.is_structure_built(b.id) else "unbuilt"
+                            )
+                            for b in scene.buildings
+                        }
+                    except Exception:
+                        states = {}
                 scn_screen = TownSceneScreen(
-                    self.screen, scene, self.assets, self.clock
+                    self.screen, scene, self.assets, self.clock, states
                 )
                 run = getattr(scn_screen, "run", None)
                 if callable(run):

--- a/tests/test_open_town.py
+++ b/tests/test_open_town.py
@@ -114,3 +114,79 @@ def test_open_town_handles_property_world(monkeypatch, pygame_stub):
     )
     game.open_town()
     assert created["towns"] == [t]
+
+
+def test_open_town_passes_scene_states(monkeypatch, pygame_stub):
+    import types
+    import sys
+    from loaders.town_scene_loader import TownScene, TownBuilding
+
+    monkeypatch.setenv("FG_FAST_TESTS", "0")
+    pg = pygame_stub(KEYDOWN=2, MOUSEBUTTONDOWN=1)
+    monkeypatch.setattr(pg.event, "get", lambda: [])
+
+    from core.game import Game
+    from core.buildings import Town
+
+    game = Game.__new__(Game)
+    game.screen = pg.Surface((100, 100))
+    game.clock = pg.time.Clock()
+    game.assets = {}
+    game.ctx = types.SimpleNamespace(repo_root=".")
+
+    town = Town("A")
+    town.owner = 0
+    town.built_structures.add("smith")
+
+    scene = TownScene(
+        size=(10, 10),
+        layers=[],
+        buildings=[
+            TownBuilding("tavern", "", (0, 0), {}),
+            TownBuilding("smith", "", (0, 0), {}),
+            TownBuilding("mage_guild", "", (0, 0), {}),
+        ],
+    )
+
+    import loaders.town_scene_loader as tsl
+
+    def fake_load(path, assets):
+        return scene
+
+    monkeypatch.setattr(tsl, "load_town_scene", fake_load)
+
+    captured = {}
+
+    class DummySceneScreen:
+        def __init__(self, screen, scn, assets, clock, building_states=None):
+            captured["states"] = dict(building_states)
+
+        def run(self, debug=False):
+            pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "ui.town_scene_screen",
+        types.SimpleNamespace(TownSceneScreen=DummySceneScreen),
+    )
+
+    class DummyTownScreen:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def run(self):
+            pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "ui.town_screen",
+        types.SimpleNamespace(TownScreen=DummyTownScreen),
+    )
+
+    game.open_town(town)
+
+    assert captured["states"] == {
+        "tavern": "built",
+        "smith": "built",
+        "mage_guild": "unbuilt",
+    }

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Minimal screen to render a town scene using :class:`TownSceneRenderer`."""
 
 import os
-from typing import Any
+from typing import Any, Mapping
 
 import pygame
 import constants
@@ -27,10 +27,18 @@ class TownSceneScreen:
         Optional pygame clock for regulating the loop.
     """
 
-    def __init__(self, screen: pygame.Surface, scene: TownScene, assets: Any, clock: pygame.time.Clock | None = None) -> None:
+    def __init__(
+        self,
+        screen: pygame.Surface,
+        scene: TownScene,
+        assets: Any,
+        clock: pygame.time.Clock | None = None,
+        building_states: Mapping[str, str] | None = None,
+    ) -> None:
         self.screen = screen
         self.clock = clock or pygame.time.Clock()
         self.renderer = TownSceneRenderer(scene, assets)
+        self.building_states = dict(building_states) if building_states else {}
 
     def on_building_click(self, building: TownBuilding) -> bool:
         """Hook executed when a building hotspot is clicked.
@@ -65,7 +73,7 @@ class TownSceneScreen:
                             if self.on_building_click(building):
                                 running = False
                             break
-            self.renderer.draw(self.screen, {}, debug=debug)
+            self.renderer.draw(self.screen, self.building_states, debug=debug)
             pygame.display.flip()
             self.clock.tick(getattr(constants, "FPS", 60))
 


### PR DESCRIPTION
## Summary
- build mapping of built/unbuilt structures when opening a town scene
- render town scenes with correct building states
- add test verifying state mapping is passed to town scenes

## Testing
- `pytest tests/test_town_scene_screen.py tests/test_town_scene_renderer.py tests/test_open_town.py::test_open_town_passes_scene_states -q`
- `pytest tests/test_open_town.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0b04723a08321951c54714d057116