### PR TITLE
Add z-index support for town scene buildings

### DIFF
--- a/loaders/town_scene_loader.py
+++ b/loaders/town_scene_loader.py
@@ -32,6 +32,7 @@ class TownBuilding:
     states: Dict[str, str]
     hotspot: Tuple[int, int, int, int] | None = None
     tooltip: str = ""
+    z_index: int = 0
 
 
 @dataclass
@@ -93,6 +94,7 @@ def load_town_scene(path: str, assets: Any | None = None) -> TownScene:
         pos = (int(pos_list[0]), int(pos_list[1])) if len(pos_list) >= 2 else (0, 0)
         hotspot_list = entry.get("hotspot")
         hotspot = tuple(hotspot_list) if hotspot_list else None
+        z_index = int(entry.get("z_index", 0))
         buildings.append(
             TownBuilding(
                 id=entry.get("id", ""),
@@ -101,6 +103,7 @@ def load_town_scene(path: str, assets: Any | None = None) -> TownScene:
                 states=states,
                 hotspot=hotspot,
                 tooltip=entry.get("tooltip", ""),
+                z_index=z_index,
             )
         )
 

--- a/render/town_scene_renderer.py
+++ b/render/town_scene_renderer.py
@@ -59,7 +59,7 @@ class TownSceneRenderer:
                 surface.blit(img, (0, 0))
 
         # Draw buildings according to their current state
-        for building in self.scene.buildings:
+        for building in sorted(self.scene.buildings, key=lambda b: b.z_index):
             state = states.get(building.id, "unbuilt")
             building_states = self._building_imgs.get(building.id, {})
             img = building_states.get(state)

--- a/tests/test_town_scene_manifest_loading.py
+++ b/tests/test_town_scene_manifest_loading.py
@@ -21,11 +21,11 @@ def test_load_towns_red_knights_scene():
         "midground",
         "foreground",
     ]
-    assert {b.id for b in scene.buildings} == {"town_hall", "blacksmith"}
+    assert {b.id for b in scene.buildings} == {"barracks", "stables"}
     assert set(calls) >= {
         "towns/red_knights/background.png",
         "towns/red_knights/midground.png",
         "towns/red_knights/foreground.png",
-        "towns/red_knights/buildings/town_hall.png",
-        "towns/red_knights/buildings/blacksmith.png",
+        "towns/red_knights/buildings/barracks.png",
+        "towns/red_knights/buildings/stables.png",
     }

--- a/tests/test_town_scene_renderer.py
+++ b/tests/test_town_scene_renderer.py
@@ -54,3 +54,39 @@ def test_draws_layers_and_buildings_in_order():
     surface2 = DummySurface()
     renderer.draw(surface2, {"b": "unbuilt"})
     assert surface2.calls[-1] == (unbuilt, (1, 2))
+
+
+def test_buildings_sorted_by_z_index():
+    b1_img = object()
+    b2_img = object()
+    assets = DummyAssets(
+        {
+            "b1.png": b1_img,
+            "b2.png": b2_img,
+        }
+    )
+
+    scene = TownScene(
+        size=(10, 10),
+        layers=[],
+        buildings=[
+            TownBuilding(
+                id="b1",
+                layer="",
+                pos=(1, 1),
+                states={"built": "b1.png"},
+                z_index=1,
+            ),
+            TownBuilding(
+                id="b2",
+                layer="",
+                pos=(2, 2),
+                states={"built": "b2.png"},
+                z_index=0,
+            ),
+        ],
+    )
+    renderer = TownSceneRenderer(scene, assets)
+    surface = DummySurface()
+    renderer.draw(surface, {"b1": "built", "b2": "built"})
+    assert surface.calls == [(b2_img, (2, 2)), (b1_img, (1, 1))]


### PR DESCRIPTION
## Summary
- support `z_index` on town buildings and parse from manifest
- render buildings sorted by `z_index`
- test z-index ordering and update town scene manifest test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0bb8a5f2c8321b838893634432a16