### PR TITLE
Implement weekly growth for neutral creatures

### DIFF
--- a/core/world.py
+++ b/core/world.py
@@ -1428,6 +1428,22 @@ class WorldMap:
             if hasattr(town, "advance_day"):
                 town.advance_day(hero, self)
 
+    def grow_creatures_weekly(self) -> None:
+        """Increase the size of all neutral creature stacks.
+
+        Each stack grows by 10% of its current size (minimum of one unit) to
+        simulate neutral dwellings spawning reinforcements over time.  The
+        update mutates the unit stacks in place so tiles referencing the same
+        list automatically see the new counts.
+        """
+
+        for creature in self.creatures:
+            for unit in creature.units:
+                if unit.count <= 0:
+                    continue
+                growth = max(1, unit.count // 10)
+                unit.count += growth
+
 
     def find_building_pos(self, building: Building) -> Optional[Tuple[int, int]]:
         """Search ``self.grid`` for ``building`` and return its coordinates.

--- a/state/game_state.py
+++ b/state/game_state.py
@@ -107,7 +107,7 @@ class GameState:
     economy: GameEconomyState = field(default_factory=GameEconomyState)
 
     def _advance_towns_week(self) -> None:
-        """Trigger weekly updates for all towns on the world map."""
+        """Trigger weekly updates for world entities such as towns and mobs."""
         if not self.world:
             return
         for town in getattr(self.world, "towns", []):
@@ -117,6 +117,8 @@ class GameState:
                 econ_player = self.economy.players[owner]
                 if hasattr(town, "recruit"):
                     town.recruit(econ_player)
+        if hasattr(self.world, "grow_creatures_weekly"):
+            self.world.grow_creatures_weekly()
 
     def next_day(self) -> None:
         """Advance the game by one day applying economic effects."""

--- a/tests/test_world_creature_growth.py
+++ b/tests/test_world_creature_growth.py
@@ -1,0 +1,25 @@
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+
+from core.world import WorldMap
+from core.entities import Unit, RECRUITABLE_UNITS
+from core.ai.creature_ai import RoamingAI
+from state.game_state import GameState
+
+
+def test_neutral_creatures_grow_each_week():
+    pygame.init()
+    world = WorldMap(map_data=["G"])
+    stats = RECRUITABLE_UNITS["Swordsman"]
+    creature = RoamingAI(0, 0, [Unit(stats, 10, "enemy")])
+    world.creatures.append(creature)
+    world.grid[0][0].enemy_units = creature.units
+    state = GameState(world=world)
+
+    for _ in range(7):
+        state.next_day()
+
+    assert creature.units[0].count == 11


### PR DESCRIPTION
## Summary
- add `grow_creatures_weekly` to WorldMap to boost neutral stacks
- call weekly creature growth from GameState weekly hook
- test that neutral creatures gain units each week

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b0cf323083219f9c7ce8d1624f82