### PR TITLE
Warn when audio file missing during sound load

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -149,6 +149,7 @@ def load_sound(key: str, filename: str) -> None:
         return
     path = _find_asset(filename)
     if path is None or not os.path.isfile(path):
+        _logger.warning("Missing audio file %s", filename)
         return
     try:  # pragma: no cover - loading depends on external files
         snd = pygame.mixer.Sound(path)


### PR DESCRIPTION
## Summary
- Log warning when a sound asset cannot be found before returning from `load_sound`

## Testing
- `pre-commit run --files audio.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4239f948c83218a276594b92ae87a