### PR TITLE
Allow custom RNG for damage previews

### DIFF
--- a/core/combat_render.py
+++ b/core/combat_render.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Tuple
 
+import random
 import pygame
 import constants
 import theme
@@ -293,6 +294,7 @@ def draw(combat, frame: int = 0) -> None:
                     attack_type=combat.selected_action,
                     distance=dist,
                     obstacles=combat.obstacles,
+                    rng=random.Random(0),
                 )["value"]
 
     combat.hover_target = hover_target

--- a/core/combat_screen.py
+++ b/core/combat_screen.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Callable, Dict, Tuple, Optional, List
 import json
 from pathlib import Path
+import random
 import pygame
 import theme
 import settings
@@ -187,6 +188,7 @@ class CombatHUD:
                 attack_type=combat.selected_action,
                 distance=dist,
                 obstacles=combat.obstacles,
+                rng=random.Random(0),
             )["value"]
 
         # Backgrounds

--- a/tests/test_luck_log.py
+++ b/tests/test_luck_log.py
@@ -1,11 +1,11 @@
 import os
-import random
 from dataclasses import replace
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
 from core.entities import Unit, RECRUITABLE_UNITS
 import pygame
+import core.combat_rules as combat_rules
 
 SWORDSMAN_STATS = RECRUITABLE_UNITS["swordsman"]
 
@@ -19,7 +19,7 @@ def test_positive_luck_logs(monkeypatch, simple_combat):
     combat = simple_combat([hero], [enemy], assets=assets)
     attacker = combat.hero_units[0]
     defender = combat.enemy_units[0]
-    monkeypatch.setattr(random, 'random', lambda: 0.0)
+    monkeypatch.setattr(combat_rules.RNG, 'random', lambda: 0.0)
     before = len(combat.fx_queue._events)
     combat.resolve_attack(attacker, defender, 'melee')
     assert combat.log[-1] == 'Lucky strike by Swordsman!'
@@ -35,7 +35,7 @@ def test_negative_luck_logs(monkeypatch, simple_combat):
     combat = simple_combat([hero], [enemy], assets=assets)
     attacker = combat.hero_units[0]
     defender = combat.enemy_units[0]
-    monkeypatch.setattr(random, 'random', lambda: 0.0)
+    monkeypatch.setattr(combat_rules.RNG, 'random', lambda: 0.0)
     before = len(combat.fx_queue._events)
     combat.resolve_attack(attacker, defender, 'melee')
     assert combat.log[-1] == 'Unlucky hit by Swordsman.'

--- a/tests/test_morale.py
+++ b/tests/test_morale.py
@@ -1,6 +1,6 @@
 import os
-import random
 from dataclasses import replace
+import core.combat_rules as combat_rules
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
@@ -27,7 +27,7 @@ def test_positive_morale_grants_extra_turn(monkeypatch, simple_combat):
         calls["count"] += 1
         return 0.0
 
-    monkeypatch.setattr(random, "random", fake_random)
+    monkeypatch.setattr(combat_rules.RNG, "random", fake_random)
     before = len(combat.fx_queue._events)
     combat.check_morale(hero_unit)
     assert hero_unit.extra_turns == 1
@@ -68,7 +68,7 @@ def test_morale_not_rechecked_after_extra_turn(monkeypatch, simple_combat):
         calls["count"] += 1
         return 0.0
 
-    monkeypatch.setattr(random, "random", fake_random)
+    monkeypatch.setattr(combat_rules.RNG, "random", fake_random)
     combat.check_morale(hero_unit)
     assert hero_unit.extra_turns == 1
     hero_unit.acted = True
@@ -92,7 +92,7 @@ def test_negative_morale_skips_turn(monkeypatch, simple_combat):
     enemy_unit = combat.enemy_units[0]
     combat.turn_order = [hero_unit, enemy_unit]
     combat.current_index = 0
-    monkeypatch.setattr(random, 'random', lambda: 0.0)
+    monkeypatch.setattr(combat_rules.RNG, 'random', lambda: 0.0)
     before = len(combat.fx_queue._events)
     combat.check_morale(hero_unit)
     assert hero_unit.skip_turn

--- a/tests/test_roll_tables.py
+++ b/tests/test_roll_tables.py
@@ -1,35 +1,35 @@
-import random
+from types import SimpleNamespace
 
 from core.combat_rules import roll_morale, roll_luck
 
 
-def test_roll_morale_table(monkeypatch):
-    monkeypatch.setattr(random, 'random', lambda: 0.03)
-    assert roll_morale(1) == 1
-    monkeypatch.setattr(random, 'random', lambda: 0.05)
-    assert roll_morale(1) == 0
-    monkeypatch.setattr(random, 'random', lambda: 0.12)
-    assert roll_morale(3) == 1
-    monkeypatch.setattr(random, 'random', lambda: 0.13)
-    assert roll_morale(3) == 0
-    monkeypatch.setattr(random, 'random', lambda: 0.0)
-    assert roll_morale(5) == 1
-    assert roll_morale(-5) == -1
+def test_roll_morale_table():
+    rng = SimpleNamespace(random=lambda: 0.03)
+    assert roll_morale(1, rng=rng) == 1
+    rng.random = lambda: 0.05
+    assert roll_morale(1, rng=rng) == 0
+    rng.random = lambda: 0.12
+    assert roll_morale(3, rng=rng) == 1
+    rng.random = lambda: 0.13
+    assert roll_morale(3, rng=rng) == 0
+    rng.random = lambda: 0.0
+    assert roll_morale(5, rng=rng) == 1
+    assert roll_morale(-5, rng=rng) == -1
 
 
-def test_roll_luck_table(monkeypatch):
-    monkeypatch.setattr(random, 'random', lambda: 0.03)
-    assert roll_luck(1) == 1.5
-    monkeypatch.setattr(random, 'random', lambda: 0.05)
-    assert roll_luck(1) == 1.0
-    monkeypatch.setattr(random, 'random', lambda: 0.03)
-    assert roll_luck(-1) == 0.5
-    monkeypatch.setattr(random, 'random', lambda: 0.05)
-    assert roll_luck(-1) == 1.0
-    monkeypatch.setattr(random, 'random', lambda: 0.08)
-    assert roll_luck(2) == 1.5
-    monkeypatch.setattr(random, 'random', lambda: 0.09)
-    assert roll_luck(2) == 1.0
-    monkeypatch.setattr(random, 'random', lambda: 0.0)
-    assert roll_luck(5) == 1.5
-    assert roll_luck(-5) == 0.5
+def test_roll_luck_table():
+    rng = SimpleNamespace(random=lambda: 0.03)
+    assert roll_luck(1, rng=rng) == 1.5
+    rng.random = lambda: 0.05
+    assert roll_luck(1, rng=rng) == 1.0
+    rng.random = lambda: 0.03
+    assert roll_luck(-1, rng=rng) == 0.5
+    rng.random = lambda: 0.05
+    assert roll_luck(-1, rng=rng) == 1.0
+    rng.random = lambda: 0.08
+    assert roll_luck(2, rng=rng) == 1.5
+    rng.random = lambda: 0.09
+    assert roll_luck(2, rng=rng) == 1.0
+    rng.random = lambda: 0.0
+    assert roll_luck(5, rng=rng) == 1.5
+    assert roll_luck(-5, rng=rng) == 0.5


### PR DESCRIPTION
## Summary
- Refactor combat damage and roll helpers to accept an optional RNG
- Use a deterministic RNG for hover damage previews
- Update tests to inject RNG instead of patching `random`

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b412723a2c8321ae841e233516461a