### PR TITLE
Use dedicated audio loader with correct project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ speed, enabling a reader-friendly tooltip mode and remapping controls. The
 world renderer's biome caching can be tuned with `biome_chunk_tiles` (tiles per
 chunk) and `biome_cache_size` (maximum cached chunks).
 
+## Audio Troubleshooting
+
+If the game starts without producing any sound, the audio mixer may have
+failed to initialise. A default `SDL_AUDIODRIVER` is chosen automatically, and
+an error is logged when mixer setup fails. Verify an audio device is available
+or set `SDL_AUDIODRIVER` (for example `pulseaudio`, `alsa` or
+`directsound`) before launching the game.
+
 ## Roadmap and Ideas
 
 There are many directions to expand the game.  Some possibilities include:

--- a/audio.py
+++ b/audio.py
@@ -1,20 +1,24 @@
+import os
+import json
+import sys
+import logging
+from typing import Dict, Optional
+
 try:
-    import os
-    import json
     import pygame
-    from typing import Dict, Optional
     try:
         from .loaders.asset_manager import AssetManager
-        from .loaders.core import Context, find_file, read_json
+        from .loaders import audio_loader
     except ImportError:  # pragma: no cover - package vs script
         from loaders.asset_manager import AssetManager  # type: ignore
-        from loaders.core import Context, find_file, read_json  # type: ignore
+        from loaders import audio_loader  # type: ignore
 except Exception:  # pragma: no cover - when pygame is unavailable
     pygame = None
     AssetManager = None  # type: ignore
-    Context = None  # type: ignore
-    find_file = None  # type: ignore
-    read_json = None  # type: ignore
+    audio_loader = None  # type: ignore
+
+
+_logger = logging.getLogger(__name__)
 
 import settings
 
@@ -47,20 +51,15 @@ def _find_asset(filename: str) -> Optional[str]:
     if _asset_manager is not None:
         search_paths = list(_asset_manager.search_paths)
     else:
-        search_paths = [os.path.join(os.path.dirname(__file__), "assets")]
+        search_paths = ["assets"]
 
-    if Context is None or find_file is None:  # pragma: no cover - defensive
-        for base in search_paths:
-            candidate = os.path.join(base, filename)
-            if os.path.isfile(candidate):
-                return candidate
-        return None
-
-    ctx = Context(repo_root="", search_paths=search_paths, asset_loader=None)
-    try:
-        return find_file(ctx, filename)
-    except FileNotFoundError:
-        return None
+    if audio_loader is not None:
+        return audio_loader.find_audio_file(filename, search_paths)
+    for base in search_paths:
+        candidate = os.path.join(base, filename)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
 
 
 def _has_mixer() -> bool:
@@ -69,22 +68,17 @@ def _has_mixer() -> bool:
 
 def _load_manifests() -> None:
     """Load sound and music manifests from the assets folder."""
-    if Context is None or read_json is None:
+    if audio_loader is None:
         return
 
     search_paths: list[str]
     if _asset_manager is not None:
         search_paths = list(_asset_manager.search_paths)
     else:
-        search_paths = [os.path.join(os.path.dirname(__file__), "assets")]
-
-    ctx = Context(repo_root="", search_paths=search_paths, asset_loader=None)
+        search_paths = ["assets"]
 
     # Load sounds
-    try:
-        data = read_json(ctx, os.path.join("audio", "sounds.json"))
-    except Exception:  # pragma: no cover - missing manifest
-        data = []
+    data = audio_loader.load_manifest("sounds.json", search_paths)
     for entry in data or []:
         key = entry.get("id")
         file = entry.get("file")
@@ -93,10 +87,7 @@ def _load_manifests() -> None:
 
     # Load music tracks
     global _default_music
-    try:
-        music_data = read_json(ctx, os.path.join("audio", "music.json"))
-    except Exception:  # pragma: no cover
-        music_data = []
+    music_data = audio_loader.load_manifest("music.json", search_paths)
     for entry in music_data or []:
         key = entry.get("id")
         file = entry.get("file")
@@ -121,11 +112,18 @@ def init(asset_manager: AssetManager | None = None) -> None:
         set_asset_manager(asset_manager)
 
     if _has_mixer():
+        if "SDL_AUDIODRIVER" not in os.environ:
+            if sys.platform.startswith("win"):
+                os.environ["SDL_AUDIODRIVER"] = "directsound"
+            else:
+                os.environ["SDL_AUDIODRIVER"] = "pulseaudio"
         try:  # pragma: no cover - depends on system audio
             if not pygame.mixer.get_init():
                 pygame.mixer.init()
-        except Exception:
-            pass
+        except Exception as exc:
+            _logger.error("Failed to initialise audio mixer: %s", exc)
+        if pygame.mixer.get_init() is None:
+            _logger.warning("Audio device not available; sound will be disabled.")
 
     _load_manifests()
 

--- a/loaders/audio_loader.py
+++ b/loaders/audio_loader.py
@@ -1,0 +1,44 @@
+"""Utilities for locating audio assets with consistent project root handling."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Sequence, Any
+
+from .core import Context, find_file, read_json
+
+
+def _build_context(search_paths: Sequence[str]) -> Context:
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    return Context(repo_root=repo_root, search_paths=search_paths, asset_loader=None)
+
+
+def find_audio_file(filename: str, search_paths: Sequence[str] | None = None) -> Optional[str]:
+    """Return absolute path to ``filename`` searching ``search_paths``.
+
+    ``search_paths`` defaults to ``["assets"]`` relative to the repository root.
+    ``None`` is returned when the file is not found.
+    """
+
+    if search_paths is None:
+        search_paths = ["assets"]
+    ctx = _build_context(search_paths)
+    try:
+        return find_file(ctx, filename)
+    except FileNotFoundError:
+        return None
+
+
+def load_manifest(name: str, search_paths: Sequence[str] | None = None) -> Any:
+    """Load an audio manifest JSON file under ``assets/audio``."""
+
+    if search_paths is None:
+        search_paths = ["assets"]
+    ctx = _build_context(search_paths)
+    try:
+        return read_json(ctx, os.path.join("audio", name))
+    except Exception:
+        return []
+
+
+__all__ = ["find_audio_file", "load_manifest"]


### PR DESCRIPTION
## Summary
- add `loaders.audio_loader` to locate audio assets using repo-root-aware `Context`
- resolve sound and music manifests via the new loader in `audio.py`

## Testing
- `pre-commit run --files audio.py loaders/audio_loader.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41f7252c88321ae76f097ef70f08a