### PR TITLE
Log missing asset search paths and biome context

### DIFF
--- a/tests/test_asset_manager_logging.py
+++ b/tests/test_asset_manager_logging.py
@@ -1,0 +1,16 @@
+import logging
+import os
+
+
+def test_missing_asset_logs_details(caplog, asset_manager):
+    missing = "missing.png"
+    expected_path = os.path.join(asset_manager.search_paths[0], missing)
+    with caplog.at_level(logging.WARNING, logger="loaders.asset_manager"):
+        asset_manager.get(missing, biome_id="test_biome")
+    assert caplog.records, "No warning logged for missing asset"
+    message = caplog.records[0].message
+    assert "search_paths" in message
+    assert "candidates" in message
+    assert "biome=test_biome" in message
+    assert expected_path in message
+


### PR DESCRIPTION
## Summary
- add biome context and attempted paths to `AssetManager.get` miss warnings
- test that missing asset logs search paths, candidates, attempted paths, and biome id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4965e5fd883218487fda72ec8e489