### PR TITLE
Avoid forcing SDL audio driver on non-Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,11 @@ chunk) and `biome_cache_size` (maximum cached chunks).
 ## Audio Troubleshooting
 
 If the game starts without producing any sound, the audio mixer may have
-failed to initialise. A default `SDL_AUDIODRIVER` is chosen automatically, and
-an error is logged when mixer setup fails. Verify an audio device is available
+failed to initialise. On Windows a default `SDL_AUDIODRIVER` of `directsound`
+is chosen automatically; other platforms rely on SDL's auto-detection. An
+error is logged when mixer setup fails. Verify an audio device is available
 or set `SDL_AUDIODRIVER` (for example `pulseaudio`, `alsa` or
-`directsound`) before launching the game.
+another driver) before launching the game.
 
 ## Roadmap and Ideas
 

--- a/audio.py
+++ b/audio.py
@@ -130,8 +130,7 @@ def init(asset_manager: AssetManager | None = None) -> None:
         if "SDL_AUDIODRIVER" not in os.environ:
             if sys.platform.startswith("win"):
                 os.environ["SDL_AUDIODRIVER"] = "directsound"
-            else:
-                os.environ["SDL_AUDIODRIVER"] = "pulseaudio"
+            # leave other platforms unset
         try:  # pragma: no cover - depends on system audio
             if not pygame.mixer.get_init():
                 pygame.mixer.init()


### PR DESCRIPTION
## Summary
- only set `SDL_AUDIODRIVER` to `directsound` on Windows
- document that other platforms rely on SDL's auto-detection

## Testing
- `python -m pre_commit run --files audio.py README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b42452477883218bdce959741f2da6