### PR TITLE
Require click to open towns

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -1492,8 +1492,6 @@ class Game:
                         # Open hero inventory and skill tree
                         if self.show_inventory():
                             self.quit_to_menu = True
-                    elif event.key == pygame.K_u:
-                        self.open_town()
                     elif event.key == pygame.K_1:
                         self.hero.choose_skill('strength')
                     elif event.key == pygame.K_2:
@@ -1916,7 +1914,8 @@ class Game:
             econ_b = getattr(self, "_econ_building_map", {}).get(tile.building)
             if self._capture_tile(nx, ny, tile, self.hero, 0, econ_state, econ_b):
                 self._publish_resources()
-            self.open_town(tile.building, actor, town_pos=(nx, ny))
+            if self.path_target == (nx, ny):
+                self.open_town(tile.building, actor, town_pos=(nx, ny))
             return
         if not tile.is_passable():
             return
@@ -2023,7 +2022,8 @@ class Game:
             if self._capture_tile(self.hero.x, self.hero.y, tile, self.hero, 0, econ_state, econ_b):
                 self._publish_resources()
             if isinstance(tile.building, Town):
-                self.open_town(tile.building, actor, town_pos=(nx, ny))
+                if self.path_target == (nx, ny):
+                    self.open_town(tile.building, actor, town_pos=(nx, ny))
             else:
                 choice = self.prompt_building_interaction(tile.building)
                 if choice == "take" and tile.building.owner != 0:
@@ -2161,7 +2161,8 @@ class Game:
                     econ_b = getattr(self, "_econ_building_map", {}).get(town)
                     if self._capture_tile(nx, ny, tile, self.hero, 0, econ_state, econ_b):
                         self._publish_resources()
-                self.open_town(town, town_pos=(nx, ny))
+                if self.path_target == (nx, ny):
+                    self.open_town(town, town_pos=(nx, ny))
             else:
                 choice = self.prompt_building_interaction(tile.building)
                 if choice == "take" and tile.building.owner != 0:

--- a/tests/test_building_interaction.py
+++ b/tests/test_building_interaction.py
@@ -138,7 +138,7 @@ def test_handle_world_click_on_building_sets_path(monkeypatch, pygame_stub):
     assert game.move_queue == []
 
 
-def test_try_move_into_town_interacts_and_opens(monkeypatch, pygame_stub):
+def test_try_move_into_town_interacts_without_opening(monkeypatch, pygame_stub):
     game, town, Game, constants = setup_game_with_town(monkeypatch, pygame_stub)
     called = {}
     orig_interact = town.interact
@@ -151,7 +151,7 @@ def test_try_move_into_town_interacts_and_opens(monkeypatch, pygame_stub):
     monkeypatch.setattr(Game, "prompt_building_interaction", lambda self, b: called.setdefault('prompt', True))
     game.try_move_hero(1, 0)
     assert called.get('interact') is True
-    assert called.get('open') is True
+    assert 'open' not in called
     assert 'prompt' not in called
     assert game.hero.ap == 1
     assert (game.hero.x, game.hero.y) == (0, 0)
@@ -220,7 +220,7 @@ def test_try_move_into_owned_town_skips_interact(monkeypatch, pygame_stub):
     monkeypatch.setattr(Game, "prompt_building_interaction", lambda self, b: called.setdefault('prompt', True))
     game.try_move_hero(1, 0)
     assert 'interact' not in called
-    assert called.get('open') is True
+    assert 'open' not in called
     assert 'prompt' not in called
     assert game.hero.ap == 1
     assert (game.hero.x, game.hero.y) == (0, 0)
@@ -244,5 +244,5 @@ def test_try_move_into_owned_town_with_garrison_no_combat(monkeypatch, pygame_st
     )
     game.try_move_hero(1, 0)
     assert 'combat' not in called
-    assert called.get('open') is True
+    assert 'open' not in called
 


### PR DESCRIPTION
## Summary
- remove keyboard hotkey for opening towns
- only open towns when the clicked path target is the town
- align building interaction tests with click-only behaviour

## Testing
- `FG_FAST_TESTS=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2dbf20fc48321bb116f3ab02810e2