### PR TITLE
Add comprehensive UI sound effect support

### DIFF
--- a/assets/audio/sounds.json
+++ b/assets/audio/sounds.json
@@ -8,5 +8,16 @@
   {"id": "defeat", "file": "audio/defeat.wav"},
   {"id": "hover", "file": "audio/hover.wav"},
   {"id": "click", "file": "audio/click.wav"},
-  {"id": "end_turn", "file": "audio/end_turn.wav"}
+  {"id": "end_turn", "file": "audio/end_turn.wav"},
+  {"id": "ui_confirm",  "file": "audio/ui/confirm.wav"},
+  {"id": "ui_cancel",   "file": "audio/ui/cancel.wav"},
+  {"id": "ui_error",    "file": "audio/ui/error.wav"},
+  {"id": "panel_open",  "file": "audio/ui/panel_open.wav"},
+  {"id": "panel_close", "file": "audio/ui/panel_close.wav"},
+  {"id": "drag_start",  "file": "audio/ui/drag_start.wav"},
+  {"id": "drag_drop",   "file": "audio/ui/drag_drop.wav"},
+  {"id": "list_scroll", "file": "audio/ui/list_scroll.wav"},
+  {"id": "notification","file": "audio/ui/notification.wav"},
+  {"id": "save_game",   "file": "audio/ui/save_game.wav"},
+  {"id": "load_game",   "file": "audio/ui/load_game.wav"}
 ]

--- a/core/game.py
+++ b/core/game.py
@@ -649,6 +649,7 @@ class Game:
     def _notify(self, message: str) -> None:
         """Log ``message`` and publish it to the UI event bus."""
         logger.info(message)
+        audio.play_sound("notification")
         EVENT_BUS.publish(ON_INFO_MESSAGE, message)
 
     def _load_sea_chain(self) -> None:
@@ -3852,6 +3853,7 @@ class Game:
         if path is None:
             msg = "No save path specified"
             logger.warning(msg)
+            audio.play_sound("ui_error")
             EVENT_BUS.publish(ON_INFO_MESSAGE, msg)
             return msg
 
@@ -3884,6 +3886,7 @@ class Game:
         slots = getattr(self, "save_slots", [])
         if path in slots:
             self.current_slot = slots.index(path)
+        audio.play_sound("save_game")
 
     def quick_save(self) -> None:
         """Convenience wrapper saving to the predefined quick-save slot."""
@@ -3929,6 +3932,7 @@ class Game:
         if path is None or not os.path.exists(path):
             msg = f"Save file not found: {path}"
             logger.warning("Save file %s not found", path)
+            audio.play_sound("ui_error")
             EVENT_BUS.publish(ON_INFO_MESSAGE, msg)
             return msg
         with open(path, "r", encoding="utf-8") as f:
@@ -3957,3 +3961,4 @@ class Game:
         slots = getattr(self, "save_slots", [])
         if path in slots:
             self.current_slot = slots.index(path)
+        audio.play_sound("load_game")

--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -7,6 +7,7 @@ from typing import Callable, Iterable, Tuple, Any
 import pygame
 
 import constants
