### PR TITLE
Play turn sound only when unit changes

### DIFF
--- a/core/combat.py
+++ b/core/combat.py
@@ -686,6 +686,7 @@ class Combat:
             u.acted = False
         combat_rules.start_round_reset_retaliations(self.turn_order)
         self.current_index = 0
+        audio.play_sound('turn_start')
 
     def _rt(self, unit: Unit):
         return self._rt_by_unit.get(unit)
@@ -1154,6 +1155,8 @@ class Combat:
         if self.current_index >= len(self.turn_order):
             # End of round: start a new round
             self.reset_turn_order()
+        else:
+            audio.play_sound('turn_start')
 
     def apply_passive_abilities(self, unit: Unit) -> None:
         """Apply passive abilities that trigger at the start of the unit's turn."""
@@ -1342,7 +1345,6 @@ class Combat:
             if current_unit.skip_turn:
                 self.advance_turn()
                 continue
-            audio.play_sound('turn_start')
             if self.auto_mode:
                 for event in pygame.event.get():
                     if self.overlays:

--- a/tests/test_combat_turn_sound.py
+++ b/tests/test_combat_turn_sound.py
@@ -1,0 +1,36 @@
+import audio
+from core.entities import UnitStats, Unit
+
+
+def _unit(side: str) -> Unit:
+    stats = UnitStats(
+        name="Test",
+        max_hp=10,
+        attack_min=0,
+        attack_max=0,
+        defence_melee=0,
+        defence_ranged=0,
+        defence_magic=0,
+        speed=0,
+        attack_range=1,
+        initiative=1,
+        sheet="",
+        hero_frames=(0, 0),
+        enemy_frames=(0, 0),
+        morale=0,
+        luck=0,
+        abilities=[],
+    )
+    return Unit(stats, 1, side)
+
+
+def test_turn_sound_once_per_unit_turn(simple_combat, monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(audio, "play_sound", lambda key: calls.append(key))
+    combat = simple_combat(hero_units=[_unit("hero")], enemy_units=[_unit("enemy")])
+
+    assert calls == ["turn_start"]
+
+    for expected in range(2, 5):
+        combat.advance_turn()
+        assert calls == ["turn_start"] * expected


### PR DESCRIPTION
## Summary
- Trigger turn-start sound when resetting the turn order
- Play turn-start sound when advancing to a new unit
- Test that the turn-start sound fires once per unit turn

## Testing
- `pytest tests/test_combat_turn_sound.py::test_turn_sound_once_per_unit_turn -q`

------
https://chatgpt.com/codex/tasks/task_e_68b461f0d2ec8321b21d1ead77ab9e28