### PR TITLE
Show enemy stack stats in world map overlay

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -3200,7 +3200,7 @@ class Game:
         return True
 
     def open_enemy_stack_overlay(self, units: List[Unit]) -> None:
-        """Show an overlay with basic information about ``units``."""
+        """Show an overlay with size labels and core stats for ``units``."""
         from ui.enemy_stack_overlay import EnemyStackOverlay
 
         overlay = EnemyStackOverlay(self.screen, self.assets, units)

--- a/tests/test_enemy_stack_overlay.py
+++ b/tests/test_enemy_stack_overlay.py
@@ -1,0 +1,52 @@
+import pygame
+from types import SimpleNamespace
+
+from core.entities import UnitStats, Unit, estimate_stack_label
+from ui.enemy_stack_overlay import EnemyStackOverlay
+import theme
+from tests.test_overlay_rendering import _ensure_stub_functions
+
+
+def test_enemy_stack_overlay_shows_stats(monkeypatch):
+    _ensure_stub_functions(monkeypatch)
+    pygame.init()
+    rendered = []
+
+    class DummyFont:
+        def render(self, text, aa, colour):
+            rendered.append(text)
+            return pygame.Surface((1, 1))
+
+    monkeypatch.setattr(theme, "get_font", lambda size=16: DummyFont())
+
+    screen = pygame.Surface((200, 200))
+    assets = SimpleNamespace(get=lambda key: None)
+    stats = UnitStats(
+        name="Goblin",
+        max_hp=6,
+        attack_min=1,
+        attack_max=3,
+        defence_melee=2,
+        defence_ranged=1,
+        defence_magic=0,
+        speed=5,
+        attack_range=1,
+        initiative=1,
+        sheet="",
+        hero_frames=(0, 0),
+        enemy_frames=(0, 0),
+    )
+    unit = Unit(stats, 10, "enemy")
+    overlay = EnemyStackOverlay(screen, assets, [unit])
+    overlay.draw()
+
+    expected_stats = (
+        f"HP {stats.max_hp}  "
+        f"ATK {stats.attack_min}-{stats.attack_max}  "
+        f"DEF {stats.defence_melee}/{stats.defence_ranged}/{stats.defence_magic}  "
+        f"SPD {stats.speed}"
+    )
+
+    assert stats.name in rendered
+    assert estimate_stack_label(unit.count) in rendered
+    assert expected_stats in rendered

--- a/ui/enemy_stack_overlay.py
+++ b/ui/enemy_stack_overlay.py
@@ -42,33 +42,51 @@ class EnemyStackOverlay:
                     icon = pygame.transform.scale(icon, (icon_size, icon_size))
             name = self.font.render(unit.stats.name, True, self.TEXT)
             count = self.font.render(estimate_stack_label(unit.count), True, self.TEXT)
-            row_h = max(
+            stats_txt = (
+                f"HP {unit.stats.max_hp}  "
+                f"ATK {unit.stats.attack_min}-{unit.stats.attack_max}  "
+                f"DEF {unit.stats.defence_melee}/{unit.stats.defence_ranged}/{unit.stats.defence_magic}  "
+                f"SPD {unit.stats.speed}"
+            )
+            stats = self.font.render(stats_txt, True, self.TEXT)
+            line1_h = max(
                 icon.get_height() if icon else 0,
                 name.get_height(),
                 count.get_height(),
             )
-            row_w = (
+            row_h = line1_h + stats.get_height() + 4
+            line1_w = (
                 (icon.get_width() if icon else 0)
                 + 8
                 + name.get_width()
                 + 8
                 + count.get_width()
             )
+            stats_w = (icon.get_width() if icon else 0) + 8 + stats.get_width()
+            row_w = max(line1_w, stats_w)
             max_w = max(max_w, row_w)
-            rows.append((icon, name, count, row_h))
+            rows.append((icon, name, count, stats, line1_h, row_h))
         width = max_w + 20
-        height = sum(r[3] + 6 for r in rows) + 20
+        height = sum(r[5] + 6 for r in rows) + 20
         surface = pygame.Surface((width, height), pygame.SRCALPHA)
         surface.fill((*self.BG, 230))
         theme.draw_frame(surface, surface.get_rect())
         y = 10
-        for icon, name, count, row_h in rows:
+        for icon, name, count, stats, line1_h, row_h in rows:
             x = 10
             if icon:
-                surface.blit(icon, (x, y + (row_h - icon.get_height()) // 2))
+                surface.blit(icon, (x, y + (line1_h - icon.get_height()) // 2))
                 x += icon.get_width() + 8
-            surface.blit(name, (x, y + (row_h - name.get_height()) // 2))
-            surface.blit(count, (width - count.get_width() - 10, y + (row_h - count.get_height()) // 2))
+            surface.blit(name, (x, y + (line1_h - name.get_height()) // 2))
+            surface.blit(
+                count,
+                (
+                    width - count.get_width() - 10,
+                    y + (line1_h - count.get_height()) // 2,
+                ),
+            )
+            stats_x = 10 + ((icon.get_width() + 8) if icon else 0)
+            surface.blit(stats, (stats_x, y + line1_h + 4))
             y += row_h + 6
         sw, sh = self.screen.get_size()
         x = (sw - width) // 2


### PR DESCRIPTION
## Summary
- Expand enemy stack overlay to list HP, attack, defence, and speed along with qualitative stack sizes
- Note stats in game.open_enemy_stack_overlay for clarity
- Test that enemy stack overlay renders name, size label, and key stats

## Testing
- `pre-commit run --files ui/enemy_stack_overlay.py core/game.py tests/test_enemy_stack_overlay.py`
- `pytest tests/test_enemy_stack_overlay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3409381e08321828754cb41d6372e