### PR TITLE
Support multiple asset directories

### DIFF
--- a/core/buildings.py
+++ b/core/buildings.py
@@ -202,9 +202,14 @@ class Town(Building):
 
         if faction_id:
             repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+            search_paths: List[str] = []
+            extra = os.environ.get("FG_ASSETS_DIR")
+            if extra:
+                search_paths.extend(p for p in extra.split(os.pathsep) if p)
+            search_paths.append(os.path.join(repo_root, "assets"))
             ctx = Context(
                 repo_root=repo_root,
-                search_paths=[os.path.join(repo_root, "assets")],
+                search_paths=search_paths,
                 asset_loader=None,
             )
             manifest = os.path.join("towns", faction_id, "town.json")

--- a/core/entities.py
+++ b/core/entities.py
@@ -767,8 +767,13 @@ def _load_stats(manifest: str, section: str) -> Dict[str, UnitStats]:
     from loaders.units_loader import load_units  # local import to avoid cycle
     from loaders.core import Context
 
-    base = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets"))
-    ctx = Context(base, [""])
+    base = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    search_paths: List[str] = []
+    extra = os.environ.get("FG_ASSETS_DIR")
+    if extra:
+        search_paths.extend(p for p in extra.split(os.pathsep) if p)
+    search_paths.append(os.path.join(base, "assets"))
+    ctx = Context(base, search_paths)
     stats_map, _ = load_units(ctx, manifest, section=section)
 
     out = {uid: st for uid, st in stats_map.items()}

--- a/core/game.py
+++ b/core/game.py
@@ -184,11 +184,16 @@ class Game:
         self.assets = AssetManager(repo_root)
         self.vfx_manifest: Dict[str, Dict[str, Any]] = {}
 
-        search_paths = [os.path.join(repo_root, "assets")]
+        search_paths: List[str] = []
         extra = os.environ.get("FG_ASSETS_DIR")
         if extra:
-            search_paths.append(extra)
-        self.ctx = Context(repo_root=repo_root, search_paths=search_paths, asset_loader=self.assets)
+            search_paths.extend(p for p in extra.split(os.pathsep) if p)
+        search_paths.append(os.path.join(repo_root, "assets"))
+        self.ctx = Context(
+            repo_root=repo_root,
+            search_paths=search_paths,
+            asset_loader=self.assets,
+        )
 
         fast_tests = os.environ.get("FG_FAST_TESTS") == "1"
 

--- a/core/world.py
+++ b/core/world.py
@@ -59,7 +59,12 @@ logger = logging.getLogger(__name__)
 # generation functions.  Errors are silently ignored and simply result in an
 # empty definition mapping which is sufficient for tests.
 _BASE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-_BOSS_CTX = Context(_BASE_PATH, [os.path.join(_BASE_PATH, "assets")])
+_SEARCH_PATHS: List[str] = []
+_EXTRA = os.environ.get("FG_ASSETS_DIR")
+if _EXTRA:
+    _SEARCH_PATHS.extend(p for p in _EXTRA.split(os.pathsep) if p)
+_SEARCH_PATHS.append(os.path.join(_BASE_PATH, "assets"))
+_BOSS_CTX = Context(_BASE_PATH, _SEARCH_PATHS)
 bosses.load_boss_definitions(_BOSS_CTX)
 _FACTIONS: Dict[str, FactionDef] = load_factions(_BOSS_CTX)
 
