### PR TITLE
Trigger morale FX when extra turn occurs

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -1068,6 +1068,7 @@ class Combat:
             unit.acted = True
             unit.skip_turn = False
         if unit.acted and unit.extra_turns > 0:
+            self.show_effect("morale_fx", (unit.x, unit.y))
             unit.extra_turns -= 1
             unit.acted = False
             return
@@ -1105,7 +1106,6 @@ class Combat:
         if outcome > 0:
             unit.extra_turns = 1
             self.add_log(f"{unit.stats.name} is inspired and gains an extra action!")
-            self.show_effect("morale_fx", (unit.x, unit.y))
         elif outcome < 0:
             unit.skip_turn = True
             self.add_log(f"{unit.stats.name} falters and loses its action!")

--- a/tests/test_morale.py
+++ b/tests/test_morale.py
@@ -26,9 +26,10 @@ def test_positive_morale_grants_extra_turn(monkeypatch, simple_combat):
     combat.check_morale(hero_unit)
     assert hero_unit.extra_turns == 1
     assert combat.log[-1] == "Swordsman is inspired and gains an extra action!"
-    assert len(combat.fx_queue._events) == before + 1
+    assert len(combat.fx_queue._events) == before
     hero_unit.acted = True
     combat.advance_turn()
+    assert len(combat.fx_queue._events) == before + 1
     assert hero_unit.extra_turns == 0
     assert not hero_unit.acted
     assert combat.turn_order[combat.current_index] is hero_unit


### PR DESCRIPTION
## Summary
- stop showing morale FX when morale bonus is granted
- trigger morale FX when extra action starts and limit to one extra turn
- update morale test to expect FX on extra turn

## Testing
- `make precommit-test`


------
https://chatgpt.com/codex/tasks/task_e_68b369c16dfc832188fdb7f9fc221d2d