### PR TITLE
Track morale bonus extra turns and skip redundant morale rolls

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -1075,6 +1075,8 @@ class Combat:
             unit.acted = False
             return
 
+        unit.morale_pending = False
+
         # Decrement ice wall durations
         for pos in list(self.ice_walls):
             self.ice_walls[pos] -= 1
@@ -1104,9 +1106,12 @@ class Combat:
 
     def check_morale(self, unit: Unit) -> None:
         """Apply morale effects to a unit at the start of its turn."""
+        if unit.morale_pending:
+            return
         outcome = combat_rules.roll_morale(unit.stats.morale)
         if outcome > 0:
             unit.extra_turns = 1
+            unit.morale_pending = True
             self.add_log(f"{unit.stats.name} is inspired and gains an extra action!")
         elif outcome < 0:
             unit.skip_turn = True

--- a/core/entities.py
+++ b/core/entities.py
@@ -203,6 +203,8 @@ class Unit:
         self.skip_turn: bool = False
         # Number of additional turns the unit may immediately take
         self.extra_turns: int = 0
+        # Whether a morale bonus extra action is pending
+        self.morale_pending: bool = False
         # Remaining retaliations available this round
         self.retaliations_left: int = stats.retaliations_per_round
         # Direction the unit is facing as a (dx, dy) vector

--- a/tests/test_morale.py
+++ b/tests/test_morale.py
@@ -21,18 +21,34 @@ def test_positive_morale_grants_extra_turn(monkeypatch, simple_combat):
     enemy_unit = combat.enemy_units[0]
     combat.turn_order = [hero_unit, enemy_unit]
     combat.current_index = 0
-    monkeypatch.setattr(random, 'random', lambda: 0.0)
+    calls = {"count": 0}
+
+    def fake_random() -> float:
+        calls["count"] += 1
+        return 0.0
+
+    monkeypatch.setattr(random, "random", fake_random)
     before = len(combat.fx_queue._events)
     combat.check_morale(hero_unit)
     assert hero_unit.extra_turns == 1
+    assert hero_unit.morale_pending
+    assert calls["count"] == 1
     assert combat.log[-1] == "Swordsman is inspired and gains an extra action!"
     assert len(combat.fx_queue._events) == before
     hero_unit.acted = True
     combat.advance_turn()
     assert len(combat.fx_queue._events) == before + 1
     assert hero_unit.extra_turns == 0
+    assert hero_unit.morale_pending
     assert not hero_unit.acted
     assert combat.turn_order[combat.current_index] is hero_unit
+    combat.check_morale(hero_unit)
+    assert calls["count"] == 1
+    hero_unit.acted = True
+    combat.advance_turn()
+    assert hero_unit.morale_pending is False
+    assert combat.turn_order[combat.current_index] is enemy_unit
+    assert len(combat.fx_queue._events) == before + 1
 
 
 def test_negative_morale_skips_turn(monkeypatch, simple_combat):
@@ -50,9 +66,11 @@ def test_negative_morale_skips_turn(monkeypatch, simple_combat):
     before = len(combat.fx_queue._events)
     combat.check_morale(hero_unit)
     assert hero_unit.skip_turn
+    assert not hero_unit.morale_pending
     assert combat.log[-1] == "Swordsman falters and loses its action!"
     assert len(combat.fx_queue._events) == before + 1
     combat.advance_turn()
     assert hero_unit.skip_turn is False
     assert hero_unit.acted
+    assert hero_unit.morale_pending is False
     assert combat.turn_order[combat.current_index] is enemy_unit


### PR DESCRIPTION
## Summary
- Add `morale_pending` flag to units to track morale-granted extra actions
- Skip morale roll on bonus turns and clear flag when unit's turn ends
- Extend morale tests to cover extra-turn flow and negative morale

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3750779ec8321b907a0d882ff63e5