@@ -129,7 +134,12 @@ def _load_creatures_by_biome() -> Tuple[
     """
 
     base = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    ctx = Context(base, [os.path.join(base, "assets")])
+    search_paths: List[str] = []
+    extra = os.environ.get("FG_ASSETS_DIR")
+    if extra:
+        search_paths.extend(p for p in extra.split(os.pathsep) if p)
+    search_paths.append(os.path.join(base, "assets"))
+    ctx = Context(base, search_paths)
     mapping: Dict[str, List[str]] = {}
     behaviour: Dict[str, Tuple[CreatureBehavior, int]] = {}
     manifest = "units/creatures.json"

--- a/loaders/building_loader.py
+++ b/loaders/building_loader.py
@@ -140,7 +140,11 @@ def load_default_buildings() -> Dict[str, BuildingAsset]:
     """Load building definitions using the repository's asset paths."""
 
     repo_root = os.path.dirname(os.path.dirname(__file__))
-    search = [os.path.join(repo_root, "assets")]
+    search: List[str] = []
+    extra = os.environ.get("FG_ASSETS_DIR")
+    if extra:
+        search.extend(p for p in extra.split(os.pathsep) if p)
+    search.append(os.path.join(repo_root, "assets"))
     ctx = Context(repo_root=repo_root, search_paths=search, asset_loader=None)
     return load_buildings(ctx)
 

--- a/loaders/i18n.py
+++ b/loaders/i18n.py
@@ -8,7 +8,7 @@ that merges the default (French) strings with the requested language so
 missing keys gracefully fall back to the French text.
 """
 
-from typing import Dict
+from typing import Dict, List
 import os
 
 from .core import Context, read_json
@@ -25,7 +25,14 @@ def load_locale(language: str, default: str = "fr") -> Dict[str, str]:
     """
 
     repo_root = os.path.dirname(os.path.dirname(__file__))
-    ctx = Context(repo_root=repo_root, search_paths=["assets/i18n"])
+    search_paths: List[str] = []
+    extra = os.environ.get("FG_ASSETS_DIR")
+    if extra:
+        search_paths.extend(
+            os.path.join(p, "i18n") for p in extra.split(os.pathsep) if p
+        )
+    search_paths.append(os.path.join(repo_root, "assets", "i18n"))
+    ctx = Context(repo_root=repo_root, search_paths=search_paths)
 
     try:
         data = read_json(ctx, f"{default}.json")

--- a/loaders/icon_loader.py
+++ b/loaders/icon_loader.py
@@ -19,8 +19,12 @@ def _candidate_asset_dirs() -> list[Path]:
     # 1) Override explicite
     env = os.environ.get("FG_ASSETS_DIR")
     if env:
-        p = Path(env).expanduser().resolve()
-        dirs.append(p)
+        for part in env.split(os.pathsep):
+            if part:
+                p = Path(part).expanduser()
+                if not p.is_absolute():
+                    p = _ROOT / p
+                dirs.append(p.resolve())
     # 2) assets du projet
     dirs.append((_ROOT / "assets").resolve())
     # 3) assets au niveau parent (ton cas : D:\FG_v0\assets)

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -182,7 +182,12 @@ def _scenario_config(screen: pygame.Surface, scenario: str) -> Tuple[Optional[di
     colour_labels = [MENU_TEXTS["blue"], MENU_TEXTS["red"]]
     colour_values = [constants.BLUE, constants.RED]
     repo_root = os.path.dirname(os.path.dirname(__file__))
-    ctx = Context(repo_root=repo_root, search_paths=[os.path.join(repo_root, "assets")])
+    search_paths: list[str] = []
+    extra = os.environ.get("FG_ASSETS_DIR")
+    if extra:
+        search_paths.extend(p for p in extra.split(os.pathsep) if p)
+    search_paths.append(os.path.join(repo_root, "assets"))
+    ctx = Context(repo_root=repo_root, search_paths=search_paths)
     factions = load_factions(ctx)
     faction_items = sorted(factions.items())
     faction_opts = [fid for fid, _ in faction_items] + [None]

--- a/ui/menu_utils.py
+++ b/ui/menu_utils.py
@@ -18,13 +18,12 @@ def _load_background() -> Optional[pygame.Surface]:
 
     filenames = ["menu_background.png", "menu_backround.png"]
     base_dir = os.path.dirname(__file__)
-    env_path = os.environ.get("FG_ASSETS_DIR")
-    search_dirs = [
-        os.path.join(base_dir, "assets"),
-        os.path.join(os.path.dirname(base_dir), "assets"),
-    ]
-    if env_path:
-        search_dirs.insert(0, env_path)
+    env_paths = os.environ.get("FG_ASSETS_DIR")
+    search_dirs: List[str] = []
+    if env_paths:
+        search_dirs.extend(p for p in env_paths.split(os.pathsep) if p)
+    search_dirs.append(os.path.join(base_dir, "assets"))
+    search_dirs.append(os.path.join(os.path.dirname(base_dir), "assets"))
     for directory in search_dirs:
         for root, _dirs, files in os.walk(directory):
             for name in filenames:


### PR DESCRIPTION
## Summary
- allow FG_ASSETS_DIR to specify multiple search paths
- prepend override asset paths before default assets when building Contexts
- update menu utilities and icon loader to scan all configured asset directories

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4a57612ac8321a5adf1e2d9a6f4c0