### PR TITLE
Fix overlay darkening

### DIFF
--- a/ui/build_structure_overlay.py
+++ b/ui/build_structure_overlay.py
@@ -52,6 +52,7 @@ def open(
     btn_cancel.topright = (panel.right - 16, panel.bottom - 48)
 
     clock = clock or pygame.time.Clock()
+    background = screen.copy()
 
     running = True
     while running:
@@ -68,6 +69,7 @@ def open(
                         return True
 
         # draw overlay
+        screen.blit(background, (0, 0))
         s = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
         s.fill((0, 0, 0, 160))
         screen.blit(s, (0, 0))

--- a/ui/castle_overlay.py
+++ b/ui/castle_overlay.py
@@ -19,8 +19,9 @@ def open(screen: pygame.Surface, game, town, hero, clock) -> None:
     castle_rect = pygame.Rect(0, 0, 860, 520)
     castle_rect.center = screen.get_rect().center
     castle_unit_cards: List[Tuple[str, pygame.Rect]] = []
-    running = True
     clock = clock or pygame.time.Clock()
+    background = screen.copy()
+    running = True
     while running:
         for event in pygame.event.get():
             if event.type == pygame.KEYDOWN and event.key in (pygame.K_ESCAPE, pygame.K_b):
@@ -28,9 +29,11 @@ def open(screen: pygame.Surface, game, town, hero, clock) -> None:
             elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 for uid, rc in castle_unit_cards:
                     if rc.collidepoint(event.pos):
+                        screen.blit(background, (0, 0))
                         recruit_overlay.open(screen, game, town, hero, clock, "castle", uid)
                         break
         # draw overlay
+        screen.blit(background, (0, 0))
         s = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
         s.fill((0, 0, 0, 170))
         screen.blit(s, (0, 0))

--- a/ui/recruit_overlay.py
+++ b/ui/recruit_overlay.py
@@ -99,6 +99,7 @@ def open(
     btn_buy.topleft = (recruit_rect.right - btn_buy.width - 16, y)
     btn_close.topleft = (recruit_rect.right - 28, recruit_rect.y + 8)
     clock = clock or pygame.time.Clock()
+    background = screen.copy()
     running = True
     while running:
         info = town.get_dwelling_info(struct_id).get(unit_id, (0, 0))
@@ -135,6 +136,7 @@ def open(
                             if hasattr(game, "_publish_resources"):
                                 game._publish_resources()
         # draw overlay
+        screen.blit(background, (0, 0))
         s = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
         s.fill((*theme.PALETTE["background"], 160))
         screen.blit(s, (0, 0))

--- a/ui/tavern_overlay.py
+++ b/ui/tavern_overlay.py
@@ -33,8 +33,9 @@ def open(screen: pygame.Surface, game, town, hero, clock) -> None:
             "army": [Unit(RECRUITABLE_UNITS["archer"], 10, "hero")],
         },
     ]
-    running = True
     clock = clock or pygame.time.Clock()
+    background = screen.copy()
+    running = True
     while running:
         for event in pygame.event.get():
             if event.type == pygame.KEYDOWN and event.key in (pygame.K_ESCAPE, pygame.K_b):
@@ -65,6 +66,7 @@ def open(screen: pygame.Surface, game, town, hero, clock) -> None:
                 if not handled and not tavern_rect.collidepoint(event.pos):
                     running = False
         # draw
+        screen.blit(background, (0, 0))
         s = pygame.Surface(screen.get_size(), pygame.SRCALPHA)
         s.fill((0, 0, 0, 160))
         screen.blit(s, (0, 0))


### PR DESCRIPTION
## Summary
- cache town background at overlay entry and redraw it each frame
- avoid cumulative dimming when opening multiple modal overlays

## Testing
- `pre-commit run --files ui/build_structure_overlay.py ui/castle_overlay.py ui/recruit_overlay.py ui/tavern_overlay.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b183839df48321b81615909d521994