### PR TITLE
Refactor town overlays into standalone modules

### DIFF
--- a/ui/bounty_overlay.py
+++ b/ui/bounty_overlay.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import pygame
+
+def open(screen: pygame.Surface, game, town, hero, clock) -> None:
+    """Open the bounty/quest overlay using the game's journal."""
+    if hasattr(game, "open_journal"):
+        game.open_journal(screen)

--- a/ui/castle_overlay.py
+++ b/ui/castle_overlay.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pygame
+
+from core.entities import RECRUITABLE_UNITS
+from .town_common import COLOR_TEXT, COLOR_ACCENT
+from . import recruit_overlay
+
+FONT_NAME = None
+COLOR_DISABLED = (120, 120, 120)
+
+
+def open(screen: pygame.Surface, game, town, hero, clock) -> None:
+    """Open a simple castle recruitment overview."""
+    font_big = pygame.font.SysFont(FONT_NAME, 20, bold=True)
+    font_small = pygame.font.SysFont(FONT_NAME, 14)
+    castle_rect = pygame.Rect(0, 0, 860, 520)
+    castle_rect.center = screen.get_rect().center
+    castle_unit_cards: List[Tuple[str, pygame.Rect]] = []
+    running = True
+    clock = clock or pygame.time.Clock()
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.KEYDOWN and event.key in (pygame.K_ESCAPE, pygame.K_b):
+                running = False
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                for uid, rc in castle_unit_cards:
+                    if rc.collidepoint(event.pos):
+                        recruit_overlay.open(screen, game, town, hero, clock, "castle", uid)
+                        break
+        # draw overlay
+        s = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
+        s.fill((0, 0, 0, 170))
+        screen.blit(s, (0, 0))
+        r = castle_rect
+        pygame.draw.rect(screen, (36, 38, 46), r, border_radius=8)
+        pygame.draw.rect(screen, (120, 120, 130), r, 2, border_radius=8)
+        screen.blit(
+            font_big.render("Castle – Recruitment Overview", True, COLOR_TEXT),
+            (r.x + 16, r.y + 10),
+        )
+        units = town.list_all_recruitables()
+        cols = 2
+        cw, ch = (r.width - 3 * 16) // cols, 130
+        x = r.x + 16
+        y = r.y + 48
+        castle_unit_cards = []
+        for i, uid in enumerate(units):
+            card = pygame.Rect(x, y, cw, ch)
+            pygame.draw.rect(screen, (48, 50, 58), card, border_radius=8)
+            pygame.draw.rect(screen, (100, 100, 110), card, 2, border_radius=8)
+            screen.blit(
+                font_big.render(uid, True, COLOR_TEXT), (card.x + 10, card.y + 6)
+            )
+            bh = pygame.Rect(card.x + 10, card.y + 34, 72, 72)
+            uh = pygame.Rect(card.right - 82, card.y + 34, 72, 72)
+            pygame.draw.rect(screen, (70, 72, 84), bh)
+            pygame.draw.rect(screen, (70, 72, 84), uh)
+            st = RECRUITABLE_UNITS.get(uid)
+            if st:
+                lines = [
+                    f"HP {st.max_hp}",
+                    f"DMG {st.attack_min}-{st.attack_max}",
+                    f"DEF M/R/Mg {st.defence_melee}/{st.defence_ranged}/{st.defence_magic}",
+                    f"SPD {st.speed}  INIT {st.initiative}",
+                ]
+                yy = card.y + 34
+                for line in lines:
+                    screen.blit(
+                        font_small.render(line, True, COLOR_TEXT),
+                        (bh.right + 10, yy),
+                    )
+                    yy += 18
+            hint = font_small.render("Click to recruit", True, COLOR_ACCENT)
+            screen.blit(hint, (card.right - hint.get_width() - 8, card.bottom - 22))
+            castle_unit_cards.append((uid, card))
+            if (i % cols) == cols - 1:
+                x = r.x + 16
+                y += ch + 12
+            else:
+                x += cw + 16
+        info = font_small.render("Esc to close", True, COLOR_DISABLED)
+        screen.blit(info, (r.right - info.get_width() - 10, r.bottom - 20))
+        pygame.display.update()
+        clock.tick(60)