+import audio
 
 
 def run_dialog(
@@ -30,12 +31,14 @@ def run_dialog(
                 pygame.quit()
                 exit()
             if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                audio.play_sound("ui_cancel")
                 if on_escape:
                     on_escape()
                 return escape_result
             if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 for rect, result in buttons:
                     if rect.collidepoint(event.pos):
+                        audio.play_sound("ui_confirm")
                         return result
         draw_fn()
         pygame.display.flip()

--- a/ui/inventory_screen.py
+++ b/ui/inventory_screen.py
@@ -14,6 +14,7 @@ import pygame
 
 import constants
 import theme
+import audio
 from .widgets.icon_button import IconButton
 from core.entities import (
     EquipmentSlot,
@@ -762,6 +763,7 @@ class InventoryScreen:
                     self.drag_item = self.hero.inventory[inv_idx]
                     self.drag_origin = inv_idx
                     self.drag_icon_size = (size - 4, size - 4)
+                    audio.play_sound("drag_start")
                     return
             for slot, r in self.slot_rects.items():
                 if r.collidepoint(pos):
@@ -791,6 +793,7 @@ class InventoryScreen:
                         self.drag_origin = None
                         self.drag_icon_size = r.size
                         del self.hero.equipment[slot]
+                        audio.play_sound("drag_start")
                     return
             self._last_click_slot = None
             self._last_click_time = 0
@@ -803,6 +806,7 @@ class InventoryScreen:
                     if unit:
                         self.drag_unit = unit
                         self.drag_unit_origin = idx
+                        audio.play_sound("drag_start")
                     return
 
         elif self.active_tab == "skills":
@@ -834,6 +838,7 @@ class InventoryScreen:
             self.drag_item = None
             self.drag_origin = None
             self.drag_icon_size = None
+            audio.play_sound("drag_drop")
             return
 
         if self.drag_unit is not None:
@@ -852,6 +857,7 @@ class InventoryScreen:
                 self.hero.army = [u for u in self.army_grid if u]
             self.drag_unit = None
             self.drag_unit_origin = None
+            audio.play_sound("drag_drop")
             return
 
         # Skills: right-click refund (safe if no dependent learned)

--- a/ui/main_screen.py
+++ b/ui/main_screen.py
@@ -13,6 +13,7 @@ from typing import Dict, Optional, List
 
 import os
 import pygame
+import audio
 from . import theme, constants
 
 from .layout import Layout
@@ -122,6 +123,7 @@ class MainScreen:
             self.game, "open_menu", None
         )
         if cb:
+            audio.play_sound("panel_open")
             cb()
 
     def save_game(self) -> None:
@@ -165,11 +167,13 @@ class MainScreen:
                     town = getattr(self.game, "_focused_town", None)
                     pos = getattr(self.game, "_focused_town_pos", None)
                     try:
+                        audio.play_sound("panel_open")
                         if town:
                             open_cb(town, town_pos=pos)
                         else:
                             open_cb()
                     except TypeError:
+                        audio.play_sound("panel_open")
                         if town:
                             open_cb(town, town_pos=pos)
                         else:

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -451,6 +451,7 @@ def main_menu(screen: pygame.Surface, can_resume: bool = False) -> pygame.Surfac
             save_dir = os.path.dirname(__file__)
             save_path = os.path.join(save_dir, SAVE_SLOT_FILES[slot])
             if not os.path.exists(save_path):
+                audio.play_sound("notification")
                 _, screen = simple_menu(
                     screen,
                     [MENU_TEXTS["file_not_found"], MENU_TEXTS["back"]],
@@ -461,10 +462,12 @@ def main_menu(screen: pygame.Surface, can_resume: bool = False) -> pygame.Surfac
             game = Game(screen, slot=slot)
             try:
                 game.load_game(save_path)
+                audio.play_sound("load_game")
             except FileNotFoundError:
                 track = audio.get_current_music() or audio.get_default_music()
                 if track:
                     audio.play_music(track)
+                audio.play_sound("notification")
                 _, screen = simple_menu(
                     screen,
                     [MENU_TEXTS["file_not_found"], MENU_TEXTS["back"]],
@@ -513,6 +516,7 @@ def pause_menu(screen: pygame.Surface, game: Game) -> Tuple[bool, pygame.Surface
             game.default_save_path = game.save_slots[slot]
             game.default_profile_path = game.profile_slots[slot]
             game.save_game(game.default_save_path, game.default_profile_path)
+            audio.play_sound("save_game")
         elif choice == 2:  # Options
             screen = options_menu(screen)
         else:  # Quit to menu

--- a/ui/menu_utils.py
+++ b/ui/menu_utils.py
@@ -70,15 +70,15 @@ def simple_menu(
             if event.type == pygame.KEYDOWN:
                 if event.key in (pygame.K_UP, pygame.K_w):
                     selected = (selected - 1) % len(opts)
-                    audio.play_sound("move")
+                    audio.play_sound("list_scroll")
                 elif event.key in (pygame.K_DOWN, pygame.K_s):
                     selected = (selected + 1) % len(opts)
-                    audio.play_sound("move")
+                    audio.play_sound("list_scroll")
                 elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
-                    audio.play_sound("click")
+                    audio.play_sound("ui_confirm")
                     return selected, screen
                 elif event.key == pygame.K_ESCAPE:
-                    audio.play_sound("click")
+                    audio.play_sound("ui_cancel")
                     return None, screen
                 elif event.key == pygame.K_F11:
                     pygame.display.toggle_fullscreen()

--- a/ui/options_menu.py
+++ b/ui/options_menu.py
@@ -171,8 +171,11 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
         choice, screen = simple_menu(screen, options, title="Options")
 
         if choice is None or choice == 11:
+            audio.play_sound("ui_cancel")
             _persist()
             return screen
+
+        audio.play_sound("ui_confirm")
 
         if choice == 0:
             sel, screen = simple_menu(
@@ -251,13 +254,18 @@ def options_menu(screen: pygame.Surface) -> pygame.Surface:
                     title="Musique de fond",
                 )
                 if sel is not None:
+                    audio.play_sound("ui_confirm")
                     if sel < len(tracks):
                         track_idx = sel
                         audio.play_music(tracks[track_idx])
                     elif sel == len(tracks):
                         track_idx = -1
                         audio.stop_music()
+                else:
+                    audio.play_sound("ui_cancel")
                 _persist()
+            else:
+                audio.play_sound("ui_error")
         elif choice == 9:
             screen = _keymap_menu(screen)
             _persist()

--- a/ui/town_overlay.py
+++ b/ui/town_overlay.py
@@ -31,16 +31,20 @@ class TownOverlay:
                     pass
         self.font = theme.get_font(16)
         self.town_rects: List[Tuple[pygame.Rect, "Town"]] = []
+        audio.play_sound("panel_open")
 
     # ------------------------------------------------------------------
     def handle_event(self, event: pygame.event.Event) -> Union[bool, "Town"]:
         if event.type == pygame.KEYDOWN and event.key == pygame.K_u:
+            audio.play_sound("panel_close")
             return True  # signal to caller to close overlay
         if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+            audio.play_sound("panel_close")
             return True
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             for rect, town in self.town_rects:
                 if rect.collidepoint(event.pos):
+                    audio.play_sound("panel_close")
                     return town
         return False
 

--- a/ui/widgets/buttons_column.py
+++ b/ui/widgets/buttons_column.py
@@ -145,12 +145,12 @@ class ButtonsColumn:
                     break
             if idx != self.hover_index:
                 if idx is not None and self.buttons[idx].button.enabled:
-                    audio.play_sound("hover")
+                    audio.play_sound("list_scroll")
                 self.hover_index = idx
         else:
             for entry in self.buttons:
                 if entry.button.handle(event):
-                    audio.play_sound("click")
+                    audio.play_sound("ui_confirm")
                     break
 
     def get_tooltip(self, pos: Tuple[int, int], rect: pygame.Rect) -> Optional[str]:

--- a/ui/widgets/hero_army_panel.py
+++ b/ui/widgets/hero_army_panel.py
@@ -12,7 +12,7 @@ from typing import Callable, List, Optional, Tuple
 
 import pygame
 
-import constants, theme
+import constants, theme, audio
 from core.entities import Unit, UnitCarrier
 from state.event_bus import EVENT_BUS, ON_SELECT_HERO
 from .quantity_dialog import QuantityDialog
@@ -248,6 +248,7 @@ class HeroArmyPanel:
                         unit = self.grid[idx]
                         if unit is not None:
                             self.drag = _DragState(idx, unit)
+                            audio.play_sound("drag_start")
             elif button == 3:
                 idx = self._cell_at(pos, rect)
                 if idx is not None:
@@ -265,6 +266,7 @@ class HeroArmyPanel:
                     )
                     self._commit_grid()
                 self.drag = None
+                audio.play_sound("drag_drop")
 
     # ------------------------------------------------------------------
     def _split_selected(self) -> None:


### PR DESCRIPTION
## Summary
- add UI sound identifiers for confirmation, cancel, errors, panels, drag/drop, scrolling and save/load
- hook up UI modules to play confirm/cancel, panel open/close, drag/drop and notification sounds
- trigger save/load and notification sounds in menu and game logic

## Testing
- `pre-commit run --files assets/audio/sounds.json core/game.py ui/dialogs.py ui/inventory_screen.py ui/main_screen.py ui/menu.py ui/menu_utils.py ui/options_menu.py ui/town_overlay.py ui/widgets/buttons_column.py ui/widgets/hero_army_panel.py`
- `pytest tests/test_buttons_column.py tests/test_menu.py tests/test_town_overlay.py tests/test_inventory_drag_double_click.py tests/test_hero_army_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68b43846d16483218a0f8351dda03041