### PR TITLE
Document audio asset lookup order

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ chunk) and `biome_cache_size` (maximum cached chunks).
 
 ## Audio Troubleshooting
 
+Audio files are searched in the following order:
+
+- Paths listed in the `FG_ASSETS_DIR` environment variable. This variable
+  accepts multiple paths separated by the operating system's path separator.
+- The project's bundled `assets` directory.
+- An `assets` directory in the parent of the project, if present.
+
 If the game starts without producing any sound, the audio mixer may have
 failed to initialise. A default `SDL_AUDIODRIVER` is chosen automatically, and
 an error is logged when mixer setup fails. Verify an audio device is available


### PR DESCRIPTION
## Summary
- document audio lookup precedence for `FG_ASSETS_DIR`, project `assets`, and parent `assets`

## Testing
- `pre-commit run --files README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b430114ecc832196370c10fa39e6a7