### PR TITLE
Enable town scene debug via env var and F1 toggle

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -3288,7 +3288,8 @@ class Game:
                 )
                 run = getattr(scn_screen, "run", None)
                 if callable(run):
-                    run()
+                    debug_scene = os.environ.get("FG_TOWN_DEBUG") == "1"
+                    run(debug=debug_scene)
             except Exception as exc:
                 logger.warning("Failed to load town scene %s: %s", scene_path, exc)
                 scene = None

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -75,8 +75,12 @@ class TownSceneScreen:
             if not events and fast_tests:
                 break
             for event in events:
-                if event.type == pygame.KEYDOWN and getattr(event, "key", None) == pygame.K_ESCAPE:
-                    running = False
+                if event.type == pygame.KEYDOWN:
+                    key = getattr(event, "key", None)
+                    if key == pygame.K_ESCAPE:
+                        running = False
+                    elif key == pygame.K_F1:
+                        debug = not debug
                 elif event.type == pygame.MOUSEBUTTONDOWN:
                     for building in self.renderer.scene.buildings:
                         hotspot = getattr(building, "hotspot", [])


### PR DESCRIPTION
## Summary
- allow setting FG_TOWN_DEBUG=1 to show town scene hotspots
- add F1 shortcut to toggle town scene debug view at runtime

## Testing
- `FG_FAST_TESTS=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0c3787d8c8321bdfe110ee7dd729d