### PR TITLE
Ensure biome images exist

### DIFF
--- a/loaders/biomes.py
+++ b/loaders/biomes.py
@@ -141,6 +141,21 @@ class BiomeCatalog:
                     priority=int(entry.get("priority", 0)),
                 )
                 biomes[biome.id] = biome
+                if ctx.asset_loader and biome.path:
+                    key = (
+                        biome.path
+                        if biome.path.endswith(".png")
+                        else f"{biome.path}.png"
+                    )
+                    _sentinel = object()
+                    if (
+                        ctx.asset_loader.get(key, default=_sentinel, biome_id=biome.id)
+                        is _sentinel
+                    ):
+                        raise RuntimeError(
+                            f"Biome {biome.id} missing image '{key}'"
+                            f" (search_paths={list(ctx.search_paths)})"
+                        )
         cls._biomes = biomes
         # Refresh derived mappings in constants
         constants.BIOME_BASE_IMAGES = constants.build_biome_base_images()

--- a/tests/test_missing_biome_asset.py
+++ b/tests/test_missing_biome_asset.py
@@ -1,0 +1,48 @@
+import json
+import pytest
+from loaders.biomes import BiomeCatalog
+from loaders.core import Context
+from loaders.asset_manager import AssetManager
+import constants
+from core import world as core_world
+
+
+def test_missing_biome_image_raises(tmp_path):
+    assets_root = tmp_path / "assets"
+    (assets_root / "biomes").mkdir(parents=True)
+    manifest = [
+        {
+            "id": "missing",
+            "type": "forest",
+            "description": "",
+            "path": "biomes/missing",
+            "variants": 1,
+            "colour": [0, 0, 0],
+            "flora": [],
+        }
+    ]
+    with open(assets_root / "biomes" / "biomes.json", "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)
+
+    ctx = Context(
+        repo_root=str(tmp_path),
+        search_paths=[str(assets_root)],
+        asset_loader=AssetManager(repo_root=str(tmp_path)),
+    )
+
+    old_biomes = BiomeCatalog._biomes
+    old_base = constants.BIOME_BASE_IMAGES
+    old_weights = constants.DEFAULT_BIOME_WEIGHTS
+    old_prio = constants.BIOME_PRIORITY
+    try:
+        with pytest.raises(RuntimeError) as exc:
+            BiomeCatalog.load(ctx)
+        assert "missing" in str(exc.value)
+        assert "biomes/missing.png" in str(exc.value)
+        assert str(assets_root) in str(exc.value)
+    finally:
+        BiomeCatalog._biomes = old_biomes
+        constants.BIOME_BASE_IMAGES = old_base
+        constants.DEFAULT_BIOME_WEIGHTS = old_weights
+        constants.BIOME_PRIORITY = old_prio
+        core_world.init_biome_images()


### PR DESCRIPTION
## Summary
- Validate biome image paths during manifest loading and fail fast if missing
- Add regression test for missing biome asset paths

## Testing
- `pytest tests/test_missing_biome_asset.py tests/test_realm_biome_paths.py tests/test_biome_tileset_variants.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4ace19f2083218c1020ca904c0118