### PR TITLE
Fix realm biome asset paths and restore ocean transition blending

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -108,12 +108,10 @@ def build_biome_priority() -> Dict[str, int]:
 
     from loaders.biomes import BiomeCatalog  # noqa: WPS433
 
-    if BiomeCatalog._biomes:
-        return {
-            b.id: int(getattr(b, "priority", 0))
-            for b in BiomeCatalog._biomes.values()
-        }
-    return {
+    mapping = {
+        b.id: int(getattr(b, "priority", 0)) for b in BiomeCatalog._biomes.values()
+    }
+    defaults = {
         "scarletia_echo_plain": 0,
         "scarletia_crimson_forest": 1,
         "hills": 2,
@@ -125,6 +123,9 @@ def build_biome_priority() -> Dict[str, int]:
         "river": 8,
         "ocean": 9,
     }
+    for key, value in defaults.items():
+        mapping.setdefault(key, value)
+    return mapping
 
 
 # Relative priority of biomes when blending neighbouring tiles.

--- a/loaders/biomes.py
+++ b/loaders/biomes.py
@@ -76,14 +76,23 @@ class BiomeCatalog:
         biomes: Dict[str, Biome] = {}
         for path in files:
             data = read_json(ctx, path)
+            base_dir = os.path.dirname(path)
             for entry in data:
                 require_keys(entry, ["id"])
                 colour = entry.get("colour", [0, 0, 0])
+                entry_path = entry.get("path", "")
+                if entry_path and not os.path.isabs(entry_path):
+                    # By default treat paths as relative to the asset search root.
+                    # When a manifest wishes to reference files relative to its own
+                    # directory it can use an explicit ``./`` or ``../`` prefix.
+                    if entry_path.startswith("./") or entry_path.startswith("../"):
+                        entry_path = os.path.join(base_dir, entry_path)
+                entry_path = os.path.normpath(entry_path).replace(os.sep, "/")
                 biome = Biome(
                     id=entry["id"],
                     type=entry.get("type", ""),
                     description=entry.get("description", ""),
-                    path=entry.get("path", ""),
+                    path=entry_path,
                     variants=int(entry.get("variants", 1)),
                     colour=tuple(colour),
                     flora=list(entry.get("flora", [])),
@@ -122,7 +131,14 @@ def load_tileset(ctx: Context, biome: Biome, tile_size: Optional[int] = None) ->
     tileset = BiomeTileset(id=biome.id, path=biome.path, variants=biome.variants)
     base = biome.path
     for i in range(max(1, biome.variants)):
-        key = f"{base}_{i}.png" if not base.endswith(".png") else base
+        if base.endswith(".png"):
+            key = base
+        elif biome.variants > 1:
+            key = f"{base}_{i}.png"
+        else:
+            # Support single-variant biomes whose manifest omits the ``_0`` suffix
+            # by loading ``<path>.png`` instead of ``<path>_0.png``.
+            key = f"{base}.png"
         surf = ctx.asset_loader.get(key) if ctx.asset_loader else None
         if surf and hasattr(surf, "get_size"):
             if surf.get_size() != (tile_size, tile_size):


### PR DESCRIPTION
## Summary
- resolve biome tileset paths relative to search root unless explicitly prefixed with `./` or `../`
- provide fallback priorities for core biomes such as ocean to ensure proper blending
- load single-variant biome tilesets without requiring an `_0` suffix

## Testing
- `pytest --maxfail=1 -q -m "not slow and not worldgen and not combat and not serial"`


------
https://chatgpt.com/codex/tasks/task_e_68b46c0cbed48321af4393fe1c364a5b