### PR TITLE
Use layout helpers for responsive main screen layout

### DIFF
--- a/tests/test_resolutions.py
+++ b/tests/test_resolutions.py
@@ -53,3 +53,15 @@ def test_buttons_remain_adjacent_with_short_height():
     assert buttons_rect.y == hero_rect.y
     assert buttons_rect.x == hero_rect.x + hero_rect.width + margin
     assert buttons_rect.width == hero_rect.width
+
+
+@pytest.mark.serial
+@pytest.mark.parametrize("size", [(1024, 768), (1600, 900), (1920, 1080)])
+def test_resource_turn_ratio(size):
+    game = _dummy_game(*size)
+    ms = MainScreen(game)
+    res = ms.widgets["3"]
+    turn = ms.widgets["3b"]
+    total = res.width + turn.width + 8
+    ratio = res.width / total
+    assert abs(ratio - 0.7) < 0.02

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -52,3 +52,77 @@ class Layout:
     def remaining(self) -> pygame.Rect:
         """Return a copy of the current remaining rectangle."""
         return pygame.Rect(self.rect.x, self.rect.y, self.rect.width, self.rect.height)
+
+    # ------------------------------------------------------------------
+    # Additional helpers
+    # ------------------------------------------------------------------
+    def split_h(self, ratio: float, margin: int = 0) -> tuple[pygame.Rect, pygame.Rect]:
+        """Split the area into two horizontal rectangles.
+
+        Parameters
+        ----------
+        ratio:
+            Fraction of the width to allocate to the left rect.  The right
+            rect takes the remaining space.
+        margin:
+            Gap in pixels inserted between the two rects.
+        """
+
+        left_w = int(self.rect.width * ratio)
+        right_w = self.rect.width - left_w - margin
+        left = pygame.Rect(self.rect.x, self.rect.y, left_w, self.rect.height)
+        right = pygame.Rect(
+            self.rect.x + left_w + margin, self.rect.y, right_w, self.rect.height
+        )
+        return left, right
+
+    def anchor(
+        self,
+        width: int | float,
+        height: int | float,
+        anchor: str = "topleft",
+        margin: int = 0,
+    ) -> pygame.Rect:
+        """Return a rectangle anchored within the current one.
+
+        ``width`` and ``height`` may be absolute pixel values or floats in the
+        range 0..1 to specify a proportion of the parent size.  The ``anchor``
+        uses :class:`pygame.Rect` attribute names (``topleft``, ``topright``,
+        ``midbottom`` ...).  Margins move the rectangle away from the anchored
+        edges.
+        """
+
+        if isinstance(width, float):
+            width = int(self.rect.width * width)
+        if isinstance(height, float):
+            height = int(self.rect.height * height)
+
+        parent = self.rect
+        x = parent.x
+        y = parent.y
+
+        if "left" in anchor:
+            x = parent.left
+        elif "right" in anchor:
+            x = parent.right - width
+        elif "center" in anchor or "mid" in anchor:
+            x = parent.centerx - width // 2
+
+        if "top" in anchor:
+            y = parent.top
+        elif "bottom" in anchor:
+            y = parent.bottom - height
+        elif "center" in anchor or "mid" in anchor:
+            y = parent.centery - height // 2
+
+        r = pygame.Rect(x, y, width, height)
+
+        if "left" in anchor:
+            r.x += margin
+        if "right" in anchor:
+            r.x -= margin
+        if "top" in anchor:
+            r.y += margin
+        if "bottom" in anchor:
+            r.y -= margin
+        return r

--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -217,16 +217,7 @@ class MainScreen:
         res_turn_rect = world_layout.dock_bottom(bar_h, margin=M)
         world_rect = world_layout.remaining()
 
-        # Split horizontal pour resources/turn
-        res_w = int(res_turn_rect.width * 0.7) - M // 2
-        turn_w = res_turn_rect.width - res_w - M
-        res_rect = pygame.Rect(res_turn_rect.x, res_turn_rect.y, res_w, res_turn_rect.height)
-        turn_rect = pygame.Rect(
-            res_rect.x + res_rect.width + M,
-            res_turn_rect.y,
-            turn_w,
-            res_turn_rect.height,
-        )
+        res_rect, turn_rect = Layout(res_turn_rect).split_h(0.7, margin=M)
 
         # Colonne de droite : minimap en haut, puis 2 panneaux juxtaposés (hero_list | buttons),
         # puis l'armée dessous qui prend tout le reste.
@@ -268,14 +259,12 @@ class MainScreen:
             mid_rect = side_layout.dock_top(mid_h, margin=M)
             army_rect = side_layout.remaining()
 
-            split_w = (mid_rect.width - M) // 2
-            hero_list_rect = pygame.Rect(mid_rect.x, mid_rect.y, split_w, mid_rect.height)
-            buttons_rect = pygame.Rect(
-                hero_list_rect.x + hero_list_rect.width + M,
-                mid_rect.y,
-                split_w,
-                mid_rect.height,
-            )
+            mid_layout = Layout(mid_rect)
+            hero_list_rect = mid_layout.anchor(0.5, 1.0, anchor="topleft")
+            buttons_rect = mid_layout.anchor(0.5, 1.0, anchor="topright")
+            hero_list_rect.width -= M // 2
+            buttons_rect.width -= M // 2
+            buttons_rect.x += M // 2
         else:
             hero_list_rect = side_layout.dock_top(mid_h, margin=M)
             buttons_rect = side_layout.dock_bottom(btn_total_h, margin=0)


### PR DESCRIPTION
## Summary
- Replace manual coordinate math in main screen layout with Layout.split_h and anchoring
- Extend Layout with split_h and anchor helpers for proportional, anchored widgets
- Add resolution tests checking resource/turn split ratios

## Testing
- `pytest tests/test_main_screen_layout.py`
- `pytest -m serial tests/test_resolutions.py`


------
https://chatgpt.com/codex/tasks/task_e_68b20ff0a7908321bd32b3f93097c031