### PR TITLE
Improve audio asset search paths

### DIFF
--- a/loaders/audio_loader.py
+++ b/loaders/audio_loader.py
@@ -3,40 +3,72 @@
 from __future__ import annotations
 
 import os
-from typing import Optional, Sequence, Any
+from pathlib import Path
+from typing import Any, Optional, Sequence
 
 from .core import Context, find_file, read_json
 
 
-def _build_context(search_paths: Sequence[str]) -> Context:
-    repo_root = os.path.dirname(os.path.dirname(__file__))
-    return Context(repo_root=repo_root, search_paths=search_paths, asset_loader=None)
+_ROOT = Path(__file__).resolve().parents[1]
 
 
-def find_audio_file(filename: str, search_paths: Sequence[str] | None = None) -> Optional[str]:
+def _candidate_asset_dirs() -> list[Path]:
+    dirs: list[Path] = []
+    env = os.environ.get("FG_ASSETS_DIR")
+    if env:
+        for part in env.split(os.pathsep):
+            if part:
+                p = Path(part).expanduser()
+                if not p.is_absolute():
+                    p = _ROOT / p
+                dirs.append(p.resolve())
+    dirs.append((_ROOT / "assets").resolve())
+    parent_assets = (_ROOT.parent / "assets").resolve()
+    if parent_assets.is_dir():
+        dirs.append(parent_assets)
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for d in dirs:
+        if d not in seen:
+            out.append(d)
+            seen.add(d)
+    return out
+
+
+def _build_context(extra_paths: Sequence[str | os.PathLike[str]] | None = None) -> Context:
+    dirs = _candidate_asset_dirs()
+    if extra_paths:
+        for p in extra_paths:
+            q = Path(p).expanduser()
+            if not q.is_absolute():
+                q = _ROOT / q
+            q = q.resolve()
+            if q not in dirs:
+                dirs.append(q)
+    return Context(repo_root=str(_ROOT), search_paths=[str(d) for d in dirs], asset_loader=None)
+
+
+def find_audio_file(filename: str, search_paths: Sequence[str | os.PathLike[str]] | None = None) -> Optional[str]:
     """Return absolute path to ``filename`` searching ``search_paths``.
 
-    ``search_paths`` defaults to ``["assets"]`` relative to the repository root.
+    ``search_paths`` augments the default candidate asset directories.
     ``None`` is returned when the file is not found.
     """
 
-    if search_paths is None:
-        search_paths = ["assets"]
     ctx = _build_context(search_paths)
     try:
-        return find_file(ctx, filename)
+        return find_file(ctx, str(filename))
     except FileNotFoundError:
         return None
 
 
-def load_manifest(name: str, search_paths: Sequence[str] | None = None) -> Any:
+def load_manifest(name: str, search_paths: Sequence[str | os.PathLike[str]] | None = None) -> Any:
     """Load an audio manifest JSON file under ``assets/audio``."""
 
-    if search_paths is None:
-        search_paths = ["assets"]
     ctx = _build_context(search_paths)
+    rel = Path("audio") / name
     try:
-        return read_json(ctx, os.path.join("audio", name))
+        return read_json(ctx, str(rel))
     except Exception:
         return []
 


### PR DESCRIPTION
## Summary
- Expand audio asset discovery to consider FG_ASSETS_DIR, local assets folder, and optional parent assets directory
- Allow audio loading helpers to accept extra search paths while using pathlib for consistent path handling

## Testing
- `pytest tests/test_audio_init.py tests/test_icon_loader.py tests/test_asset_manager_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42e95e40c832180ac919a343c0d2a