### PR TITLE
Show locked build state in town structure overlay

### DIFF
--- a/ui/build_structure_overlay.py
+++ b/ui/build_structure_overlay.py
@@ -27,6 +27,8 @@ def open(
     hero,
     struct_id: str,
     clock: pygame.time.Clock | None = None,
+    *,
+    locked: bool = False,
 ) -> bool:
     """Open an overlay to confirm construction of ``struct_id``.
 
@@ -60,7 +62,7 @@ def open(
                 if btn_cancel.collidepoint(event.pos):
                     return False
                 if btn_build.collidepoint(event.pos):
-                    if _can_afford(hero, cost) and not town.built_today and all(
+                    if _can_afford(hero, cost) and not locked and all(
                         town.is_structure_built(p) for p in prereq
                     ):
                         return True
@@ -104,7 +106,7 @@ def open(
         else:
             screen.blit(font_small.render("None", True, COLOR_TEXT), (panel.x + 32, y))
 
-        can_build = _can_afford(hero, cost) and not town.built_today and all(
+        can_build = _can_afford(hero, cost) and not locked and all(
             town.is_structure_built(p) for p in prereq
         )
         btn_col = (70, 140, 70) if can_build else COLOR_DISABLED
@@ -118,6 +120,16 @@ def open(
             font_big.render("Annuler", True, COLOR_TEXT),
             (btn_cancel.x + 12, btn_cancel.y + 2),
         )
+
+        if locked:
+            screen.blit(
+                font_small.render(
+                    "Vous avez déjà construit un bâtiment aujourd’hui",
+                    True,
+                    COLOR_WARN,
+                ),
+                (panel.x + 16, btn_build.y - 28),
+            )
 
         pygame.display.update()
         clock.tick(60)

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -110,10 +110,13 @@ class TownSceneScreen:
 
         # Build structure if not yet built
         if not self.town.is_structure_built(sid):
-            if self.town.built_today:
-                return False
             confirmed = build_structure_overlay.open(
-                self.screen, self.town, hero, sid, self.clock
+                self.screen,
+                self.town,
+                hero,
+                sid,
+                self.clock,
+                locked=self.town.built_today,
             )
             if confirmed:
                 player = economy.PlayerEconomy()


### PR DESCRIPTION
## Summary
- Always open build structure overlay and pass daily build lock status
- Allow build overlay to accept `locked` flag, showing message and disabling build button when a building has already been constructed today

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b170840fec8321b81693db15856aa1