### PR TITLE
Queue music to resume map theme after jingles

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -2877,7 +2877,10 @@ class Game:
             self.refresh_army_list()
             self._update_player_visibility()
             try:
-                audio.play_music('event_turn_end')
+                prev = audio.get_current_music()
+                audio.play_music('event_turn_end', loop=0)
+                if prev:
+                    audio.queue_music(prev)
                 audio.play_sound('end_turn')
             except Exception:  # pragma: no cover
                 pass
@@ -2897,12 +2900,9 @@ class Game:
             return
         self._notify("End of day. All heroes' action points are restored.")
         if hasattr(self, "state") and hasattr(self.state, "next_day"):
-            prev_week = getattr(self.state.turn, "week", None)
             self._sync_economy_from_hero()
             self.state.next_day()
             self._sync_hero_from_economy()
-            if prev_week is not None and self.state.turn.week != prev_week:
-                audio.play_music('event_week_start')
         else:
             for row in self.world.grid:
                 for tile in row:
@@ -2921,7 +2921,10 @@ class Game:
         self.refresh_army_list()
         self._update_player_visibility()
         try:
-            audio.play_music('event_turn_end')
+            prev = audio.get_current_music()
+            audio.play_music('event_turn_end', loop=0)
+            if prev:
+                audio.queue_music(prev)
             audio.play_sound('end_turn')
         except Exception:  # pragma: no cover
             pass

--- a/state/game_state.py
+++ b/state/game_state.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from core import economy
+import audio
 
 
 @dataclass
@@ -134,6 +135,10 @@ class GameState:
                         town.advance_day(hero, self.world)
         self.turn.turn_index += 1
         if self.economy.calendar.day == 1:
+            prev = audio.get_current_music()
+            audio.play_music('event_week_start', loop=0)
+            if prev:
+                audio.queue_music(prev)
             self._advance_towns_week()
 
     def next_week(self) -> None:

--- a/tests/test_audio_queue.py
+++ b/tests/test_audio_queue.py
@@ -1,0 +1,52 @@
+import types
+import audio
+
+
+def test_queue_music_resumes_previous_track(monkeypatch, tmp_path):
+    queued = []
+
+    class DummyMusic:
+        @staticmethod
+        def load(path):
+            pass
+
+        @staticmethod
+        def play(loop):
+            pass
+
+        @staticmethod
+        def queue(path):
+            queued.append(path)
+
+        @staticmethod
+        def set_volume(vol):
+            pass
+
+    dummy_mixer = types.SimpleNamespace(music=DummyMusic)
+    dummy_pygame = types.SimpleNamespace(mixer=dummy_mixer)
+    monkeypatch.setattr(audio, "pygame", dummy_pygame)
+    monkeypatch.setattr(audio, "_has_mixer", lambda: True)
+
+    files = {}
+    for name in ["theme.ogg", "jingle.ogg"]:
+        p = tmp_path / name
+        p.write_bytes(b"0")
+        files[name] = str(p)
+
+    monkeypatch.setattr(audio, "_find_asset", lambda filename: files.get(filename))
+
+    audio._music_tracks.clear()
+    audio._music_tracks.update({"theme": "theme.ogg", "jingle": "jingle.ogg"})
+    audio._current_music = None
+
+    audio.play_music("theme")
+    prev = audio.get_current_music()
+    audio.play_music("jingle", loop=0)
+    audio.queue_music(prev)
+
+    assert queued == [files["theme.ogg"]]
+    assert audio._queued_music == "theme"
+
+    # Simulate jingle ending
+    audio.play_music(audio._queued_music)
+    assert audio.get_current_music() == "theme"


### PR DESCRIPTION
## Summary
- add `queue_music` helper to resolve and queue tracks
- resume map theme after end turn or week start jingles
- cover jingle queueing with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45fe510f483219b265546bcfcb3bf