### PR TITLE
Use VFX manifest for frame timing and handle missing effects

### DIFF
--- a/assets/vfx/vfx.json
+++ b/assets/vfx/vfx.json
@@ -1,5 +1,5 @@
 [
-  {"id": "fireball", "image": "vfx/fireball.png"},
+  {"id": "fireball", "image": "vfx/fireball.png", "frame_time": 0.05},
   {"id": "arrow", "image": "vfx/arrow.png"},
   {"id": "chain_lightning", "image": "vfx/chain_lightning.png"},
   {"id": "ice_wall", "image": "vfx/ice_wall.png"},

--- a/tests/test_missing_vfx_asset.py
+++ b/tests/test_missing_vfx_asset.py
@@ -1,0 +1,18 @@
+from core.spell import _trigger_fx
+from core.fx import FXQueue, FXEvent
+
+
+def test_trigger_fx_missing_asset(asset_manager):
+    queue = FXQueue()
+    _trigger_fx(queue, asset_manager, "missing_fx", (0, 0))
+    assert len(queue._events) == 1
+    event = queue._events[0]
+    assert isinstance(event, FXEvent)
+
+
+def test_combat_show_effect_missing_asset(asset_manager, simple_combat):
+    combat = simple_combat(assets=asset_manager)
+    combat.show_effect("missing_fx", (0, 0))
+    assert len(combat.fx_queue._events) == 1
+    event = combat.fx_queue._events[0]
+    assert isinstance(event, FXEvent)


### PR DESCRIPTION
## Summary
- use VFX manifest to fetch per-effect frame_time
- avoid flicker by skipping animation when assets fallback to placeholder
- include regression tests for missing VFX assets

## Testing
- `pytest tests/test_missing_vfx_asset.py -q`
- `pytest tests/test_spells.py::test_fireball_spell_damages_enemies -q`


------
https://chatgpt.com/codex/tasks/task_e_68b35e574ebc8321a27575ec16a365c8