### PR TITLE
Load common and realm biomes separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ enumerate entries with metadata and image paths.  Dedicated loaders such as
 `loaders.flora_loader.FloraLoader` and
 `loaders.resources_loader.load_resources` parse these manifests, load the
 referenced PNGs via the `AssetManager` and make them available to the rest of
-the game.  Biome and flora manifests are organised per realm under
-`assets/realms/<realm>/`, letting each realm ship its own `biomes.json` and
-`flora.json` files.  Additional JSON files can be dropped into these realm
-folders and will automatically be merged by the loaders.
+the game.  Common biome data is defined in `assets/biomes/` (e.g.
+`biomes.json`, `char_map.json`) while realm-specific extensions are placed in
+`assets/realms/<realm>/` and merged on top of the shared files.  Each realm may
+provide its own `biomes*.json`, `flora.json` and related manifests.
 
 This approach allows each asset to define variants, biome tags or spawn rules
 without hard‑coding file names.  To add new artwork, place the image in the
@@ -152,8 +152,8 @@ context to read JSON manifests and register assets:
 
 * `loaders.resources_loader.load_resources` imports resource definitions from
   `assets/resources/resources.json`.
-* `loaders.biomes.BiomeCatalog` merges every `biomes*.json` file from a realm
-  directory like `assets/realms/scarletia/`.
+* `loaders.biomes.BiomeCatalog` reads `assets/biomes/biomes.json` and merges
+  any `biomes*.json` files from `assets/realms/<realm>/`.
 * `loaders.flora_loader.FloraLoader` loads all `flora*.json` files from the same
   realm directory and can automatically scatter props across the map via
   `autoplace` using biome information and spawn rules.

--- a/core/game.py
+++ b/core/game.py
@@ -210,8 +210,9 @@ class Game:
                 self.enemy_faction_id = self.faction_id
                 self.enemy_faction = self.faction
 
-            realm_dir = f"realms/{self.realm}"
-            BiomeCatalog.load(self.ctx, realm_dir)
+            realm = self.realm
+            realm_dir = f"realms/{realm}"
+            BiomeCatalog.load(self.ctx, realm)
             init_biome_images()
 
             # Load unit and creature definitions early so ``load_assets`` can

--- a/core/world.py
+++ b/core/world.py
@@ -73,8 +73,8 @@ def load_biome_char_map(ctx: Context = _BOSS_CTX, realm: Optional[str] = None) -
     """Load ``BIOME_CHAR_MAP`` from JSON files.
 
     The base mapping comes from ``assets/biomes/char_map.json``.  If ``realm`` is
-    provided, an additional ``<realm>/char_map.json`` is merged on top allowing
-    custom realms to extend or override the default characters.
+    provided, an additional ``assets/realms/<realm>/char_map.json`` is merged on
+    top allowing custom realms to extend or override the default characters.
     """
 
     mapping: Dict[str, str] = {}
@@ -86,7 +86,7 @@ def load_biome_char_map(ctx: Context = _BOSS_CTX, realm: Optional[str] = None) -
         pass
     if realm:
         try:
-            realm_map = read_json(ctx, f"{realm}/char_map.json")
+            realm_map = read_json(ctx, f"realms/{realm}/char_map.json")
             if isinstance(realm_map, dict):
                 mapping.update({k: str(v) for k, v in realm_map.items()})
         except Exception:

--- a/tests/test_realm_biome_paths.py
+++ b/tests/test_realm_biome_paths.py
@@ -15,6 +15,9 @@ def test_manifest_relative_paths_resolved(tmp_path):
 
     repo_root = tmp_path
     assets_root = tmp_path / "assets"
+    (assets_root / "biomes").mkdir(parents=True)
+    with open(assets_root / "biomes" / "biomes.json", "w", encoding="utf-8") as fh:
+        json.dump([], fh)
     (assets_root / "realms" / "testrealm" / "biomes").mkdir(parents=True)
     (assets_root / "realms" / "testrealm" / "biomes" / "test_biome.png").write_bytes(PNG_1x1)
     manifest = [
@@ -38,7 +41,7 @@ def test_manifest_relative_paths_resolved(tmp_path):
     old_weights = constants.DEFAULT_BIOME_WEIGHTS
     old_prio = constants.BIOME_PRIORITY
     try:
-        BiomeCatalog.load(ctx, "realms/testrealm")
+        BiomeCatalog.load(ctx, "testrealm")
         biome = BiomeCatalog.get("test_biome")
         assert biome is not None
         assert biome.path == "realms/testrealm/biomes/test_biome"


### PR DESCRIPTION
## Summary
- load shared biomes from `assets/biomes/biomes.json` then merge realm `biomes*.json`
- merge base and realm char maps when building the biome char mapping
- document common vs realm-specific biome JSON structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49e7f747083219ef067b100b95acc