### PR TITLE
Handle town building interactions in scenic view

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -3284,12 +3284,20 @@ class Game:
                     except Exception:
                         states = {}
                 scn_screen = TownSceneScreen(
-                    self.screen, scene, self.assets, self.clock, states
+                    self.screen,
+                    scene,
+                    self.assets,
+                    self.clock,
+                    states,
+                    self,
+                    town,
                 )
                 run = getattr(scn_screen, "run", None)
                 if callable(run):
                     debug_scene = os.environ.get("FG_TOWN_DEBUG") == "1"
-                    run(debug=debug_scene)
+                    handled = run(debug=debug_scene)
+                    if handled:
+                        return
             except Exception as exc:
                 logger.warning("Failed to load town scene %s: %s", scene_path, exc)
                 scene = None

--- a/tests/test_open_town.py
+++ b/tests/test_open_town.py
@@ -158,11 +158,20 @@ def test_open_town_passes_scene_states(monkeypatch, pygame_stub):
     captured = {}
 
     class DummySceneScreen:
-        def __init__(self, screen, scn, assets, clock, building_states=None):
+        def __init__(
+            self,
+            screen,
+            scn,
+            assets,
+            clock,
+            building_states=None,
+            game=None,
+            town=None,
+        ):
             captured["states"] = dict(building_states)
 
         def run(self, debug=False):
-            pass
+            return False
 
     monkeypatch.setitem(
         sys.modules,

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -10,6 +10,9 @@ import constants
 
 from loaders.town_scene_loader import TownScene, TownBuilding
 from render.town_scene_renderer import TownSceneRenderer
+from core import economy
+from . import market_screen
+from .town_screen import TownScreen
 
 
 def _point_in_poly(pt: tuple[int, int], poly: list[tuple[int, int]]) -> bool:
@@ -49,11 +52,15 @@ class TownSceneScreen:
         assets: Any,
         clock: pygame.time.Clock | None = None,
         building_states: Mapping[str, str] | None = None,
+        game: Any | None = None,
+        town: Any | None = None,
     ) -> None:
         self.screen = screen
         self.clock = clock or pygame.time.Clock()
         self.renderer = TownSceneRenderer(scene, assets)
         self.building_states = dict(building_states) if building_states else {}
+        self.game = game
+        self.town = town
 
     def on_building_click(self, building: TownBuilding) -> bool:
         """Hook executed when a building hotspot is clicked.
@@ -61,14 +68,55 @@ class TownSceneScreen:
         Subclasses may override this to open panels or trigger other actions.
         Return ``True`` to close the screen after handling the click.
         """
+        if not (self.game and self.town):
+            return False
 
-        # Placeholder action: override in subclass for real behaviour
-        return False
+        sid = getattr(building, "id", "")
+        hero = getattr(self.game, "hero", None)
+        if not sid or hero is None:
+            return False
 
-    def run(self, debug: bool = False) -> None:
+        # Build structure if not yet built
+        if not self.town.is_structure_built(sid):
+            if self.town.built_today:
+                return False
+            cost = self.town.structure_cost(sid)
+            if TownScreen._can_afford(hero, cost):
+                player = economy.PlayerEconomy()
+                player.resources.update(getattr(hero, "resources", {}))
+                player.resources["gold"] = getattr(hero, "gold", 0)
+                if self.town.build_structure(sid, hero, player):
+                    if hasattr(self.game, "_publish_resources"):
+                        self.game._publish_resources()
+                    self.building_states[sid] = "built"
+            return False
+
+        # Already built -> open corresponding panel
+        ts = TownScreen(self.screen, self.game, self.town, clock=self.clock)
+        if sid == "market":
+            market_screen.open(self.screen, self.game, self.town, hero, self.clock)
+        elif sid == "castle":
+            ts._open_castle_overlay()
+            ts.run()
+        elif sid == "tavern":
+            ts._open_tavern_overlay()
+            ts.run()
+        elif sid == "bounty_board":
+            ts._open_bounty_overlay()
+        elif sid == "magic_school":
+            ts._open_spellbook_overlay()
+        else:
+            units = self.town.recruitable_units(sid)
+            if units:
+                ts._open_recruit_overlay(sid, units[0])
+                ts.run()
+        return True
+
+    def run(self, debug: bool = False) -> bool:
         if not (self.renderer.scene.layers or self.renderer.scene.buildings):
