### PR TITLE
Handle single-variant biome paths

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -246,10 +246,12 @@ def build_biome_base_images() -> Dict[str, List[str]]:
     for biome in BiomeCatalog._biomes.values():
         variant_count = max(1, int(getattr(biome, "variants", 1)))
         base_path = biome.path
-        files = [
-            f"{base_path}_{i}.png" if not base_path.endswith(".png") else base_path
-            for i in range(variant_count)
-        ]
+        if base_path.endswith(".png"):
+            files = [base_path]
+        elif variant_count == 1:
+            files = [f"{base_path}.png"]
+        else:
+            files = [f"{base_path}_{i}.png" for i in range(variant_count)]
         images[biome.id] = files
 
     # Load legacy terrain tiles for backward compatibility

--- a/docs/asset_manifests.md
+++ b/docs/asset_manifests.md
@@ -7,7 +7,7 @@ with at least the following fields:
 * `id` – unique identifier used in code.
 * `path` – base path to the asset image relative to the `assets/` directory.
 * `variants` – optional number of variants. ``0`` or ``1`` resolves to
-  ``<path>/base.png`` while higher counts use ``_<n>.png`` suffixes.
+  ``<path>.png`` while higher counts use ``_<n>.png`` suffixes.
 * additional rule-specific fields depending on the category (e.g. `income`
   for resources).
 

--- a/loaders/biomes.py
+++ b/loaders/biomes.py
@@ -162,22 +162,33 @@ def load_tileset(ctx: Context, biome: Biome, tile_size: Optional[int] = None) ->
         tile_size = constants.COMBAT_TILE_SIZE
     base = biome.path[:-4] if biome.path.endswith(".png") else biome.path
     matches: List[str] = []
-    seen: set[str] = set()
-    for root in ctx.search_paths:
-        root_abs = root if os.path.isabs(root) else os.path.join(ctx.repo_root, root)
-        pattern = os.path.join(root_abs, f"{base}_*.png")
-        for fn in sorted(glob.glob(pattern)):
-            rel = os.path.relpath(fn, root_abs).replace(os.sep, "/")
-            if rel not in seen:
-                matches.append(rel)
-                seen.add(rel)
-    if not matches:
+    if biome.variants == 1:
         for root in ctx.search_paths:
             root_abs = root if os.path.isabs(root) else os.path.join(ctx.repo_root, root)
-            candidate = os.path.join(root_abs, f"{base}.png")
+            candidate = os.path.join(
+                root_abs,
+                biome.path if biome.path.endswith(".png") else f"{base}.png",
+            )
             if os.path.isfile(candidate):
                 matches.append(os.path.relpath(candidate, root_abs).replace(os.sep, "/"))
                 break
+    else:
+        seen: set[str] = set()
+        for root in ctx.search_paths:
+            root_abs = root if os.path.isabs(root) else os.path.join(ctx.repo_root, root)
+            pattern = os.path.join(root_abs, f"{base}_*.png")
+            for fn in sorted(glob.glob(pattern)):
+                rel = os.path.relpath(fn, root_abs).replace(os.sep, "/")
+                if rel not in seen:
+                    matches.append(rel)
+                    seen.add(rel)
+        if not matches:
+            for root in ctx.search_paths:
+                root_abs = root if os.path.isabs(root) else os.path.join(ctx.repo_root, root)
+                candidate = os.path.join(root_abs, f"{base}.png")
+                if os.path.isfile(candidate):
+                    matches.append(os.path.relpath(candidate, root_abs).replace(os.sep, "/"))
+                    break
     if biome.variants > len(matches):
         logger.warning(
             "Biome %s specifies %d variants but only %d files found",

--- a/loaders/core.py
+++ b/loaders/core.py
@@ -48,5 +48,5 @@ def expand_variants(entry: Dict[str, Any], key: str = "path", variants: str = "v
         return []
     var = int(entry.get(variants, 0))
     if var <= 1:
-        return [base if base.endswith(".png") else f"{base}/base.png"]
+        return [base if base.endswith(".png") else f"{base}.png"]
     return [f"{base}_{i}.png" for i in range(var)]

--- a/loaders/flora_loader.py
+++ b/loaders/flora_loader.py
@@ -26,7 +26,7 @@ et dessin trié (baseline) compatible top‑down et futur rendu isométrique.
     "anchor_px": [128,236],
     "passable": false,
     "occludes": true,
-    "path": "flora/tall/scarlet_tree_a",  # utilise suffixes _0.._N‑1 si variants>1, sinon "/base.png"
+    "path": "flora/tall/scarlet_tree_a",  # utilise suffixes _0.._N‑1 si variants>1, sinon ".png"
     "variants": 2,
     "spawn": {"density": 0.006, "min_dist": 3}
   },

--- a/tools/check_assets.py
+++ b/tools/check_assets.py
@@ -42,7 +42,7 @@ def _expected_files(entry: dict) -> List[str]:
     variants = int(entry.get("variants", 1))
     if variants > 1:
         return [f"{base}_{i}.png" for i in range(variants)]
-    return [f"{base}.png" if base.endswith(".png") else f"{base}/base.png"]
+    return [base if base.endswith(".png") else f"{base}.png"]
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- Emit `<base>.png` instead of `<base>_0.png` when biomes only have one variant
- Update variant expansion and asset checks for new naming
- Clarify documentation and comments about single-variant assets

## Testing
- `pre-commit run --files constants.py loaders/biomes.py loaders/core.py tools/check_assets.py loaders/flora_loader.py docs/asset_manifests.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b49afd98548321b69daa3327599f44