### PR TITLE
Handle dynamic biome mapping for continent generation

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -56,6 +56,7 @@ from core.entities import (
     ARTIFACT_ICONS,
 )
 from core.world import WorldMap, generate_combat_map, init_biome_images, Tile
+import core.world
 from core.faction import FactionDef
 from graphics.spritesheet import load_sprite_sheet
 from mapgen import generate_continent_map
@@ -327,7 +328,7 @@ class Game:
                 height,
                 map_type=self.map_type,
                 smoothing_iterations=5,
-                biome_chars="GFD",
+                biome_chars="".join(core.world.BIOME_CHARS),
             )
             self.world = WorldMap(
                 map_data=map_rows,

--- a/mapgen/continents.py
+++ b/mapgen/continents.py
@@ -8,6 +8,8 @@ from collections import deque
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set
 
+import constants
+
 Cell = Tuple[int, int]
 
 
@@ -213,6 +215,20 @@ def generate_continent_map(
             land_chance = 0.7
         else:
             land_chance = 0.45
+
+    if not biome_chars:
+        repo_root = Path(__file__).resolve().parents[1]
+        try:
+            with open(repo_root / "assets" / "biomes" / "char_map.json", "r", encoding="utf-8") as fh:
+                char_map = json.load(fh)
+        except Exception:
+            char_map = {}
+        id_to_char = {v: k for k, v in char_map.items()}
+        biome_chars = "".join(
+            id_to_char[b]
+            for b in constants.DEFAULT_BIOME_WEIGHTS.keys()
+            if b in id_to_char
+        )
 
     grid = _cellular_automata_land_mask(width, height, land_chance, smoothing_iterations)
 

--- a/tests/test_continent_generation.py
+++ b/tests/test_continent_generation.py
@@ -69,3 +69,69 @@ def test_generate_map_with_custom_rules():
                         continue
                     assert c2 in custom.get(c1, {c2})
 
+
+def test_loaded_biome_can_appear(tmp_path):
+    import base64
+    import json
+    from loaders.biomes import BiomeCatalog
+    from loaders.core import Context
+    import constants
+    from core import world as core_world
+
+    png_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAAC0lEQVR42mP8/x8AAwMB/kwAXzAAAAAASUVORK5CYII="
+    )
+    assets = tmp_path / "assets"
+    realm = assets / "realms" / "testrealm" / "biomes"
+    realm.mkdir(parents=True)
+    (realm / "test_biome.png").write_bytes(png_bytes)
+    with open(realm.parent / "char_map.json", "w", encoding="utf-8") as fh:
+        json.dump({"T": "test_biome"}, fh)
+    manifest = [
+        {
+            "id": "test_biome",
+            "type": "forest",
+            "description": "",
+            "path": "realms/testrealm/biomes/test_biome",
+            "variants": 1,
+            "colour": [0, 0, 0],
+            "flora": [],
+        }
+    ]
+    with open(realm.parent / "biomes.json", "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    ctx = Context(
+        repo_root=str(repo_root),
+        search_paths=[str(repo_root / "assets"), str(assets)],
+        asset_loader=None,
+    )
+
+    old_biomes = BiomeCatalog._biomes
+    old_base = constants.BIOME_BASE_IMAGES
+    old_weights = constants.DEFAULT_BIOME_WEIGHTS
+    old_prio = constants.BIOME_PRIORITY
+    old_char_map = core_world.BIOME_CHAR_MAP
+    old_chars = core_world.BIOME_CHARS
+    try:
+        BiomeCatalog.load(ctx, "testrealm")
+        rows = generate_continent_map(
+            20,
+            20,
+            seed=0,
+            land_chance=1.0,
+            smoothing_iterations=0,
+            biome_chars="".join(core_world.BIOME_CHARS),
+        )
+        chars = set("".join(rows))
+        assert "T" in chars
+    finally:
+        BiomeCatalog._biomes = old_biomes
+        constants.BIOME_BASE_IMAGES = old_base
+        constants.DEFAULT_BIOME_WEIGHTS = old_weights
+        constants.BIOME_PRIORITY = old_prio
+        core_world.BIOME_CHAR_MAP = old_char_map
+        core_world.BIOME_CHARS = old_chars
+        core_world.init_biome_images()
+


### PR DESCRIPTION
## Summary
- use runtime biome characters when generating continents
- default to configured biome weights if no biome chars provided
- add test ensuring newly loaded biome IDs appear in generated maps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4ab8217808321ad6beb6f6c777a09