### PR TITLE
Load biome metadata from asset definitions

### DIFF
--- a/assets/biomes/char_map.json
+++ b/assets/biomes/char_map.json
@@ -1,0 +1,13 @@
+{
+  "G": "scarletia_echo_plain",
+  "F": "scarletia_crimson_forest",
+  "D": "scarletia_volcanic",
+  "M": "mountain",
+  "H": "hills",
+  "S": "swamp",
+  "J": "jungle",
+  "I": "ice",
+  "R": "river",
+  "W": "ocean",
+  "O": "ocean"
+}

--- a/assets/realms/scarletia/biomes.json
+++ b/assets/realms/scarletia/biomes.json
@@ -14,7 +14,9 @@
     ],
     "vision_bonus": 0,
     "passable": true,
-    "overlays": []
+    "overlays": [],
+    "weight": 0.3,
+    "priority": 0
   },
   {
     "id": "scarletia_crimson_forest",
@@ -30,7 +32,9 @@
     ],
     "vision_bonus": 0,
     "passable": true,
-    "overlays": []
+    "overlays": [],
+    "weight": 0.15,
+    "priority": 1
   },
   {
     "id": "scarletia_volcanic",
@@ -51,6 +55,8 @@
     "overlays": [
       "coast",
       "cliff"
-    ]
+    ],
+    "weight": 0.15,
+    "priority": 5
   }
 ]

--- a/assets/realms/sylvan/biomes.json
+++ b/assets/realms/sylvan/biomes.json
@@ -13,7 +13,9 @@
     ],
     "vision_bonus": 0,
     "passable": true,
-    "overlays": []
+    "overlays": [],
+    "weight": 0.4,
+    "priority": 0
   },
   {
     "id": "sylvan_calywen_garden",
@@ -29,7 +31,9 @@
     ],
     "vision_bonus": 0,
     "passable": true,
-    "overlays": []
+    "overlays": [],
+    "weight": 0.3,
+    "priority": 1
   },
   {
     "id": "sylvan_herbyplain",
@@ -44,6 +48,8 @@
     ],
     "vision_bonus": 0,
     "passable": true,
-    "overlays": []
+    "overlays": [],
+    "weight": 0.3,
+    "priority": 2
   }
 ]

--- a/assets/realms/sylvan/char_map.json
+++ b/assets/realms/sylvan/char_map.json
@@ -1,0 +1,5 @@
+{
+  "L": "sylvan_lirael_brume",
+  "C": "sylvan_calywen_garden",
+  "P": "sylvan_herbyplain"
+}

--- a/constants.py
+++ b/constants.py
@@ -70,35 +70,65 @@ WORLD_HEIGHT = 8
 # Allow slightly larger automatically generated worlds so exploration feels
 # less cramped.  The range is used when no explicit size is provided.
 WORLD_SIZE_RANGE = (12, 20)
-# Default distribution of biomes for purely random maps (non‑continent
-# generation).  Additional terrains beyond the core four are included so the
-# world contains a richer variety of regions to explore.
-DEFAULT_BIOME_WEIGHTS = {
-    "scarletia_echo_plain": 0.3,
-    "scarletia_crimson_forest": 0.15,
-    "scarletia_volcanic": 0.15,
-    "mountain": 0.1,
-    "hills": 0.1,
-    "swamp": 0.08,
-    "jungle": 0.07,
-    "ice": 0.05,
-}
-"""Default distribution of biomes used for random map generation."""
 
