### PR TITLE
Add sound cues for hero progression and town actions

### DIFF
--- a/assets/audio/sounds.json
+++ b/assets/audio/sounds.json
@@ -31,5 +31,9 @@
   {"id": "artifact_pickup","file": "audio/world/artifact_pickup.wav"},
   {"id": "enter_town",  "file": "audio/world/enter_town.wav"},
   {"id": "exit_town",   "file": "audio/world/exit_town.wav"},
-  {"id": "capture_mine","file": "audio/world/capture_mine.wav"}
+  {"id": "capture_mine","file": "audio/world/capture_mine.wav"},
+  {"id": "hero_level_up",   "file": "audio/rpg/hero_level_up.wav"},
+  {"id": "skill_learned",   "file": "audio/rpg/skill_learned.wav"},
+  {"id": "building_built",  "file": "audio/town/building_built.wav"},
+  {"id": "unit_recruited",  "file": "audio/town/unit_recruited.wav"}
 ]

--- a/core/buildings.py
+++ b/core/buildings.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Set, List, Tuple, Union
 
 import constants
 import settings
+import audio
 from core.economy import DEFAULT_MARKET_RATES
 from loaders import building_loader
 from loaders.building_loader import BuildingAsset
@@ -508,6 +509,7 @@ class Town(Building):
         if isinstance(growth, dict):
             for uid, amount in growth.items():
                 self.stock[uid] = self.stock.get(uid, 0) + int(amount)
+        audio.play_sound("building_built")
         return True
 
     def recruit_units(

--- a/ui/inventory_screen.py
+++ b/ui/inventory_screen.py
@@ -67,10 +67,13 @@ class InventoryScreen:
         hero: Hero,
         clock: Optional[pygame.time.Clock] = None,
         pause_cb: Optional[Callable[[], Tuple[bool, pygame.Surface]]] = None,
+        *,
+        game: "Game" | None = None,
     ) -> None:
         self.screen = screen
         self.assets = assets
         self.hero = hero
+        self.game = game
         self.clock = clock or pygame.time.Clock()
         self.active_tab = "stats"
         self.active_skill_tab = ""
@@ -815,8 +818,12 @@ class InventoryScreen:
                 if rect and rect.collidepoint(pos):
                     node = self.skill_nodes[nid]
                     branch = self.skill_branch_of.get(nid, "")
-                    if not self.hero.learn_skill(node, branch):
-                        self._toast("Cannot learn")
+                    if self.game:
+                        if not self.game.learn_skill(node, branch):
+                            self._toast("Cannot learn")
+                    else:
+                        if not self.hero.learn_skill(node, branch):
+                            self._toast("Cannot learn")
                     return
 
     def _on_lmb_up(self, pos: Tuple[int, int]) -> None:

--- a/ui/recruit_overlay.py
+++ b/ui/recruit_overlay.py
@@ -6,6 +6,7 @@ import pygame
 
 from core.entities import RECRUITABLE_UNITS
 import theme
+import audio
 from loaders import icon_loader as IconLoader
 
 FONT_NAME = None
@@ -149,6 +150,7 @@ def open(
                                 hero.apply_bonuses_to_army()
                             if hasattr(game, "_publish_resources"):
                                 game._publish_resources()
+                            audio.play_sound("unit_recruited")
         # draw overlay
         screen.blit(background, (0, 0))
         s = pygame.Surface(screen.get_size(), pygame.SRCALPHA)

--- a/ui/town_scene_screen.py
+++ b/ui/town_scene_screen.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 
 import pygame
 import constants
+import audio
 
 from loaders.town_scene_loader import TownScene, TownBuilding
 from render.town_scene_renderer import TownSceneRenderer
@@ -138,6 +139,7 @@ class TownSceneScreen:
                 if self.town.build_structure(sid, hero, player):
                     if hasattr(self.game, "_publish_resources"):
                         self.game._publish_resources()
+                    audio.play_sound("building_built")
                     self.building_states[sid] = "built"
             return False
 


### PR DESCRIPTION
## Summary
- add new RPG and town sound effects to manifest
- play level-up and skill-learn sounds via Game helpers
- trigger building and recruitment sounds in town interfaces

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b43c6bc7dc8321966c425f4da75d97