### PR TITLE
Improve asset path resolution and tileset errors

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -185,11 +185,10 @@ class Game:
         self.assets = AssetManager(repo_root)
         self.vfx_manifest: Dict[str, Dict[str, Any]] = {}
 
-        search_paths: List[str] = []
+        search_paths: List[str] = [os.path.join(repo_root, "assets")]
         extra = os.environ.get("FG_ASSETS_DIR")
         if extra:
-            search_paths.extend(p for p in extra.split(os.pathsep) if p)
-        search_paths.append(os.path.join(repo_root, "assets"))
+            search_paths = [p for p in extra.split(os.pathsep) if p] + search_paths
         self.ctx = Context(
             repo_root=repo_root,
             search_paths=search_paths,

--- a/loaders/flora_loader.py
+++ b/loaders/flora_loader.py
@@ -154,41 +154,25 @@ class FloraLoader:
         if not manifest_files:
             manifest_files.append(manifest_path)
 
-        def _asset_exists(rel: str) -> bool:
-            for base in self.ctx.search_paths:
-                base_abs = (
-                    base
-                    if os.path.isabs(base)
-                    else os.path.join(self.ctx.repo_root, base)
-                )
-                if os.path.isfile(os.path.join(base_abs, f"{rel}.png")):
-                    return True
-                if glob.glob(os.path.join(base_abs, f"{rel}_*.png")):
-                    return True
-            return False
-
         for path in manifest_files:
             data = read_json(self.ctx, path)
             base_dir = os.path.dirname(path)
             for entry in data:
                 entry_path = entry.get("path")
-                if entry_path and not os.path.isabs(entry_path):
-                    candidate = os.path.normpath(os.path.join(base_dir, entry_path))
-                    if _asset_exists(candidate):
-                        entry["path"] = candidate.replace(os.sep, "/")
-                    else:
-                        entry["path"] = os.path.normpath(entry_path).replace(
-                            os.sep, "/"
-                        )
+                if entry_path:
+                    entry_path = os.path.normpath(
+                        entry_path
+                        if os.path.isabs(entry_path)
+                        else os.path.join(base_dir, entry_path)
+                    )
+                    entry["path"] = entry_path.replace(os.sep, "/")
                 if "files" in entry:
                     new_files = []
                     for f in entry["files"]:
-                        if not os.path.isabs(f):
-                            cand = os.path.normpath(os.path.join(base_dir, f))
-                            base_cand = cand[:-4] if cand.endswith(".png") else cand
-                            if _asset_exists(base_cand):
-                                f = cand
-                        new_files.append(os.path.normpath(f).replace(os.sep, "/"))
+                        f = os.path.normpath(
+                            f if os.path.isabs(f) else os.path.join(base_dir, f)
+                        ).replace(os.sep, "/")
+                        new_files.append(f)
                     entry["files"] = new_files
                 biomes = entry.get("biomes", [])
                 for b in biomes:


### PR DESCRIPTION
## Summary
- ensure external assets search paths override built-ins
- resolve biome and flora paths relative to manifest directories
- raise clear error listing attempted tileset files when none found

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ccf7c80c8321940f837172564fa7