### PR TITLE
Add aggressiveness factor to creature AI

### DIFF
--- a/core/ai/creature_ai.py
+++ b/core/ai/creature_ai.py
@@ -31,6 +31,7 @@ class CreatureAI:
     y: int
     units: List[Unit]
     behavior: CreatureBehavior
+    aggressiveness: int = 5
     spawn: Tuple[int, int] = field(init=False)
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
@@ -49,8 +50,15 @@ class GuardianAI(CreatureAI):
 
     guard_range: int = 0
 
-    def __init__(self, x: int, y: int, units: List[Unit], guard_range: int = 0):
-        super().__init__(x, y, units, CreatureBehavior.GUARDIAN)
+    def __init__(
+        self,
+        x: int,
+        y: int,
+        units: List[Unit],
+        guard_range: int = 0,
+        aggressiveness: int = 5,
+    ):
+        super().__init__(x, y, units, CreatureBehavior.GUARDIAN, aggressiveness)
         self.guard_range = guard_range
 
     def update(self, world, hero_pos: Tuple[int, int], hero_strength: int) -> None:
@@ -60,7 +68,10 @@ class GuardianAI(CreatureAI):
         dist = abs(hx - self.x) + abs(hy - self.y)
         if dist > self.guard_range:
             return  # stay put
-        pursuing = self._strength() >= hero_strength
+        my_strength = self._strength()
+        pursuing = my_strength >= hero_strength
+        if not pursuing:
+            pursuing = random.randint(1, 10) <= self.aggressiveness
         dx = 1 if hx > self.x else -1 if hx < self.x else 0
         dy = 1 if hy > self.y else -1 if hy < self.y else 0
         if not pursuing:
@@ -88,8 +99,15 @@ class RoamingAI(CreatureAI):
 
     patrol_radius: int = 3
 
-    def __init__(self, x: int, y: int, units: List[Unit], patrol_radius: int = 3):
-        super().__init__(x, y, units, CreatureBehavior.ROAMER)
+    def __init__(
+        self,
+        x: int,
+        y: int,
+        units: List[Unit],
+        patrol_radius: int = 3,
+        aggressiveness: int = 5,
+    ):
+        super().__init__(x, y, units, CreatureBehavior.ROAMER, aggressiveness)
         self.patrol_radius = patrol_radius
 
     def update(self, world, hero_pos: Tuple[int, int], hero_strength: int) -> None:
@@ -101,6 +119,8 @@ class RoamingAI(CreatureAI):
         target = None
         if dist <= self.patrol_radius:
             pursuing = my_strength >= hero_strength
+            if not pursuing:
+                pursuing = random.randint(1, 10) <= self.aggressiveness
             dx = 1 if hx > self.x else -1 if hx < self.x else 0
             dy = 1 if hy > self.y else -1 if hy < self.y else 0
             if not pursuing:

--- a/core/world.py
+++ b/core/world.py
@@ -1014,7 +1014,7 @@ class WorldMap:
             tile.enemy_units = units
             cid = units[0].stats.name
             _, guard = CREATURE_BEHAVIOUR.get(cid, (CreatureBehavior.GUARDIAN, 3))
-            ai = GuardianAI(x, y, units, guard)
+            ai = GuardianAI(x, y, units, guard, rng.randint(1, 10))
             self.creatures.append(ai)
 
         # spawn roaming stacks near frontiers
@@ -1036,7 +1036,7 @@ class WorldMap:
             tile.enemy_units = units
             cid = units[0].stats.name
             _, guard = CREATURE_BEHAVIOUR.get(cid, (CreatureBehavior.ROAMER, 3))
-            ai = RoamingAI(x, y, units, guard)
+            ai = RoamingAI(x, y, units, guard, rng.randint(1, 10))
             self.creatures.append(ai)
             placed += 1
 
@@ -1124,9 +1124,9 @@ class WorldMap:
             cid = units[0].stats.name
             mode, guard = CREATURE_BEHAVIOUR.get(cid, (CreatureBehavior.ROAMER, 3))
             if mode is CreatureBehavior.GUARDIAN:
-                ai = GuardianAI(x, y, units, guard)
+                ai = GuardianAI(x, y, units, guard, rng.randint(1, 10))
             else:
-                ai = RoamingAI(x, y, units, guard)
+                ai = RoamingAI(x, y, units, guard, rng.randint(1, 10))
             self.creatures.append(ai)
 
     def _create_starting_area(self) -> None:


### PR DESCRIPTION
## Summary
- track an aggressiveness stat for neutral creature AI
- use aggressiveness to sometimes chase heroes even when weaker
- spawn guardian and roaming stacks with randomized aggressiveness

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1ab4c9c1c8321a46a87589c7cc363