### PR TITLE
Add stack size label helper

### DIFF
--- a/core/entities.py
+++ b/core/entities.py
@@ -35,6 +35,40 @@ if cf is not None:
                 setattr(stub_factory, attr, getattr(stub_module, attr))
 
 
+# Qualitative descriptions for stack sizes used by various UI overlays.
+STACK_COUNT_LABELS = [
+    (4, "a few"),
+    (9, "several"),
+    (19, "pack"),
+    (49, "lots"),
+    (99, "horde"),
+    (249, "throng"),
+    (499, "swarm"),
+    (999, "zounds"),
+    (float("inf"), "legion"),
+]
+
+
+def estimate_stack_label(count: int) -> str:
+    """Return a qualitative label describing a stack size.
+
+    Parameters
+    ----------
+    count:
+        Number of creatures in the stack.
+
+    Returns
+    -------
+    str
+        Human-friendly label estimating the stack size.
+    """
+
+    for limit, label in STACK_COUNT_LABELS:
+        if count <= limit:
+            return label
+    return STACK_COUNT_LABELS[-1][1]
+
+
 class EquipmentSlot(Enum):
     """Possible equipment locations for heroes and units."""
 

--- a/ui/enemy_stack_overlay.py
+++ b/ui/enemy_stack_overlay.py
@@ -4,6 +4,7 @@ import pygame
 import theme
 from typing import List
 from core.world import ENEMY_UNIT_IMAGES
+from core.entities import estimate_stack_label
 
 
 class EnemyStackOverlay:
@@ -11,18 +12,6 @@ class EnemyStackOverlay:
 
     BG = theme.PALETTE.get("background", (40, 42, 50))
     TEXT = theme.PALETTE.get("text", (230, 230, 230))
-
-    COUNT_LABELS = [
-        (4, "a few"),
-        (9, "several"),
-        (19, "pack"),
-        (49, "lots"),
-        (99, "horde"),
-        (249, "throng"),
-        (499, "swarm"),
-        (999, "zounds"),
-        (float("inf"), "legion"),
-    ]
 
     def __init__(self, screen: pygame.Surface, assets, units) -> None:
         self.screen = screen
@@ -38,13 +27,6 @@ class EnemyStackOverlay:
             return True
         return False
 
-    @classmethod
-    def _count_label(cls, count: int) -> str:
-        for limit, label in cls.COUNT_LABELS:
-            if count <= limit:
-                return label
-        return cls.COUNT_LABELS[-1][1]
-
     def draw(self) -> None:
         icon_size = 32
         rows: List[tuple] = []
@@ -59,7 +41,7 @@ class EnemyStackOverlay:
                 except Exception:
                     icon = pygame.transform.scale(icon, (icon_size, icon_size))
             name = self.font.render(unit.stats.name, True, self.TEXT)
-            count = self.font.render(self._count_label(unit.count), True, self.TEXT)
+            count = self.font.render(estimate_stack_label(unit.count), True, self.TEXT)
             row_h = max(
                 icon.get_height() if icon else 0,
                 name.get_height(),


### PR DESCRIPTION
## Summary
- add `estimate_stack_label` helper for qualitative stack size labels
- use `estimate_stack_label` in `EnemyStackOverlay`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ae5d487c832199abba8c5c9b5bd7