### PR TITLE
Fix audio loading before mixer init

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -120,15 +120,14 @@ def init(asset_manager: AssetManager | None = None) -> None:
     if asset_manager is not None:
         set_asset_manager(asset_manager)
 
-    _load_manifests()
+    if _has_mixer():
+        try:  # pragma: no cover - depends on system audio
+            if not pygame.mixer.get_init():
+                pygame.mixer.init()
+        except Exception:
+            pass
 
-    if not _has_mixer():
-        return
-    try:  # pragma: no cover - depends on system audio
-        if not pygame.mixer.get_init():
-            pygame.mixer.init()
-    except Exception:
-        return
+    _load_manifests()
 
 
 def load_sound(key: str, filename: str) -> None:

--- a/tests/test_audio_init.py
+++ b/tests/test_audio_init.py
@@ -1,0 +1,47 @@
+import types
+import audio
+
+
+def test_init_initializes_mixer_before_loading(monkeypatch, tmp_path):
+    init_states: list[bool] = []
+
+    class DummySound:
+        def __init__(self, path):
+            init_states.append(DummyMixer.initialized)
+        def set_volume(self, vol):
+            pass
+
+    class DummyMixer:
+        initialized = False
+        @staticmethod
+        def get_init():
+            return DummyMixer.initialized
+        @staticmethod
+        def init():
+            DummyMixer.initialized = True
+        Sound = DummySound
+        class music:
+            @staticmethod
+            def set_volume(vol):
+                pass
+            @staticmethod
+            def load(path):
+                pass
+            @staticmethod
+            def play(loop):
+                pass
+
+    dummy_pygame = types.SimpleNamespace(mixer=DummyMixer)
+    monkeypatch.setattr(audio, "pygame", dummy_pygame)
+    monkeypatch.setattr(audio, "_has_mixer", lambda: True)
+
+    dummy_file = tmp_path / "foo.wav"
+    dummy_file.write_bytes(b"\0")
+    monkeypatch.setattr(audio, "_find_asset", lambda filename: str(dummy_file))
+    monkeypatch.setattr(audio, "_load_manifests", lambda: audio.load_sound("beep", "foo.wav"))
+
+    audio._sounds.clear()
+    audio.init()
+
+    assert init_states and init_states[0]
+    assert "beep" in audio._sounds


### PR DESCRIPTION
## Summary
- ensure pygame mixer is initialized before loading audio manifests
- add regression test for audio initialization order

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41a655ba88321b150952274923b2d