### PR TITLE
docs: add contributor and modding guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,5 +256,11 @@ There are many directions to expand the game.  Some possibilities include:
 - Multiple heroes, fog of war and a quest system.
 - Packaging the project so it can be installed as a Python package.
 
+
+## Additional Guides
+
+- [Contributor Guide](docs/contributor_guide.md) – repository layout, build steps and contribution standards.
+- [Modding Guide](docs/modding_guide.md) – asset manifests, plugin APIs and scripting hooks.
+
 Contributions and suggestions are welcome!
 

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -1,0 +1,41 @@
+# Contributor Guide
+
+This guide outlines the repository structure, how to build the project and the standards expected of contributions.
+
+## Code Layout
+
+- `assets/` – game data and JSON manifests.
+- `core/` – fundamental logic and data structures.
+- `events/` – game events and event handling helpers.
+- `graphics/` – image utilities such as scaling helpers.
+- `mapgen/` – procedural map generation algorithms.
+- `render/` – window and map rendering code.
+- `tests/` – automated test suite.
+- additional packages like `ui/` and `tools/` contain user interface widgets and developer utilities.
+
+## Build and Test
+
+Create a development environment with the optional tooling extras:
+
+```bash
+pip install -e .[dev]
+```
+
+Run the test suite before submitting changes:
+
+```bash
+pytest
+```
+
+To produce a standalone build, install **PyInstaller** and run the provided spec:
+
+```bash
+pyinstaller fantaisie.spec
+```
+
+## Contribution Standards
+
+- Follow PEP 8 style guidelines and keep imports sorted.
+- Include tests and documentation alongside code changes.
+- Ensure `pytest` and `make precommit-test` pass before committing.
+- Write descriptive commit messages and reference related issues when applicable.

--- a/docs/modding_guide.md
+++ b/docs/modding_guide.md
@@ -1,0 +1,32 @@
+# Modding Guide
+
+This guide explains how to extend the game with custom content and behaviour.
+
+## Asset Manifests
+
+Game data is driven by JSON manifests located under `assets/<category>/<category>.json`. Each entry lists an `id`, image `path` and optional metadata. See [asset_manifests.md](asset_manifests.md) for full details on the format. To add new art, place images in the appropriate directory and reference them from the manifest.
+
+## Plugin APIs
+
+Several subsystems expose small plugin APIs through hook registries. Modules such as `siege`, `diplomacy` and `weather` provide a `register_hook` helper and a `hooks` list:
+
+```python
+from siege import register_hook
+
+def my_siege_rule(engine):
+    ...
+
+register_hook(my_siege_rule)
+```
+
+Registered callbacks run whenever the game triggers that subsystem, allowing mods to inject custom logic.
+
+## Scripting Hooks
+
+Hooks make it possible to execute Python code at key moments without modifying core files. Common hook points include:
+
+- `diplomacy.register_hook` – react to relation changes between factions.
+- `siege.register_hook` – augment siege encounters.
+- `weather.register_hook` – update weather effects.
+
+Hook functions can import game types, adjust state or call back into the engine, enabling rich scripting capabilities.


### PR DESCRIPTION
## Summary
- document repository layout, build steps, and contribution standards
- outline asset manifests, plugin APIs, and scripting hooks for modders
- link new contributor and modding guides from README

## Testing
- `FG_FAST_TESTS=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b211029064832188d515badc128c55