### PR TITLE
Scale morale effect to hex size

### DIFF
--- a/assets/vfx/vfx.json
+++ b/assets/vfx/vfx.json
@@ -8,6 +8,6 @@
   {"id": "shield_block", "image": "vfx/shield_block.png", "frame_width": 64, "frame_height": 64, "frame_time": 0.1},
   {"id": "charge", "image": "vfx/charge.png", "frame_width": 64, "frame_height": 64, "frame_time": 0.1},
   {"id": "dragon_breath", "image": "vfx/dragon_breath.png", "frame_width": 64, "frame_height": 64, "frame_time": 0.1},
-  {"id": "morale_fx", "image": "icons/stat_morale.png", "frame_width": 64, "frame_height": 64, "frame_time": 0.1},
+  {"id": "morale_fx", "image": "icons/stat_morale.png", "frame_width": 128, "frame_height": 128, "frame_time": 0.1},
   {"id": "luck_fx", "image": "icons/stat_luck.png", "frame_width": 64, "frame_height": 64, "frame_time": 0.1}
 ]

--- a/core/combat.py
+++ b/core/combat.py
@@ -1797,7 +1797,7 @@ class Combat:
         rect = self.cell_rect(*pos)
         if hasattr(frames[0], "get_size"):
             w, h = frames[0].get_size()
-            scale = min(rect.width / w, rect.height / h, 1.0)
+            scale = min(self.hex_width / w, self.hex_height / h)
             if scale != 1.0 and hasattr(pygame, "transform"):
                 frames = [
                     pygame.transform.smoothscale(f, (int(w * scale), int(h * scale)))


### PR DESCRIPTION
## Summary
- increase morale_fx frame size for sharper visuals
- scale combat effects using hex dimensions and allow upscaling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b36b5926c88321a564f1e3b23a005b