### PR TITLE
docs: clarify SDL audio driver defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,12 @@ chunk) and `biome_cache_size` (maximum cached chunks).
 ## Audio Troubleshooting
 
 If the game starts without producing any sound, the audio mixer may have
-failed to initialise. On Windows a default `SDL_AUDIODRIVER` of `directsound`
-is chosen automatically; other platforms rely on SDL's auto-detection. An
-error is logged when mixer setup fails. Verify an audio device is available
-or set `SDL_AUDIODRIVER` (for example `pulseaudio`, `alsa` or
-another driver) before launching the game.
+failed to initialise. On Windows, when `SDL_AUDIODRIVER` is not set the game
+defaults it to `directsound` before initialising audio. Other platforms leave
+the variable unset and rely on SDL's auto-detection. An error is logged when
+mixer setup fails. Ensure an audio device is available or manually set
+`SDL_AUDIODRIVER` (for example `pulseaudio`, `alsa`, `coreaudio` or another
+driver) before launching the game.
 
 ## Roadmap and Ideas
 


### PR DESCRIPTION
## Summary
- clarify audio troubleshooting instructions
- document Windows default to `directsound` when `SDL_AUDIODRIVER` is unset
- note that other platforms rely on SDL auto-detection and may set `SDL_AUDIODRIVER` manually

## Testing
- `pre-commit run --files README.md`


------
https://chatgpt.com/codex/tasks/task_e_68b4252e1bf88321bea5950f5fe6e8d1