### PR TITLE
Enable super user mode building overrides

### DIFF
--- a/core/economy.py
+++ b/core/economy.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any, Set, Tuple
 
+import settings
+
 # Ressources par défaut (tu peux en ajouter)
 DEFAULT_RESOURCES = ("gold", "wood", "stone", "crystal")
 
@@ -153,7 +155,12 @@ def trade(
 
 def build_structure(b: Building, sid: str) -> bool:
     """Marque ``sid`` comme construit pour ``b`` si possible."""
-    if b.construction_done or sid in b.built_structures:
+    if sid in b.built_structures:
+        return False
+    if settings.SUPER_USER_MODE:
+        b.built_structures.add(sid)
+        return True
+    if b.construction_done:
         return False
     b.built_structures.add(sid)
     b.construction_done = True


### PR DESCRIPTION
## Summary
- Auto-build all town structures and ignore garrison slot limits in SUPER_USER_MODE
- Allow SUPER_USER_MODE to bypass cost and daily build checks
- Skip construction lock in economy layer when SUPER_USER_MODE is enabled

## Testing
- `pre-commit run --files core/buildings.py core/economy.py`

------
https://chatgpt.com/codex/tasks/task_e_68b19f5aaca08321ba62339c6d4eedc7