### PR TITLE
Define costs for town structures and validate

### DIFF
--- a/assets/town_buildings.json
+++ b/assets/town_buildings.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "market",
-    "cost": {},
+    "cost": {"gold": 1000},
     "prereq": [
       "tavern"
     ],
@@ -10,7 +10,7 @@
   },
   {
     "id": "castle",
-    "cost": {},
+    "cost": {"gold": 5000, "wood": 20, "stone": 20},
     "prereq": [
       "market"
     ],
@@ -19,14 +19,14 @@
   },
   {
     "id": "tavern",
-    "cost": {},
+    "cost": {"gold": 500},
     "prereq": [],
     "desc": "Hire new heroes.",
     "image": "buildings/tavern.png"
   },
   {
     "id": "caravansary",
-    "cost": {},
+    "cost": {"gold": 1500, "wood": 5},
     "prereq": [
       "market"
     ],
@@ -35,7 +35,7 @@
   },
   {
     "id": "bounty_board",
-    "cost": {},
+    "cost": {"gold": 1000},
     "prereq": [
       "tavern"
     ],
@@ -44,7 +44,7 @@
   },
   {
     "id": "magic_school",
-    "cost": {},
+    "cost": {"gold": 2000, "crystal": 5},
     "prereq": [
       "castle"
     ],

--- a/core/buildings.py
+++ b/core/buildings.py
@@ -250,7 +250,16 @@ class Town(Building):
 
     def structure_cost(self, name: str) -> Dict[str, int]:
         info = self.structures.get(name, {})
-        return dict(info.get("cost", {})) if isinstance(info, dict) else {}
+        cost: Dict[str, int] = {}
+        if isinstance(info, dict):
+            data = info.get("cost", {})
+            if isinstance(data, dict):
+                cost = dict(data)
+        if not cost:
+            asset = building_loader.BUILDINGS.get(name)
+            if asset is not None:
+                cost = dict(getattr(asset, "upgrade_cost", {}))
+        return {res: int(val) for res, val in cost.items()}
 
     def recruitable_units(self, name: str) -> List[str]:
         info = self.structures.get(name)

--- a/tests/test_town_structure_costs.py
+++ b/tests/test_town_structure_costs.py
@@ -1,0 +1,18 @@
+import os
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+import json
+from core.buildings import Town
+
+
+def test_all_town_structures_have_costs():
+    path = os.path.join(os.path.dirname(__file__), '..', 'assets', 'town_buildings.json')
+    with open(path, 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+    town = Town()
+    for entry in data:
+        sid = entry['id']
+        cost = entry.get('cost', {})
+        assert cost and any(v > 0 for v in cost.values())
+        assert town.structure_cost(sid) == cost
+


### PR DESCRIPTION
## Summary
- assign resource costs to base town structures
- make `Town.structure_cost` return those costs and fall back to asset data
- ensure all town structures define positive costs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17247c3c48321be45dadba1c44a9a