--- a/ui/recruit_overlay.py
+++ b/ui/recruit_overlay.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import Dict
+import os
+import pygame
+
+from core.entities import RECRUITABLE_UNITS
+from .town_common import COLOR_TEXT, COLOR_ACCENT
+
+FONT_NAME = None
+COLOR_WARN = (210, 90, 70)
+COLOR_DISABLED = (120, 120, 120)
+
+
+def _unit_cost(unit_id: str, count: int) -> Dict[str, int]:
+    try:
+        import constants
+
+        base = dict(getattr(constants, "UNIT_RECRUIT_COSTS", {}).get(unit_id, {}))
+    except Exception:
+        base = {}
+    return {k: v * count for k, v in base.items()}
+
+
+def _can_afford(hero, cost: Dict[str, int]) -> bool:
+    g = cost.get("gold", 0)
+    if hero.gold < g:
+        return False
+    for k, v in cost.items():
+        if k == "gold":
+            continue
+        if hero.resources.get(k, 0) < v:
+            return False
+    return True
+
+
+def open(
+    screen: pygame.Surface,
+    game,
+    town,
+    hero,
+    clock,
+    struct_id: str,
+    unit_id: str,
+) -> None:
+    """Open the recruitment overlay for a specific unit."""
+    font = pygame.font.SysFont(FONT_NAME, 18)
+    font_small = pygame.font.SysFont(FONT_NAME, 14)
+    font_big = pygame.font.SysFont(FONT_NAME, 20, bold=True)
+    recruit_max = town.stock.get(unit_id, 0)
+    recruit_count = min(1, recruit_max)
+    portrait_path = os.path.join(
+        "assets",
+        "units",
+        "portrait",
+        f"{unit_id.lower()}_portrait.png",
+    )
+    try:
+        recruit_portrait = pygame.image.load(portrait_path).convert_alpha()
+    except Exception:
+        recruit_portrait = None
+    recruit_stats = RECRUITABLE_UNITS.get(unit_id)
+    recruit_rect = pygame.Rect(0, 0, 360, 190)
+    recruit_rect.center = screen.get_rect().center
+    btn_min = pygame.Rect(0, 0, 28, 28)
+    btn_minus = pygame.Rect(0, 0, 28, 28)
+    btn_plus = pygame.Rect(0, 0, 28, 28)
+    btn_max = pygame.Rect(0, 0, 28, 28)
+    slider_rect = pygame.Rect(0, 0, 72, 8)
+    btn_buy = pygame.Rect(0, 0, 120, 32)
+    btn_close = pygame.Rect(0, 0, 24, 24)
+    y = recruit_rect.y + recruit_rect.height - 44
+    x = recruit_rect.x + 16
+    btn_min.topleft = (x, y)
+    btn_minus.topleft = (x + 32, y)
+    slider_rect.topleft = (x + 64, y + 10)
+    btn_plus.topleft = (slider_rect.right + 8, y)
+    btn_max.topleft = (btn_plus.right + 4, y)
+    btn_buy.topleft = (recruit_rect.right - btn_buy.width - 16, y)
+    btn_close.topleft = (recruit_rect.right - 28, recruit_rect.y + 8)
+    clock = clock or pygame.time.Clock()
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.KEYDOWN and event.key in (pygame.K_ESCAPE, pygame.K_b):
+                running = False
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                if btn_close.collidepoint(event.pos):
+                    running = False
+                elif btn_min.collidepoint(event.pos):
+                    recruit_count = 0
+                elif btn_minus.collidepoint(event.pos):
+                    recruit_count = max(0, recruit_count - 1)
+                elif btn_plus.collidepoint(event.pos):
+                    recruit_count = min(recruit_max, recruit_count + 1)
+                elif btn_max.collidepoint(event.pos):
+                    recruit_count = recruit_max
+                elif (
+                    slider_rect.collidepoint(event.pos)
+                    and slider_rect.width > 0
+                    and recruit_max > 0
+                ):
+                    ratio = (event.pos[0] - slider_rect.x) / slider_rect.width
+                    recruit_count = max(0, min(recruit_max, int(recruit_max * ratio + 0.5)))
+                elif btn_buy.collidepoint(event.pos):
+                    cost = _unit_cost(unit_id, recruit_count)
+                    if recruit_count > 0 and _can_afford(hero, cost):
+                        if town.recruit_units(unit_id, hero, recruit_count, town.garrison):
+                            if hasattr(hero, "apply_bonuses_to_army"):
+                                hero.apply_bonuses_to_army()
+                            if hasattr(game, "_publish_resources"):
+                                game._publish_resources()
+                            running = False
+        # draw overlay
+        s = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
+        s.fill((0, 0, 0, 160))
+        screen.blit(s, (0, 0))
+        r = recruit_rect
+        pygame.draw.rect(screen, (40, 42, 50), r, border_radius=8)
+        pygame.draw.rect(screen, (110, 110, 120), r, 2, border_radius=8)
+        title = f"Recruit {unit_id} – {struct_id.replace('_', ' ').title()}"
+        screen.blit(font_big.render(title, True, COLOR_TEXT), (r.x + 16, r.y + 12))
+        portrait_rect = pygame.Rect(r.x + 16, r.y + 40, 72, 72)
+        if recruit_portrait:
+            portrait = recruit_portrait
+            if portrait.get_size() != (72, 72):
+                portrait = pygame.transform.scale(portrait, (72, 72))
+            screen.blit(portrait, portrait_rect)
+        else:
+            pygame.draw.rect(screen, (70, 72, 84), portrait_rect)
+        st = recruit_stats
+        if st:
+            lines = [
+                f"HP {st.max_hp}",
+                f"DMG {st.attack_min}-{st.attack_max}",
+                f"DEF M/R/Mg {st.defence_melee}/{st.defence_ranged}/{st.defence_magic}",
+                f"SPD {st.speed}  INIT {st.initiative}",
+            ]
+            yy = portrait_rect.y
+            for line in lines:
+                screen.blit(
+                    font_small.render(line, True, COLOR_TEXT),
+                    (portrait_rect.right + 10, yy),
+                )
+                yy += 18
+        cost = _unit_cost(unit_id, recruit_count)
+        cost_str = " / ".join(f"{k}:{v}" for k, v in cost.items()) if cost else "Free"
+        can_afford = _can_afford(hero, cost)
+        col = COLOR_TEXT if can_afford else COLOR_WARN
+        screen.blit(
+            font.render(f"Cost x{recruit_count}: {cost_str}", True, col),
+            (r.x + 16, r.y + 120),
+        )
+        pygame.draw.rect(screen, (60, 62, 72), btn_min, border_radius=4)
+        pygame.draw.rect(screen, (60, 62, 72), btn_minus, border_radius=4)
+        pygame.draw.rect(screen, (60, 62, 72), slider_rect, border_radius=4)
+        if recruit_max > 0:
+            filled = int(slider_rect.width * recruit_count / recruit_max)
+            pygame.draw.rect(
+                screen,
+                (80, 160, 80),
+                pygame.Rect(
+                    slider_rect.x,
+                    slider_rect.y,
+                    filled,
+                    slider_rect.height,
+                ),
+                border_radius=4,
+            )
+        pygame.draw.rect(screen, (60, 62, 72), btn_plus, border_radius=4)
+        pygame.draw.rect(screen, (60, 62, 72), btn_max, border_radius=4)
+        btn_col = (70, 140, 70) if recruit_count > 0 and can_afford else COLOR_DISABLED
+        pygame.draw.rect(screen, btn_col, btn_buy, border_radius=4)
+        screen.blit(font_small.render("min", True, COLOR_TEXT), (btn_min.x + 3, btn_min.y + 5))
+        screen.blit(font_big.render("-", True, COLOR_TEXT), (btn_minus.x + 8, btn_minus.y + 2))
+        screen.blit(font_big.render("+", True, COLOR_TEXT), (btn_plus.x + 6, btn_plus.y + 2))
+        screen.blit(font_small.render("max", True, COLOR_TEXT), (btn_max.x + 2, btn_max.y + 5))
+        screen.blit(font_big.render("Recruit", True, COLOR_TEXT), (btn_buy.x + 12, btn_buy.y + 2))
+        pygame.draw.rect(screen, (90, 50, 50), btn_close, border_radius=4)
+        screen.blit(font.render("x", True, COLOR_TEXT), (btn_close.x + 7, btn_close.y + 3))
+        pygame.display.update()
+        clock.tick(60)