-# Relative priority of biomes when blending neighbouring tiles.  A higher
-# value means the neighbouring biome overlays this tile during rendering.
-BIOME_PRIORITY = {
-    "scarletia_echo_plain": 0,
-    "scarletia_crimson_forest": 1,
-    "hills": 2,
-    "swamp": 3,
-    "jungle": 4,
-    "scarletia_volcanic": 5,
-    "ice": 6,
-    "mountain": 7,
-    "river": 8,
-    "ocean": 9,
-}
+
+def build_default_biome_weights() -> Dict[str, float]:
+    """Return mapping of biome ids to selection weights.
+
+    When the biome catalogue has not yet been loaded, legacy values are used as
+    sensible defaults so random map generation continues to work in tests that
+    depend on the original Scarletiа terrains.
+    """
+
+    from loaders.biomes import BiomeCatalog  # noqa: WPS433
+
+    if BiomeCatalog._biomes:
+        return {
+            b.id: float(getattr(b, "weight", 1.0))
+            for b in BiomeCatalog._biomes.values()
+        }
+    return {
+        "scarletia_echo_plain": 0.3,
+        "scarletia_crimson_forest": 0.15,
+        "scarletia_volcanic": 0.15,
+        "mountain": 0.1,
+        "hills": 0.1,
+        "swamp": 0.08,
+        "jungle": 0.07,
+        "ice": 0.05,
+    }
+
+
+# Default distribution of biomes used for random map generation.
+DEFAULT_BIOME_WEIGHTS: Dict[str, float] = build_default_biome_weights()
+
+
+def build_biome_priority() -> Dict[str, int]:
+    """Return relative priority of biomes when blending neighbours."""
+
+    from loaders.biomes import BiomeCatalog  # noqa: WPS433
+
+    if BiomeCatalog._biomes:
+        return {
+            b.id: int(getattr(b, "priority", 0))
+            for b in BiomeCatalog._biomes.values()
+        }
+    return {
+        "scarletia_echo_plain": 0,
+        "scarletia_crimson_forest": 1,
+        "hills": 2,
+        "swamp": 3,
+        "jungle": 4,
+        "scarletia_volcanic": 5,
+        "ice": 6,
+        "mountain": 7,
+        "river": 8,
+        "ocean": 9,
+    }
+
+
+# Relative priority of biomes when blending neighbouring tiles.
+BIOME_PRIORITY: Dict[str, int] = build_biome_priority()
 
 # Biomes that are inherently impassable regardless of the ``obstacle`` flag on a
 # tile.  Units may never enter these terrains.

--- a/docs/asset_manifests.md
+++ b/docs/asset_manifests.md
@@ -32,6 +32,20 @@ tiles such as `grass` or `forest` whose images live under `terrain/*.png`.  Thes
 backward compatibility and will eventually be replaced by equivalent biome
 definitions.
 
+### Biomes
+
+Entries in `biomes.json` support two optional fields in addition to the basic
+metadata:
+
+* `weight` – relative likelihood that the biome appears during random world
+  generation.
+* `priority` – numeric ordering used when blending neighbouring biomes.  Higher
+  values overlay lower ones.
+
+Characters in text-based map files are translated to biome identifiers via
+`biomes/char_map.json`.  Realms may provide their own `char_map.json` alongside
+their biome definitions to extend the mapping without modifying core code.
+
 ## Missing images
 
 When an image referenced in a manifest is absent from disk, the

--- a/loaders/biomes.py
+++ b/loaders/biomes.py
@@ -26,6 +26,8 @@ class Biome:
     passable: bool = True
     overlays: List[str] = field(default_factory=list)
     vision_bonus: int = 0
+    weight: float = 1.0
+    priority: int = 0
 
 
 @dataclass
@@ -91,13 +93,18 @@ class BiomeCatalog:
                     passable=bool(entry.get("passable", True)),
                     overlays=list(entry.get("overlays", [])),
                     vision_bonus=int(entry.get("vision_bonus", 0)),
+                    weight=float(entry.get("weight", 1.0)),
+                    priority=int(entry.get("priority", 0)),
                 )
                 biomes[biome.id] = biome
         cls._biomes = biomes
         # Refresh derived mappings in constants
         constants.BIOME_BASE_IMAGES = constants.build_biome_base_images()
+        constants.DEFAULT_BIOME_WEIGHTS = constants.build_default_biome_weights()
+        constants.BIOME_PRIORITY = constants.build_biome_priority()
         from core import world as core_world
         core_world.init_biome_images()
+        core_world.load_biome_char_map(ctx, manifest)
         try:
             from ui.widgets.minimap import Minimap
             Minimap.invalidate_all()


### PR DESCRIPTION
## Summary
- Build biome weights and priorities dynamically from manifest entries
- Load BIOME_CHAR_MAP from JSON so realms can extend character mappings
- Document biome weight/priority fields and sample realm data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b472315cb88321950137b3c24ca73d