### PR TITLE
Reduce biome chunk memory usage

### DIFF
--- a/render/world_renderer.py
+++ b/render/world_renderer.py
@@ -132,15 +132,19 @@ class WorldRenderer:
                 self._prefetch_queue.task_done()
             except queue.Empty:
                 break
-        # Queue up all biome chunks for background generation so the
-        # renderer has them ready when needed.
+        # Prefetch only the chunk around the current camera position to
+        # avoid allocating surfaces for the entire map at once. Remaining
+        # chunks will be generated lazily as they enter view.
         chunk = settings.BIOME_CHUNK_TILES
+        tile = constants.TILE_SIZE
         world = self.world
+        cx = int(self.cam_x // (chunk * tile))
+        cy = int(self.cam_y // (chunk * tile))
         chunks_x = math.ceil(world.width / chunk)
         chunks_y = math.ceil(world.height / chunk)
-        for cy in range(chunks_y):
-            for cx in range(chunks_x):
-                self._queue_prefetch(cx, cy)
+        cx = max(0, min(chunks_x - 1, cx))
+        cy = max(0, min(chunks_y - 1, cy))
+        self._queue_prefetch(cx, cy)
 
     def invalidate_biome(self, x: int, y: int) -> None:
         """Invalidate the cached chunk containing tile ``(x, y)``."""

--- a/settings.json
+++ b/settings.json
@@ -10,8 +10,8 @@
   "animation_speed": 1.0,
   "tooltip_read_mode": false,
   "super_user_mode": false,
-  "biome_chunk_tiles": 32,
-  "biome_cache_size": 64,
+  "biome_chunk_tiles": 16,
+  "biome_cache_size": 32,
   "keymap": {
     "pan_left": ["K_LEFT", "K_a"],
     "pan_right": ["K_RIGHT", "K_d"],

--- a/settings.py
+++ b/settings.py
@@ -84,12 +84,12 @@ SCROLL_SPEED: int = _get_int("FG_SCROLL_SPEED", "scroll_speed", 20)
 
 # Number of tiles per cached biome chunk in the world renderer
 BIOME_CHUNK_TILES: int = _get_int(
-    "FG_BIOME_CHUNK_TILES", "biome_chunk_tiles", 32
+    "FG_BIOME_CHUNK_TILES", "biome_chunk_tiles", 16
 )
 
 # Maximum number of biome chunks stored in the cache
 BIOME_CACHE_SIZE: int = _get_int(
-    "FG_BIOME_CACHE_SIZE", "biome_cache_size", 64
+    "FG_BIOME_CACHE_SIZE", "biome_cache_size", 32
 )
 
 # Animation speed multiplier for game visuals


### PR DESCRIPTION
## Summary
- limit biome cache chunk generation to current camera instead of entire map
- lower default chunk size and cache count to reduce memory footprint

## Testing
- `SDL_VIDEODRIVER=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b33e3b5e108321a8df1b8a76d4c7a0