### PR TITLE
Trim scarletia fallbacks from biome handling

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -91,11 +91,6 @@ def build_default_biome_weights() -> Dict[str, float]:
         "scarletia_echo_plain": 0.3,
         "scarletia_crimson_forest": 0.15,
         "scarletia_volcanic": 0.15,
-        "mountain": 0.1,
-        "hills": 0.1,
-        "swamp": 0.08,
-        "jungle": 0.07,
-        "ice": 0.05,
     }
 
 
@@ -108,24 +103,16 @@ def build_biome_priority() -> Dict[str, int]:
 
     from loaders.biomes import BiomeCatalog  # noqa: WPS433
 
-    mapping = {
-        b.id: int(getattr(b, "priority", 0)) for b in BiomeCatalog._biomes.values()
-    }
-    defaults = {
+    if BiomeCatalog._biomes:
+        return {
+            b.id: int(getattr(b, "priority", 0))
+            for b in BiomeCatalog._biomes.values()
+        }
+    return {
         "scarletia_echo_plain": 0,
         "scarletia_crimson_forest": 1,
-        "hills": 2,
-        "swamp": 3,
-        "jungle": 4,
         "scarletia_volcanic": 5,
-        "ice": 6,
-        "mountain": 7,
-        "river": 8,
-        "ocean": 9,
     }
-    for key, value in defaults.items():
-        mapping.setdefault(key, value)
-    return mapping
 
 
 # Relative priority of biomes when blending neighbouring tiles.
@@ -288,8 +275,4 @@ BIOME_BASE_IMAGES: Dict[str, List[str]] = {
     "ice": ["terrain/ice.png"],
     "river": ["terrain/river.png"],
     "ocean": ["terrain/ocean.png"],
-    # Fallbacks for the core Scarletiа biomes used in tests
-    "scarletia_echo_plain": ["terrain/grass.png"],
-    "scarletia_crimson_forest": ["terrain/forest.png"],
-    "scarletia_volcanic": ["terrain/desert.png"],
 }

--- a/core/world.py
+++ b/core/world.py
@@ -183,42 +183,7 @@ BIOME_IMAGES: Dict[str, Tuple[str, Tuple[int, int, int]]] = {}
 def init_biome_images() -> None:
     """(Re)build :data:`BIOME_IMAGES` from :class:`BiomeCatalog`."""
 
-    images: Dict[str, Tuple[str, Tuple[int, int, int]]] = {
-        "mountain": (
-            constants.BIOME_BASE_IMAGES.get("mountain", [""])[0],
-            constants.GREY,
-        ),
-        "hills": (
-            constants.BIOME_BASE_IMAGES.get("hills", [""])[0],
-            constants.GREY,
-        ),
-        "swamp": (
-            constants.BIOME_BASE_IMAGES.get("swamp", [""])[0],
-            constants.GREEN,
-        ),
-        "jungle": (
-            constants.BIOME_BASE_IMAGES.get("jungle", [""])[0],
-            constants.GREEN,
-        ),
-        "ice": (
-            constants.BIOME_BASE_IMAGES.get("ice", [""])[0],
-            constants.WHITE,
-        ),
-        "ocean": (
-            constants.BIOME_BASE_IMAGES.get("ocean", [""])[0],
-            constants.BLUE,
-        ),
-        # Fallbacks for the core Scarletiа biomes used in tests
-        "scarletia_echo_plain": (
-            constants.BIOME_BASE_IMAGES.get("grass", [""])[0], constants.GREEN
-        ),
-        "scarletia_crimson_forest": (
-            constants.BIOME_BASE_IMAGES.get("forest", [""])[0], constants.GREEN
-        ),
-        "scarletia_volcanic": (
-            constants.BIOME_BASE_IMAGES.get("desert", [""])[0], constants.YELLOW
-        ),
-    }
+    images: Dict[str, Tuple[str, Tuple[int, int, int]]] = {}
     for biome in BiomeCatalog._biomes.values():
         paths = constants.BIOME_BASE_IMAGES.get(biome.id, [""])
         base = paths[0] if isinstance(paths, list) else paths

--- a/ui/widgets/minimap.py
+++ b/ui/widgets/minimap.py
@@ -243,9 +243,11 @@ class Minimap:
                     for ty in range(ty0, ty1):
                         for tx in range(tx0, tx1):
                             tile = self.world.grid[ty][tx]
-                            colour = BIOME_IMAGES.get(
-                                tile.biome, BIOME_IMAGES["scarletia_echo_plain"]
-                            )[1]
+                            default = next(
+                                iter(BIOME_IMAGES.values()),
+                                ("", constants.GREEN),
+                            )
+                            colour = BIOME_IMAGES.get(tile.biome, default)[1]
                             rect = pygame.Rect(
                                 int(tx * tile_w - px0),
                                 int(ty * tile_h - py0),


### PR DESCRIPTION
## Summary
- Remove scarletia placeholder entries from default biome images
- Return scarletia weights and priority only when no biomes are loaded
- Build biome image map solely from the biome catalog and minimise hardcoded fallbacks
- Use a generic colour fallback in minimap instead of scarletia-specific key

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b49d091e348321b75f1a34bdc453e0