-            return
+            return False
         running = True
+        handled = False
         fast_tests = os.environ.get("FG_FAST_TESTS") == "1"
         while running:
             events = pygame.event.get()
@@ -87,10 +135,12 @@ class TownSceneScreen:
                         if hotspot and _point_in_poly(event.pos, hotspot):
                             if self.on_building_click(building):
                                 running = False
+                                handled = True
                             break
             self.renderer.draw(self.screen, self.building_states, debug=debug)
             pygame.display.flip()
             self.clock.tick(getattr(constants, "FPS", 60))
+        return handled
 
 
 __all__ = ["TownSceneScreen"]

--- a/ui/town_screen.py
+++ b/ui/town_screen.py
@@ -570,10 +570,7 @@ class TownScreen:
 
         bid = self._find_building_at(pos)
         if bid:
-            if self.town.is_structure_built(bid):
-                self.town.built_structures.discard(bid)
-            else:
-                self.town.built_structures.add(bid)
+            self._handle_building_click(bid)
             self.hovered_building = bid
             return
 
@@ -596,32 +593,36 @@ class TownScreen:
         # Cards click
         for sid, rc in self.building_cards:
             if rc.collidepoint(pos):
-                if not self.town.is_structure_built(sid):
-                    if self.town.built_today:
-                        return
-                    cost = self.town.structure_cost(sid)
-                    if self._can_afford(self.hero, cost):
-                        player = economy.PlayerEconomy()
-                        player.resources.update(self.hero.resources)
-                        player.resources["gold"] = self.hero.gold
-                        if self.town.build_structure(sid, self.hero, player):
-                            self._publish_resources()
-                else:
-                    if sid == "market":
-                        market_screen.open(self.screen, self.game, self.town, self.hero, self.clock)
-                    elif sid == "castle":
-                        self._open_castle_overlay()
-                    elif sid == "tavern":
-                        self._open_tavern_overlay()
-                    elif sid == "bounty_board":
-                        self._open_bounty_overlay()
-                    elif sid == "magic_school":
-                        self._open_spellbook_overlay()
-                    else:
-                        units = self.town.recruitable_units(sid)
-                        if units:
-                            self._open_recruit_overlay(sid, units[0])
+                self._handle_building_click(sid)
                 return
+    def _handle_building_click(self, sid: str) -> None:
+        if not self.town.is_structure_built(sid):
+            if self.town.built_today:
+                return
+            cost = self.town.structure_cost(sid)
+            if self._can_afford(self.hero, cost):
+                player = economy.PlayerEconomy()
+                player.resources.update(self.hero.resources)
+                player.resources["gold"] = self.hero.gold
+                if self.town.build_structure(sid, self.hero, player):
+                    self._publish_resources()
+        else:
+            if sid == "market":
+                market_screen.open(
+                    self.screen, self.game, self.town, self.hero, self.clock
+                )
+            elif sid == "castle":
+                self._open_castle_overlay()
+            elif sid == "tavern":
+                self._open_tavern_overlay()
+            elif sid == "bounty_board":
+                self._open_bounty_overlay()
+            elif sid == "magic_school":
+                self._open_spellbook_overlay()
+            else:
+                units = self.town.recruitable_units(sid)
+                if units:
+                    self._open_recruit_overlay(sid, units[0])
 
     def _on_mouseup(self, pos: Tuple[int,int], button: int) -> None:
         if self._overlay_active():


### PR DESCRIPTION
## Summary
- Enable full building actions from the town scene screen, allowing construction and opening of building panels
- Pass game and town objects to scene screen and handle scene exit when an action occurs
- Unify TownScreen building click handling for hotspots and cards via shared helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0c4780f3083219f994d1228cc973c