### PR TITLE
Sync UnitView stack counts in combat previews

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -274,6 +274,7 @@ def draw(combat, frame: int = 0) -> None:
                     attacker.retaliations_left,
                     attacker.facing,
                 )
+                att_view.count = attacker.count
                 def_view = UnitView(
                     candidate.side,
                     candidate.stats,
@@ -282,6 +283,7 @@ def draw(combat, frame: int = 0) -> None:
                     candidate.retaliations_left,
                     candidate.facing,
                 )
+                def_view.count = candidate.count
                 dist = combat.hex_distance(
                     (attacker.x, attacker.y), (candidate.x, candidate.y)
                 )

--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -168,6 +168,7 @@ class CombatHUD:
                 attacker.retaliations_left,
                 attacker.facing,
             )
+            att_view.count = attacker.count
             def_view = UnitView(
                 hover_target.side,
                 hover_target.stats,
@@ -176,6 +177,7 @@ class CombatHUD:
                 hover_target.retaliations_left,
                 hover_target.facing,
             )
+            def_view.count = hover_target.count
             dist = combat.hex_distance(
                 (attacker.x, attacker.y), (hover_target.x, hover_target.y)
             )


### PR DESCRIPTION
## Summary
- Preserve attacker and defender stack sizes when constructing `UnitView` for combat hover previews.
- Ensures damage projections and tooltips use accurate unit counts.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b411a1a2ac83218f0e5d289499797c