### PR TITLE
Scale combat effects with cell size

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -1845,10 +1845,12 @@ class Combat:
         rect = self.cell_rect(*pos)
         if hasattr(frames[0], "get_size"):
             w, h = frames[0].get_size()
-            scale = min(self.hex_width / w, self.hex_height / h)
+            scale = min(rect.width / w, rect.height / h)
             if scale != 1.0 and hasattr(pygame, "transform"):
                 frames = [
-                    pygame.transform.smoothscale(f, (int(w * scale), int(h * scale)))
+                    pygame.transform.smoothscale(
+                        f, (int(f.get_width() * scale), int(f.get_height() * scale))
+                    )
                     for f in frames
                 ]
         if hasattr(rect, "center"):


### PR DESCRIPTION
## Summary
- Scale combat effects based on cell rect dimensions
- Resize each effect frame individually so animations fit current zoom

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b40fc6f9b883218bffb514ab4870f2