--- a/ui/spellbook_overlay.py
+++ b/ui/spellbook_overlay.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from builtins import open as builtin_open
 import pygame
 import theme
 import settings
@@ -50,7 +51,7 @@ class SpellbookOverlay:
         base = os.path.dirname(os.path.dirname(__file__))
         path = os.path.join(base, "assets", "spells", "spells.json")
         try:
-            with open(path, "r", encoding="utf-8") as fh:
+            with builtin_open(path, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
         except Exception:
             data = {}
@@ -291,3 +292,18 @@ class SpellbookOverlay:
         self.screen.blit(overlay, (offset_x, offset_y))
         if self.info_overlay is not None:
             self.info_overlay.draw()
+
+
+def open(screen: pygame.Surface, game, town, hero, clock) -> None:
+    """Display the spellbook overlay."""
+    overlay = SpellbookOverlay(screen, town=True)
+    clock = clock or pygame.time.Clock()
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if overlay.handle_event(event):
+                running = False
+                break
+        overlay.draw()
+        pygame.display.update()
+        clock.tick(60)

--- a/ui/tavern_overlay.py
+++ b/ui/tavern_overlay.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pygame
+
+from core.entities import Hero, HeroStats, Unit, RECRUITABLE_UNITS
+from .town_common import COLOR_TEXT, COLOR_ACCENT
+
+FONT_NAME = None
+
+
+def open(screen: pygame.Surface, game, town, hero, clock) -> None:
+    """Open the tavern overlay allowing hero recruitment."""
+    font = pygame.font.SysFont(FONT_NAME, 18)
+    font_small = pygame.font.SysFont(FONT_NAME, 14)
+    font_big = pygame.font.SysFont(FONT_NAME, 20, bold=True)
+    tavern_rect = pygame.Rect(0, 0, 420, 260)
+    tavern_rect.center = screen.get_rect().center
+    tavern_cards: List[Tuple[int, pygame.Rect]] = []
+    tavern_msg = ""
+    tavern_heroes = [
+        {
+            "name": "Bran",
+            "cost": 1500,
+            "stats": HeroStats(1, 1, 0, 0, 0, 0, 0, 0, 0),
+            "army": [Unit(RECRUITABLE_UNITS["swordsman"], 10, "hero")],
+        },
+        {
+            "name": "Luna",
+            "cost": 2500,
+            "stats": HeroStats(0, 0, 1, 1, 0, 0, 0, 0, 0),
+            "army": [Unit(RECRUITABLE_UNITS["archer"], 10, "hero")],
+        },
+    ]
+    running = True
+    clock = clock or pygame.time.Clock()
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.KEYDOWN and event.key in (pygame.K_ESCAPE, pygame.K_b):
+                running = False
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                handled = False
+                for idx, btn in tavern_cards:
+                    if btn.collidepoint(event.pos):
+                        info = tavern_heroes[idx]
+                        cost = info["cost"]
+                        if hero.gold >= cost:
+                            hero.gold -= cost
+                            new_hero = Hero(
+                                town.origin[0],
+                                town.origin[1],
+                                info["army"],
+                                info["stats"],
+                            )
+                            new_hero.name = info["name"]
+                            game.add_hero(new_hero)
+                            if hasattr(game, "_publish_resources"):
+                                game._publish_resources()
+                            running = False
+                        else:
+                            tavern_msg = "Not enough gold"
+                        handled = True
+                        break
+                if not handled and not tavern_rect.collidepoint(event.pos):
+                    running = False
+        # draw
+        s = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
+        s.fill((0, 0, 0, 160))
+        screen.blit(s, (0, 0))
+        r = tavern_rect
+        pygame.draw.rect(screen, (40, 42, 50), r, border_radius=8)
+        pygame.draw.rect(screen, (110, 110, 120), r, 2, border_radius=8)
+        screen.blit(font_big.render("Tavern – Hire Heroes", True, COLOR_TEXT), (r.x + 16, r.y + 12))
+        card_w, card_h, gap = 180, 180, 20
+        x = r.x + 20
+        y = r.y + 60
+        tavern_cards = []
+        for idx, info in enumerate(tavern_heroes):
+            card = pygame.Rect(x + idx * (card_w + gap), y, card_w, card_h)
+            pygame.draw.rect(screen, (60, 62, 72), card, border_radius=6)
+            pygame.draw.rect(screen, (110, 110, 120), card, 2, border_radius=6)
+            portrait = pygame.Rect(card.x + 8, card.y + 8, 64, 64)
+            pygame.draw.rect(screen, (80, 80, 90), portrait)
+            pygame.draw.rect(screen, (110, 110, 120), portrait, 2)
+            name = info["name"]
+            cost = info["cost"]
+            screen.blit(font.render(name, True, COLOR_TEXT), (card.x + 8, card.y + 80))
+            screen.blit(
+                font_small.render(f"Cost: {cost}", True, COLOR_ACCENT),
+                (card.x + 8, card.y + 110),
+            )
+            btn = pygame.Rect(card.x + 40, card.bottom - 40, 100, 28)
+            pygame.draw.rect(screen, (70, 140, 70), btn, border_radius=4)
+            screen.blit(font_small.render("Hire", True, COLOR_TEXT), (btn.x + 28, btn.y + 6))
+            tavern_cards.append((idx, btn))
+        if tavern_msg:
+            msg_surf = font_small.render(tavern_msg, True, (210, 90, 70))
+            msg_rect = msg_surf.get_rect()
+            msg_rect.midtop = (r.centerx, r.bottom - 30)
+            screen.blit(msg_surf, msg_rect)
+        pygame.display.update()
+        clock.tick(60)

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -12,7 +12,14 @@ from loaders.town_scene_loader import TownScene, TownBuilding
 from render.town_scene_renderer import TownSceneRenderer
 from core import economy
 from state.game_state import PlayerResources
-from . import market_screen
+from . import (
+    market_screen,
+    castle_overlay,
+    tavern_overlay,
+    bounty_overlay,
+    recruit_overlay,
+    spellbook_overlay,
+)
 from .town_common import (
     draw_army_row,
     draw_label,
@@ -116,24 +123,28 @@ class TownSceneScreen:
             return False
 
         # Already built -> open corresponding panel
-        ts = TownScreen(self.screen, self.game, self.town, clock=self.clock)
         if sid == "market":
             market_screen.open(self.screen, self.game, self.town, hero, self.clock)
         elif sid == "castle":
-            ts._open_castle_overlay()
-            ts.run()
+            castle_overlay.open(self.screen, self.game, self.town, hero, self.clock)
         elif sid == "tavern":
-            ts._open_tavern_overlay()
-            ts.run()
+            tavern_overlay.open(self.screen, self.game, self.town, hero, self.clock)
         elif sid == "bounty_board":
-            ts._open_bounty_overlay()
+            bounty_overlay.open(self.screen, self.game, self.town, hero, self.clock)
         elif sid == "magic_school":
-            ts._open_spellbook_overlay()
+            spellbook_overlay.open(self.screen, self.game, self.town, hero, self.clock)
         else:
             units = self.town.recruitable_units(sid)
             if units:
-                ts._open_recruit_overlay(sid, units[0])
-                ts.run()
+                recruit_overlay.open(
+                    self.screen,
+                    self.game,
+                    self.town,
+                    hero,
+                    self.clock,
+                    sid,
+                    units[0],
+                )
         return True
 
     def run(self, debug: bool = False) -> bool:

--- a/ui/town_screen.py
+++ b/ui/town_screen.py
@@ -5,7 +5,14 @@ import logging
 import pygame
 from core import economy
 from loaders import icon_loader as IconLoader
-from . import market_screen
+from . import (
+    market_screen,
+    castle_overlay,
+    tavern_overlay,
+    bounty_overlay,
+    recruit_overlay,
+    spellbook_overlay,
+)
 from render.town_scene_renderer import TownSceneRenderer
 from core.entities import (
     Hero,
@@ -757,33 +764,9 @@ class TownScreen:
 
     # ------------------------------------------------------- recruit overlay UI
     def _open_recruit_overlay(self, struct_id: str, unit_id: str) -> None:
-        self.recruit_open = True
-        self.recruit_struct = struct_id
-        self.recruit_unit = unit_id
-        self.recruit_max = self.town.stock.get(unit_id, 0)
-        self.recruit_count = min(1, self.recruit_max)
-        portrait_path = os.path.join(
-            "assets",
-            "units",
-            "portrait",
-            f"{unit_id.lower()}_portrait.png",
+        recruit_overlay.open(
+            self.screen, self.game, self.town, self.hero, self.clock, struct_id, unit_id
         )
-        try:
-            self.recruit_portrait = pygame.image.load(portrait_path).convert_alpha()
-        except Exception:
-            self.recruit_portrait = None
-        self.recruit_stats = RECRUITABLE_UNITS.get(unit_id)
-        W, H = self.screen.get_size()
-        self.recruit_rect.center = (W // 2, H // 2)
-        y = self.recruit_rect.y + self.recruit_rect.height - 44
-        x = self.recruit_rect.x + 16
-        self.btn_min.topleft = (x, y)
-        self.btn_minus.topleft = (x + 32, y)
-        self.slider_rect.topleft = (x + 64, y + 10)
-        self.btn_plus.topleft = (self.slider_rect.right + 8, y)
-        self.btn_max.topleft = (self.btn_plus.right + 4, y)
-        self.btn_buy.topleft = (self.recruit_rect.right - self.btn_buy.width - 16, y)
-        self.btn_close.topleft = (self.recruit_rect.right - 28, self.recruit_rect.y + 8)
 
     def _draw_recruit_overlay(self) -> None:
         s = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
@@ -1122,10 +1105,7 @@ class TownScreen:
 
     # ----------------------------------------------------------- Tavern overlay
     def _open_tavern_overlay(self) -> None:
-        self.tavern_open = True
-        self.tavern_msg = ""
-        W, H = self.screen.get_size()
-        self.tavern_rect.center = (W // 2, H // 2)
+        tavern_overlay.open(self.screen, self.game, self.town, self.hero, self.clock)
 
     def _draw_tavern_overlay(self) -> None:
         s = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
@@ -1199,33 +1179,17 @@ class TownScreen:
 
     # ----------------------------------------------------------- Bounty overlay
     def _open_bounty_overlay(self) -> None:
-        # Reuse the game's quest overlay
-        self.game.open_journal(self.screen)
+        bounty_overlay.open(self.screen, self.game, self.town, self.hero, self.clock)
 
     # -------------------------------------------------------- Spellbook overlay
     def _open_spellbook_overlay(self) -> None:
-        try:  # pragma: no cover - allow running without package context
-            from ui.spellbook_overlay import SpellbookOverlay
-        except ImportError:  # pragma: no cover
-            from .spellbook_overlay import SpellbookOverlay  # type: ignore
-
-        overlay = SpellbookOverlay(self.screen, town=True)
-        clock = pygame.time.Clock()
-        running = True
-        while running:
-            for event in pygame.event.get():
-                if overlay.handle_event(event):
-                    running = False
-                    break
-            overlay.draw()
-            pygame.display.update()
-            clock.tick(60)
+        spellbook_overlay.open(
+            self.screen, self.game, self.town, self.hero, self.clock
+        )
 
     # ----------------------------------------------------------- Castle overlay
     def _open_castle_overlay(self) -> None:
-        self.castle_open = True
-        W, H = self.screen.get_size()
-        self.castle_rect.center = (W // 2, H // 2)
+        castle_overlay.open(self.screen, self.game, self.town, self.hero, self.clock)
 
     def _draw_castle_overlay(self) -> None:
         s = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)


### PR DESCRIPTION
## Summary
- Extract castle, tavern, bounty, recruit and spellbook overlays into dedicated modules
- Call overlay modules directly from TownSceneScreen and TownScreen
- Add helper overlay implementations for recruiting, tavern heroes and spellbook display

## Testing
- `pre-commit run --files ui/bounty_overlay.py ui/castle_overlay.py ui/tavern_overlay.py ui/recruit_overlay.py ui/spellbook_overlay.py ui/town_screen.py ui/town_scene_screen.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0d63488788321b1b15abbce0afb34