### PR TITLE
Handle None asset keys gracefully

### DIFF
--- a/loaders/asset_manager.py
+++ b/loaders/asset_manager.py
@@ -72,11 +72,14 @@ class AssetManager(dict):
         # assets.
         self._load_alpha_masks()
 
-    def get(self, key: str, default: Any = None) -> Any:
+    def get(self, key: str | None, default: Any = None) -> Any:
         """Return the image for ``key`` or a placeholder if missing."""
 
         if default is None:
             default = self._fallback
+
+        if not key:
+            return default
 
         name, ext = os.path.splitext(key)
         cache_key = name if ext else key


### PR DESCRIPTION
## Summary
- avoid TypeError in AssetManager when asset key is None by returning fallback image

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2d090c1048321b757f9f4cb5e2606