### PR TITLE
Ensure mouse position fetched before HUD button collisions

### DIFF
--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -149,6 +149,9 @@ class CombatHUD:
 
         right, bottom = self._panel_rects(screen, grid_rect, combat)
 
+        mouse_get_pos = getattr(getattr(pygame, "mouse", None), "get_pos", lambda: (0, 0))
+        mouse_pos = mouse_get_pos()
+
         hover_target = getattr(combat, "hover_target", None)
         hover_damage = None
         if (


### PR DESCRIPTION
## Summary
- Retrieve mouse coordinates at the start of `CombatHUD.draw`
- Use the coordinates for hover checks before any `collidepoint` calls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b40ee77ff88321b8c10dbec680e357